### PR TITLE
feat(skills): Switch to fixed slot worktree mode

### DIFF
--- a/.claude/skills/issue-start/SKILL.md
+++ b/.claude/skills/issue-start/SKILL.md
@@ -10,52 +10,31 @@ allowed-tools: Bash(git:*), Bash(gh:*)
 
 1. 引数でIssue番号を受け取る（例: `/issue-start 4`）
 2. `gh issue view <number> --json title,labels` でIssueタイトルとラベルを取得
-3. `wip` ラベルがあれば警告して中止（既に作業中）
+3. `wip` ラベルがあれば警告して中止（既に別のClaude Codeが作業中）
 4. タイトルからslugを生成（小文字、スペースをハイフンに、記号削除）
-5. mainブランチを最新に取得: `git fetch origin main`
+5. `git fetch origin main` でmainを最新に取得
+6. `gh issue edit <number> --add-label wip` でラベル追加
+7. `git checkout -b feature/<number>-<slug> origin/main` でブランチ作成・切り替え
+8. 作業開始を報告
 
-## Worktree クリーンアップ
+## 注意
 
-6. `git worktree list` で既存worktreeを確認
-7. 各worktreeについて（メインリポジトリ以外）:
-   - パスから `ruster-<number>` 形式を探す
-   - ブランチ名から `feature/<number>-xxx` を抽出
-   - `gh pr list --head <branch> --state merged --json number` でマージ済みPRを確認
-   - マージ済みなら「削除しますか？」とユーザーに質問
-   - 承認されたら:
-     - `git worktree remove <path>` でworktree削除
-     - `git branch -d <branch>` でブランチ削除
-
-## Worktree 作成
-
-8. `gh issue edit <number> --add-label wip` でラベル追加
-9. `gh issue comment <number> -b "🔧 Started in worktree: ../ruster-<number>"` でコメント追加
-10. `git worktree add ../ruster-<number> -b feature/<number>-<slug> origin/main` でworktree作成
-11. 作業ディレクトリのパスを表示
+- 固定スロット方式: worktreeは事前に作成済み（ruster-1〜5）
+- 各worktreeでClaude Codeを起動して、このスキルでブランチ切り替え
+- `wip`ラベルで重複作業を防止
 
 ## Example
 
 ```
-/issue-start 12
+/issue-start 9
 ```
 
 実行結果:
 ```
-Issue #12 "新機能XYZ" の作業を開始します
+Issue #9 "MAC学習・FDB実装" の作業を開始します
 
---- Worktree クリーンアップ ---
-既存worktree: ../ruster-8 (feature/8-config-system)
-  → PR #35 がマージ済みです。削除しますか？ [Y/n]
-✓ ../ruster-8 を削除しました
-
---- 新規Worktree作成 ---
 ✓ wip ラベルを追加
-✓ 作業開始コメントを追加
-✓ Worktree作成: ../ruster-12
+✓ ブランチ作成: feature/9-mac-fdb
 
-作業ディレクトリ: /home/aoki/ruster-12
-ブランチ: feature/12-new-feature-xyz
-
-このディレクトリで Claude Code を起動してください:
-  cd ../ruster-12 && claude
+作業を開始してください
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# Ruster
+
+Rustで実装するソフトウェアルータ。ネットワーク学習を目的としたプロジェクト。
+
+## クイックリファレンス
+
+```bash
+# ビルド
+cargo build
+
+# テスト（ユニットテスト）
+cargo test
+
+# フォーマット・リント
+cargo fmt
+cargo clippy
+
+# E2Eテスト（Docker/Containerlab必要）
+cargo test --test e2e -- --ignored --test-threads=1
+```
+
+## プロジェクト構造
+
+```
+src/
+├── capture/    # パケットキャプチャ (AF_PACKET等)
+├── config/     # 設定ファイルパース・バリデーション
+├── dataplane/  # データプレーン処理パイプライン
+├── protocol/   # プロトコル実装 (Ethernet, IPv4, ICMP等)
+├── error.rs    # エラー型定義
+├── lib.rs      # ライブラリエントリポイント
+└── main.rs     # バイナリエントリポイント
+```
+
+## 設計原則
+
+1. **L1はLinuxに委任**: ハードウェア固有の設定はLinuxの機能を活用
+2. **L2以上は自前実装**: スイッチング・ルーティングをユーザースペースで処理
+3. **外部ライブラリ非依存**: ネットワーク処理部分（パケット解析、ルーティング）は独自実装
+4. **設定の透明性**: lockファイルによる完全な設定可視化
+
+## GitHub CLI使用ルール
+
+**重要**: `gh issue view` や `gh pr view` は必ず `--json` フラグを使用すること。
+
+GitHub Projects (classic) の廃止により、素の `gh issue view` はエラーになる。
+
+```bash
+# NG - エラーになる
+gh issue view 8
+
+# OK - 必要なフィールドを指定
+gh issue view 8 --json title,labels,state
+gh pr view 42 --json number,title,state,url
+```
+
+## 並列開発ワークフロー
+
+固定スロット方式でworktreeを使用:
+
+```bash
+# 事前に作成済み
+/home/aoki/ruster    # メインリポジトリ
+/home/aoki/ruster-1  # スロット1
+/home/aoki/ruster-2  # スロット2
+...
+/home/aoki/ruster-5  # スロット5
+
+# 各スロットでClaude Codeを起動
+cd ~/ruster-1 && claude
+> /issue-start 9
+```
+
+- `wip`ラベルで重複作業を防止
+- 各スロットは独立して並列作業可能
+
+## テスト
+
+- **ユニットテスト**: プロトコルパース、ルーティングテーブル等
+- **E2Eテスト**: Containerlabを使用。Dockerが必要。`tests/e2e/`以下に配置
+
+E2Eテストはシングルスレッド実行が必要（`--test-threads=1`）
+
+## 注意事項
+
+- ruster実行時はAF_PACKET使用のためroot権限が必要


### PR DESCRIPTION
## Summary

- `/issue-start`スキルをworktree作成方式から固定スロット方式に変更
- `gh issue view`等で`--json`フラグを必須とするルールをCLAUDE.mdに追加
- 並列開発ワークフローのドキュメント追加

## 変更内容

### issue-start/SKILL.md
- worktree作成・クリーンアップロジックを削除
- ブランチ切り替え方式に簡素化
- wipラベルで重複作業防止

### CLAUDE.md（新規）
- GitHub CLI使用ルール（--json必須）
- 固定スロット方式の説明（ruster-1〜5）
- プロジェクト概要・構造

## 背景

- GitHub Projects (classic) 廃止により素の`gh issue view`がエラーになる
- 5並列開発のため、worktreeを事前作成しておくスロット方式に変更

## Test plan

- [ ] `/issue-start 9`でブランチ切り替え確認
- [ ] wipラベルが追加されることを確認