### PR TITLE
feat(skills): Add git worktree support for parallel development

### DIFF
--- a/.claude/skills/issue-pr/SKILL.md
+++ b/.claude/skills/issue-pr/SKILL.md
@@ -17,7 +17,11 @@ allowed-tools: Bash(git:*), Bash(gh:*)
 5. `gh pr create` でPR作成
 6. PR URLを表示
 7. 少し待ってから `gh pr checks <PR番号>` でCIステータスを確認
-8. 全てpassしたらユーザーに報告。pendingなら待って再確認。failなら原因を調査
+8. 全てpassしたら:
+   - `gh issue edit <number> --remove-label wip` でwipラベルを削除
+   - ユーザーに報告
+9. pendingなら待って再確認
+10. failなら原因を調査
 
 ## CI確認の流れ
 
@@ -29,7 +33,7 @@ sleep 20
 gh pr checks <PR番号>
 ```
 
-- **pass**: マージ可能
+- **pass**: wipラベル削除、マージ可能
 - **pending**: しばらく待って再確認
 - **fail**: `gh run view <run_id> --log-failed` で原因調査、修正してpush
 
@@ -45,4 +49,5 @@ gh pr checks <PR番号>
 - Issue #4 にリンクしたPRを作成
 - `Closes #4` がbodyに含まれる
 - PR URLを表示
-- CIステータスを表示
+- CIステータスを確認
+- 全てpass: wipラベル削除、マージ準備完了を報告

--- a/.claude/skills/issue-start/SKILL.md
+++ b/.claude/skills/issue-start/SKILL.md
@@ -9,19 +9,53 @@ allowed-tools: Bash(git:*), Bash(gh:*)
 ## Instructions
 
 1. 引数でIssue番号を受け取る（例: `/issue-start 4`）
-2. `gh issue view <number>` でIssueタイトルを取得
-3. タイトルからslugを生成（小文字、スペースをハイフンに、記号削除）
-4. mainブランチを最新に更新
-5. `feature/<number>-<slug>` ブランチを作成してチェックアウト
+2. `gh issue view <number> --json title,labels` でIssueタイトルとラベルを取得
+3. `wip` ラベルがあれば警告して中止（既に作業中）
+4. タイトルからslugを生成（小文字、スペースをハイフンに、記号削除）
+5. mainブランチを最新に取得: `git fetch origin main`
+
+## Worktree クリーンアップ
+
+6. `git worktree list` で既存worktreeを確認
+7. 各worktreeについて（メインリポジトリ以外）:
+   - パスから `ruster-<number>` 形式を探す
+   - ブランチ名から `feature/<number>-xxx` を抽出
+   - `gh pr list --head <branch> --state merged --json number` でマージ済みPRを確認
+   - マージ済みなら「削除しますか？」とユーザーに質問
+   - 承認されたら:
+     - `git worktree remove <path>` でworktree削除
+     - `git branch -d <branch>` でブランチ削除
+
+## Worktree 作成
+
+8. `gh issue edit <number> --add-label wip` でラベル追加
+9. `gh issue comment <number> -b "🔧 Started in worktree: ../ruster-<number>"` でコメント追加
+10. `git worktree add ../ruster-<number> -b feature/<number>-<slug> origin/main` でworktree作成
+11. 作業ディレクトリのパスを表示
 
 ## Example
 
 ```
-/issue-start 4
+/issue-start 12
 ```
 
 実行結果:
-- Issue #4 "Ethernetフレーム処理" を取得
-- `git checkout main && git pull`
-- `git checkout -b feature/4-ethernet-frame`
-- 作業開始準備完了
+```
+Issue #12 "新機能XYZ" の作業を開始します
+
+--- Worktree クリーンアップ ---
+既存worktree: ../ruster-8 (feature/8-config-system)
+  → PR #35 がマージ済みです。削除しますか？ [Y/n]
+✓ ../ruster-8 を削除しました
+
+--- 新規Worktree作成 ---
+✓ wip ラベルを追加
+✓ 作業開始コメントを追加
+✓ Worktree作成: ../ruster-12
+
+作業ディレクトリ: /home/aoki/ruster-12
+ブランチ: feature/12-new-feature-xyz
+
+このディレクトリで Claude Code を起動してください:
+  cd ../ruster-12 && claude
+```


### PR DESCRIPTION
## Summary
- `/issue-start`: worktree作成 + wipラベル + コメント追加、既存worktreeのクリーンアップ提案
- `/issue-pr`: CI pass後にwipラベル削除を追加

## 利点
- 複数のClaude Codeセッションで別々のIssueを同時進行できる
- wipラベルで重複作業を防止
- コメントでworktree場所を追跡可能

## Test plan
- [ ] 新しいIssueで `/issue-start` を実行してworktreeが作成されることを確認
- [ ] wipラベルが付与されることを確認
- [ ] `/issue-pr` 実行後、CI pass時にwipラベルが削除されることを確認

Closes #41