### PR TITLE
feat: Add CI/CD infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check --all-targets
+
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets -- -D warnings
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --all-targets
+
+  doc:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo doc --no-deps
+        env:
+          RUSTDOCFLAGS: -Dwarnings

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,33 @@
+name: E2E Tests
+
+on:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  e2e:
+    name: Containerlab E2E
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: cargo build --release
+
+      - name: Install containerlab
+        run: |
+          bash -c "$(curl -sL https://get.containerlab.dev)"
+
+      - name: Pull container images
+        run: |
+          docker pull debian:bookworm-slim
+
+      - name: Run E2E tests
+        run: |
+          cargo test --test e2e -- --ignored --test-threads=1

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Cargo.lock
 clab-*/
 *.log
+.claude/

--- a/src/dataplane/fdb.rs
+++ b/src/dataplane/fdb.rs
@@ -52,10 +52,7 @@ impl Fdb {
 
     /// Lookup a MAC address
     pub fn lookup(&self, mac: &MacAddr, vlan: u16) -> Option<PortId> {
-        self.tables
-            .get(&vlan)?
-            .get(mac)
-            .map(|entry| entry.port)
+        self.tables.get(&vlan)?.get(mac).map(|entry| entry.port)
     }
 
     /// Remove aged-out entries

--- a/src/protocol/arp.rs
+++ b/src/protocol/arp.rs
@@ -65,8 +65,8 @@ impl ArpPacket {
         }
 
         let operation = u16::from_be_bytes([buffer[6], buffer[7]]);
-        let operation =
-            ArpOp::from_u16(operation).ok_or_else(|| Error::Parse("invalid ARP operation".into()))?;
+        let operation = ArpOp::from_u16(operation)
+            .ok_or_else(|| Error::Parse("invalid ARP operation".into()))?;
 
         let sender_mac = MacAddr(buffer[8..14].try_into().unwrap());
         let sender_ip = Ipv4Addr::new(buffer[14], buffer[15], buffer[16], buffer[17]);

--- a/src/protocol/ethernet.rs
+++ b/src/protocol/ethernet.rs
@@ -24,7 +24,8 @@ impl<'a> Frame<'a> {
         }
 
         let ethertype_offset = 12;
-        let ethertype = u16::from_be_bytes([buffer[ethertype_offset], buffer[ethertype_offset + 1]]);
+        let ethertype =
+            u16::from_be_bytes([buffer[ethertype_offset], buffer[ethertype_offset + 1]]);
 
         let (vlan_tag, payload_offset) = if ethertype == EtherType::Vlan as u16 {
             if buffer.len() < 18 {
@@ -92,7 +93,8 @@ impl FrameBuilder {
     }
 
     pub fn vlan_tag(mut self, tag: VlanTag) -> Self {
-        self.buffer.extend_from_slice(&(EtherType::Vlan as u16).to_be_bytes());
+        self.buffer
+            .extend_from_slice(&(EtherType::Vlan as u16).to_be_bytes());
         self.buffer.extend_from_slice(&tag.to_bytes());
         self
     }

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -82,9 +82,8 @@ impl VlanTag {
     }
 
     pub fn to_bytes(&self) -> [u8; 2] {
-        let value = ((self.pcp as u16 & 0x07) << 13)
-            | ((self.dei as u16) << 12)
-            | (self.vid & 0x0FFF);
+        let value =
+            ((self.pcp as u16 & 0x07) << 13) | ((self.dei as u16) << 12) | (self.vid & 0x0FFF);
         value.to_be_bytes()
     }
 

--- a/tests/clab/config.toml
+++ b/tests/clab/config.toml
@@ -1,0 +1,10 @@
+# Ruster test configuration
+
+[interfaces.eth1]
+addresses = ["10.0.1.1/24"]
+
+[interfaces.eth2]
+addresses = ["10.0.2.1/24"]
+
+[routing]
+static_routes = []

--- a/tests/clab/topology.yml
+++ b/tests/clab/topology.yml
@@ -1,0 +1,34 @@
+name: ruster-test
+
+topology:
+  nodes:
+    # Device Under Test - ruster router
+    ruster:
+      kind: linux
+      image: debian:bookworm-slim
+      binds:
+        - ../../target/release/ruster:/usr/local/bin/ruster:ro
+        - ./config.toml:/etc/ruster/config.toml:ro
+      exec:
+        - ip addr add 10.0.1.1/24 dev eth1
+        - ip addr add 10.0.2.1/24 dev eth2
+
+    # Client host
+    client:
+      kind: linux
+      image: debian:bookworm-slim
+      exec:
+        - ip addr add 10.0.1.2/24 dev eth1
+        - ip route add 10.0.2.0/24 via 10.0.1.1
+
+    # Server host
+    server:
+      kind: linux
+      image: debian:bookworm-slim
+      exec:
+        - ip addr add 10.0.2.2/24 dev eth1
+        - ip route add 10.0.1.0/24 via 10.0.2.1
+
+  links:
+    - endpoints: ["ruster:eth1", "client:eth1"]
+    - endpoints: ["ruster:eth2", "server:eth1"]

--- a/tests/e2e/clab.rs
+++ b/tests/e2e/clab.rs
@@ -1,0 +1,91 @@
+//! Containerlab test helpers
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+/// Containerlab topology wrapper
+pub struct Topology {
+    name: String,
+    topology_file: String,
+}
+
+impl Topology {
+    /// Deploy a containerlab topology
+    pub fn deploy(topology_file: impl AsRef<Path>) -> Result<Self, String> {
+        let topology_file = topology_file.as_ref();
+        let topology_path = topology_file
+            .to_str()
+            .ok_or("Invalid topology path")?
+            .to_string();
+
+        // Read topology name from file
+        let content =
+            std::fs::read_to_string(topology_file).map_err(|e| format!("Read error: {}", e))?;
+
+        let name = content
+            .lines()
+            .find(|l| l.starts_with("name:"))
+            .and_then(|l| l.split(':').nth(1))
+            .map(|s| s.trim().to_string())
+            .ok_or("Could not find topology name")?;
+
+        // Deploy topology
+        let output = Command::new("sudo")
+            .args([
+                "containerlab",
+                "deploy",
+                "-t",
+                &topology_path,
+                "--reconfigure",
+            ])
+            .output()
+            .map_err(|e| format!("Failed to run containerlab: {}", e))?;
+
+        if !output.status.success() {
+            return Err(format!(
+                "containerlab deploy failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+
+        Ok(Self {
+            name,
+            topology_file: topology_path,
+        })
+    }
+
+    /// Execute a command in a container
+    pub fn exec(&self, node: &str, cmd: &str) -> Output {
+        let container_name = format!("clab-{}-{}", self.name, node);
+        Command::new("sudo")
+            .args(["docker", "exec", &container_name, "sh", "-c", cmd])
+            .output()
+            .expect("Failed to execute docker command")
+    }
+
+    /// Check if a ping succeeds
+    pub fn ping(&self, from_node: &str, target_ip: &str, count: u32) -> bool {
+        let cmd = format!("ping -c {} -W 2 {}", count, target_ip);
+        let output = self.exec(from_node, &cmd);
+        output.status.success()
+    }
+
+    /// Destroy the topology
+    pub fn destroy(&self) {
+        let _ = Command::new("sudo")
+            .args([
+                "containerlab",
+                "destroy",
+                "-t",
+                &self.topology_file,
+                "--cleanup",
+            ])
+            .output();
+    }
+}
+
+impl Drop for Topology {
+    fn drop(&mut self) {
+        self.destroy();
+    }
+}

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -1,0 +1,53 @@
+//! E2E tests using containerlab
+//!
+//! Run with: cargo test --test e2e -- --ignored
+
+mod clab;
+
+use clab::Topology;
+use std::path::PathBuf;
+
+fn topology_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/clab/topology.yml")
+}
+
+/// Test basic L3 connectivity through ruster
+///
+/// Topology:
+///   client (10.0.1.2) -- eth1 -- ruster -- eth2 -- server (10.0.2.2)
+#[test]
+#[ignore] // Requires containerlab and sudo
+fn test_ping_connectivity() {
+    let topo = Topology::deploy(topology_path()).expect("Failed to deploy topology");
+
+    // Wait for interfaces to be ready
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
+    // Test 1: Client can reach ruster's eth1
+    assert!(
+        topo.ping("client", "10.0.1.1", 3),
+        "Client should be able to ping ruster (10.0.1.1)"
+    );
+
+    // Test 2: Server can reach ruster's eth2
+    assert!(
+        topo.ping("server", "10.0.2.1", 3),
+        "Server should be able to ping ruster (10.0.2.1)"
+    );
+}
+
+/// Test L3 forwarding through ruster (requires ruster to be running)
+#[test]
+#[ignore] // Requires containerlab, sudo, and ruster implementation
+fn test_routing_through_ruster() {
+    let topo = Topology::deploy(topology_path()).expect("Failed to deploy topology");
+
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
+    // This test will pass once ruster implements IP forwarding
+    // For now, Linux kernel forwarding in the container handles this
+    assert!(
+        topo.ping("client", "10.0.2.2", 3),
+        "Client should be able to ping server (10.0.2.2) through ruster"
+    );
+}


### PR DESCRIPTION
## Summary
- GitHub Actions workflows for CI (build/test/clippy/fmt/doc)
- Containerlab E2E test infrastructure
- E2E tests as Rust integration tests (`cargo test --test e2e -- --ignored`)

Closes #1