### PR TITLE
feat(dataplane): Add packet processing pipeline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "sync"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "time"] }
 libc = "0.2"
 toml = "0.8"
 serde = { version = "1", features = ["derive"] }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -78,7 +78,7 @@ pub struct StaticRoute {
 // ============================================================================
 
 /// Generated lock file with all defaults filled in
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConfigLock {
     pub generated_at: String,
     pub source_hash: String,
@@ -88,7 +88,7 @@ pub struct ConfigLock {
     pub routing: RoutingLock,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InterfaceLock {
     pub role: String,
     pub addressing: String,
@@ -98,7 +98,7 @@ pub struct InterfaceLock {
     pub duplex: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DhcpLock {
     pub interface: String,
     pub range: (Ipv4Addr, Ipv4Addr),
@@ -108,7 +108,7 @@ pub struct DhcpLock {
     pub domain: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NatLock {
     pub enabled: bool,
     pub wan: String,
@@ -116,12 +116,12 @@ pub struct NatLock {
     pub nat_type: String,
 }
 
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RoutingLock {
     pub static_routes: Vec<StaticRouteLock>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StaticRouteLock {
     pub destination: String,
     pub gateway: String,

--- a/src/dataplane/mod.rs
+++ b/src/dataplane/mod.rs
@@ -6,10 +6,12 @@ mod arp_processor;
 mod arp_table;
 mod fdb;
 mod forwarder;
+mod router;
 mod routing;
 
 pub use arp_processor::{process_arp, ArpAction, ArpPendingQueue};
 pub use arp_table::{ArpState, ArpTable};
 pub use fdb::Fdb;
 pub use forwarder::{ForwardAction, Forwarder, InterfaceInfo};
+pub use router::{Interface, Router};
 pub use routing::{Route, RouteSource, RoutingTable};

--- a/src/dataplane/router.rs
+++ b/src/dataplane/router.rs
@@ -1,0 +1,467 @@
+//! Packet processing router
+//!
+//! Integrates all dataplane components (FDB, Forwarder, ARP) into
+//! a unified packet processing pipeline.
+
+use crate::capture::AfPacketSocket;
+use crate::dataplane::{
+    process_arp, ArpAction, ArpPendingQueue, ArpTable, Fdb, ForwardAction, Forwarder,
+    InterfaceInfo, RoutingTable,
+};
+use crate::protocol::arp::ArpPacket;
+use crate::protocol::ethernet::{Frame, FrameBuilder};
+use crate::protocol::icmp::{build_echo_reply, IcmpType};
+use crate::protocol::types::EtherType;
+use crate::protocol::MacAddr;
+use std::collections::{HashMap, HashSet};
+use std::net::Ipv4Addr;
+use std::time::Duration;
+use tokio::time::{interval, Interval};
+use tracing::{debug, trace, warn};
+
+/// Default FDB aging time in seconds
+const FDB_AGING_SECS: u64 = 300;
+
+/// Default ARP reachable time in seconds
+const ARP_REACHABLE_SECS: u64 = 30;
+
+/// Default ARP stale time in seconds
+const ARP_STALE_SECS: u64 = 120;
+
+/// Maximum packets to queue per ARP resolution
+const ARP_QUEUE_MAX_PER_IP: usize = 3;
+
+/// Maximum age of queued ARP packets in seconds
+const ARP_QUEUE_MAX_AGE_SECS: u64 = 60;
+
+/// Port ID type for FDB
+pub type PortId = u32;
+
+/// Interface with its socket and metadata
+pub struct Interface {
+    /// The raw socket for packet I/O
+    pub socket: AfPacketSocket,
+    /// Interface name
+    pub name: String,
+    /// MAC address
+    pub mac_addr: MacAddr,
+    /// IP address (if configured)
+    pub ip_addr: Option<Ipv4Addr>,
+    /// Prefix length (if configured)
+    pub prefix_len: Option<u8>,
+    /// Port ID for FDB
+    pub port_id: PortId,
+}
+
+/// The main router structure integrating all components
+pub struct Router {
+    /// Interfaces indexed by name
+    interfaces: HashMap<String, Interface>,
+    /// Port ID to interface name mapping
+    port_to_name: HashMap<PortId, String>,
+    /// All port IDs (for flooding)
+    all_ports: HashSet<PortId>,
+    /// L2 forwarding database
+    fdb: Fdb,
+    /// IP routing table
+    routing_table: RoutingTable,
+    /// ARP table
+    arp_table: ArpTable,
+    /// Pending packets waiting for ARP resolution
+    arp_pending: ArpPendingQueue,
+    /// L3 forwarder
+    forwarder: Forwarder,
+    /// Next port ID to assign
+    next_port_id: PortId,
+}
+
+impl Router {
+    /// Create a new router
+    pub fn new() -> Self {
+        Self {
+            interfaces: HashMap::new(),
+            port_to_name: HashMap::new(),
+            all_ports: HashSet::new(),
+            fdb: Fdb::new(Duration::from_secs(FDB_AGING_SECS)),
+            routing_table: RoutingTable::new(),
+            arp_table: ArpTable::new(
+                Duration::from_secs(ARP_REACHABLE_SECS),
+                Duration::from_secs(ARP_STALE_SECS),
+            ),
+            arp_pending: ArpPendingQueue::new(ARP_QUEUE_MAX_PER_IP, ARP_QUEUE_MAX_AGE_SECS),
+            forwarder: Forwarder::new(),
+            next_port_id: 1,
+        }
+    }
+
+    /// Add an interface to the router
+    pub fn add_interface(
+        &mut self,
+        name: String,
+        socket: AfPacketSocket,
+        mac_addr: MacAddr,
+        ip_addr: Option<Ipv4Addr>,
+        prefix_len: Option<u8>,
+    ) -> PortId {
+        let port_id = self.next_port_id;
+        self.next_port_id += 1;
+
+        // Track port for flooding
+        self.all_ports.insert(port_id);
+
+        // Register with L3 forwarder if IP configured
+        if let (Some(ip), Some(prefix)) = (ip_addr, prefix_len) {
+            self.forwarder.add_interface(
+                name.clone(),
+                InterfaceInfo {
+                    ip_addr: ip,
+                    mac_addr,
+                    prefix_len: prefix,
+                },
+            );
+        }
+
+        self.port_to_name.insert(port_id, name.clone());
+        self.interfaces.insert(
+            name.clone(),
+            Interface {
+                socket,
+                name,
+                mac_addr,
+                ip_addr,
+                prefix_len,
+                port_id,
+            },
+        );
+
+        debug!("Added interface with port_id={}", port_id);
+        port_id
+    }
+
+    /// Add a static route
+    pub fn add_route(&mut self, route: crate::dataplane::Route) {
+        self.routing_table.add(route);
+    }
+
+    /// Get interface by name
+    pub fn get_interface(&self, name: &str) -> Option<&Interface> {
+        self.interfaces.get(name)
+    }
+
+    /// Get mutable interface by name
+    pub fn get_interface_mut(&mut self, name: &str) -> Option<&mut Interface> {
+        self.interfaces.get_mut(name)
+    }
+
+    /// Get interface by port ID
+    fn get_interface_by_port(&self, port_id: PortId) -> Option<&Interface> {
+        self.port_to_name
+            .get(&port_id)
+            .and_then(|name| self.interfaces.get(name))
+    }
+
+    /// Get all interface names
+    pub fn interface_names(&self) -> Vec<String> {
+        self.interfaces.keys().cloned().collect()
+    }
+
+    /// Get flood ports (all except ingress)
+    fn get_flood_ports(&self, ingress_port: PortId) -> Vec<PortId> {
+        self.all_ports
+            .iter()
+            .copied()
+            .filter(|&p| p != ingress_port)
+            .collect()
+    }
+
+    /// Process a received packet
+    ///
+    /// Returns a list of (interface_name, packet_data) to send
+    pub fn process_packet(&mut self, ingress_iface: &str, packet: &[u8]) -> Vec<(String, Vec<u8>)> {
+        let mut to_send = Vec::new();
+
+        // Get ingress interface info
+        let (ingress_port, ingress_mac, _ingress_ip) = {
+            let iface = match self.interfaces.get(ingress_iface) {
+                Some(i) => i,
+                None => {
+                    warn!("Unknown ingress interface: {}", ingress_iface);
+                    return to_send;
+                }
+            };
+            (iface.port_id, iface.mac_addr, iface.ip_addr)
+        };
+
+        // Parse Ethernet frame
+        let frame = match Frame::parse(packet) {
+            Ok(f) => f,
+            Err(e) => {
+                trace!("Failed to parse Ethernet frame: {:?}", e);
+                return to_send;
+            }
+        };
+
+        let src_mac = frame.src_mac();
+        let dst_mac = frame.dst_mac();
+        let ethertype = frame.ethertype();
+
+        // MAC learning (VLAN 1 for now)
+        self.fdb.learn(src_mac, 1, ingress_port);
+        trace!(
+            "Learned {} on port {} ({})",
+            src_mac,
+            ingress_port,
+            ingress_iface
+        );
+
+        // Check if frame is for us (broadcast, multicast, or our MAC)
+        let is_for_us = dst_mac.is_broadcast() || dst_mac.is_multicast() || dst_mac == ingress_mac;
+
+        if is_for_us {
+            // L3 processing
+            match ethertype {
+                x if x == EtherType::Arp as u16 => {
+                    if let Some(packets) = self.process_arp_packet(ingress_iface, frame.payload()) {
+                        to_send.extend(packets);
+                    }
+                }
+                x if x == EtherType::Ipv4 as u16 => {
+                    if let Some(packets) = self.process_ipv4_packet(ingress_iface, frame.payload())
+                    {
+                        to_send.extend(packets);
+                    }
+                }
+                _ => {
+                    trace!("Unsupported EtherType: 0x{:04x}", ethertype);
+                }
+            }
+        } else {
+            // L2 forwarding - lookup destination MAC
+            if let Some(egress_port) = self.fdb.lookup(&dst_mac, 1) {
+                // Known unicast - forward to specific port
+                if egress_port != ingress_port {
+                    if let Some(iface) = self.get_interface_by_port(egress_port) {
+                        to_send.push((iface.name.clone(), packet.to_vec()));
+                        trace!("L2 forward to port {} ({})", egress_port, iface.name);
+                    }
+                } else {
+                    trace!("L2 filter (same port)");
+                }
+            } else {
+                // Unknown unicast - flood to all ports except ingress
+                let flood_ports = self.get_flood_ports(ingress_port);
+                for port in flood_ports {
+                    if let Some(iface) = self.get_interface_by_port(port) {
+                        to_send.push((iface.name.clone(), packet.to_vec()));
+                    }
+                }
+                trace!("L2 flood (unknown destination)");
+            }
+        }
+
+        to_send
+    }
+
+    /// Process an ARP packet
+    fn process_arp_packet(
+        &mut self,
+        ingress_iface: &str,
+        payload: &[u8],
+    ) -> Option<Vec<(String, Vec<u8>)>> {
+        let arp = match ArpPacket::parse(payload) {
+            Ok(p) => p,
+            Err(e) => {
+                trace!("Failed to parse ARP: {:?}", e);
+                return None;
+            }
+        };
+
+        let iface = self.interfaces.get(ingress_iface)?;
+        let local_ip = iface.ip_addr?;
+        let local_mac = iface.mac_addr;
+        let iface_name = iface.name.clone();
+
+        let action = process_arp(&arp, &mut self.arp_table, local_ip, local_mac);
+
+        match action {
+            ArpAction::Reply(reply) => {
+                // Build Ethernet frame for ARP reply
+                let frame = FrameBuilder::new()
+                    .src_mac(local_mac)
+                    .dst_mac(reply.target_mac)
+                    .ethertype(EtherType::Arp as u16)
+                    .payload(&reply.to_bytes())
+                    .build();
+
+                debug!("Sending ARP reply to {}", reply.target_ip);
+                Some(vec![(iface_name, frame)])
+            }
+            ArpAction::TableUpdated => {
+                // Check if we have pending packets for this IP
+                let pending = self.arp_pending.dequeue(&arp.sender_ip);
+                if !pending.is_empty() {
+                    debug!(
+                        "ARP resolved for {}, sending {} queued packets",
+                        arp.sender_ip,
+                        pending.len()
+                    );
+                    let mut results = Vec::new();
+                    for ip_packet in pending {
+                        let frame = FrameBuilder::new()
+                            .src_mac(local_mac)
+                            .dst_mac(arp.sender_mac)
+                            .ethertype(EtherType::Ipv4 as u16)
+                            .payload(&ip_packet)
+                            .build();
+                        results.push((iface_name.clone(), frame));
+                    }
+                    Some(results)
+                } else {
+                    None
+                }
+            }
+            ArpAction::None => None,
+        }
+    }
+
+    /// Process an IPv4 packet
+    fn process_ipv4_packet(
+        &mut self,
+        ingress_iface: &str,
+        payload: &[u8],
+    ) -> Option<Vec<(String, Vec<u8>)>> {
+        let action = self.forwarder.forward(
+            payload,
+            &self.routing_table,
+            &self.arp_table,
+            &mut self.arp_pending,
+        );
+
+        match action {
+            ForwardAction::Forward {
+                interface,
+                next_hop_mac,
+                packet,
+            } => {
+                let iface = self.interfaces.get(&interface)?;
+                let frame = FrameBuilder::new()
+                    .src_mac(iface.mac_addr)
+                    .dst_mac(next_hop_mac)
+                    .ethertype(EtherType::Ipv4 as u16)
+                    .payload(&packet)
+                    .build();
+
+                debug!(
+                    "Forwarding IPv4 packet to {} via {}",
+                    next_hop_mac, interface
+                );
+                Some(vec![(interface, frame)])
+            }
+            ForwardAction::ArpRequest {
+                interface,
+                target_ip,
+                request,
+            } => {
+                let iface = self.interfaces.get(&interface)?;
+                let frame = FrameBuilder::new()
+                    .src_mac(iface.mac_addr)
+                    .dst_mac(MacAddr::BROADCAST)
+                    .ethertype(EtherType::Arp as u16)
+                    .payload(&request.to_bytes())
+                    .build();
+
+                debug!("Sending ARP request for {} on {}", target_ip, interface);
+                Some(vec![(interface, frame)])
+            }
+            ForwardAction::Local => {
+                // Packet is for us - handle locally (e.g., ICMP)
+                self.handle_local_packet(ingress_iface, payload)
+            }
+            ForwardAction::TtlExpired { src_addr, .. } => {
+                debug!("TTL expired for packet from {}", src_addr);
+                // TODO: Send ICMP Time Exceeded
+                None
+            }
+            ForwardAction::NoRoute { dst_addr } => {
+                debug!("No route to {}", dst_addr);
+                // TODO: Send ICMP Destination Unreachable
+                None
+            }
+            ForwardAction::Dropped => {
+                trace!("Packet dropped");
+                None
+            }
+        }
+    }
+
+    /// Handle a packet destined for this router
+    fn handle_local_packet(
+        &mut self,
+        ingress_iface: &str,
+        payload: &[u8],
+    ) -> Option<Vec<(String, Vec<u8>)>> {
+        use crate::protocol::icmp::IcmpPacket;
+        use crate::protocol::ipv4::{Ipv4Builder, Ipv4Header};
+
+        let ip_header = Ipv4Header::parse(payload).ok()?;
+        let ip_payload = ip_header.payload();
+
+        // Check if ICMP
+        if ip_header.protocol() != 1 {
+            return None;
+        }
+
+        let icmp = IcmpPacket::parse(ip_payload).ok()?;
+
+        // Handle echo request (ping)
+        if icmp.icmp_type() == IcmpType::EchoRequest as u8 {
+            let iface = self.interfaces.get(ingress_iface)?;
+            let local_ip = iface.ip_addr?;
+
+            // Build ICMP echo reply from the request
+            let icmp_reply = build_echo_reply(icmp.as_bytes()).ok()?;
+
+            // Build IPv4 packet
+            let ip_packet = Ipv4Builder::new()
+                .src_addr(local_ip)
+                .dst_addr(ip_header.src_addr())
+                .ttl(64)
+                .protocol(1) // ICMP
+                .payload(&icmp_reply)
+                .build();
+
+            // Lookup MAC for reply
+            if let Some((dst_mac, _)) = self.arp_table.lookup(&ip_header.src_addr()) {
+                let frame = FrameBuilder::new()
+                    .src_mac(iface.mac_addr)
+                    .dst_mac(dst_mac)
+                    .ethertype(EtherType::Ipv4 as u16)
+                    .payload(&ip_packet)
+                    .build();
+
+                debug!("Sending ICMP echo reply to {}", ip_header.src_addr());
+                return Some(vec![(iface.name.clone(), frame)]);
+            }
+        }
+
+        None
+    }
+
+    /// Run aging for FDB and ARP tables
+    pub fn run_aging(&mut self) {
+        self.fdb.age_out();
+        self.arp_table.refresh_states();
+        self.arp_pending.expire_old();
+    }
+
+    /// Create an aging timer interval
+    pub fn aging_interval() -> Interval {
+        interval(Duration::from_secs(FDB_AGING_SECS / 10))
+    }
+}
+
+impl Default for Router {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,12 @@ enum Commands {
         #[command(subcommand)]
         action: ConfigAction,
     },
+    /// Run the router daemon
+    Run {
+        /// Path to config.lock file
+        #[arg(short, long, default_value = "config.lock")]
+        config: PathBuf,
+    },
 }
 
 #[derive(Subcommand)]
@@ -65,11 +71,207 @@ fn main() {
                 }
             }
         },
+        Some(Commands::Run { config: lock_path }) => {
+            if let Err(e) = cmd_run(&lock_path) {
+                eprintln!("[ERROR] {}", e);
+                std::process::exit(1);
+            }
+        }
         None => {
             info!("ruster starting...");
-            // TODO: Start router daemon
+            // Default: run with config.lock
+            if let Err(e) = cmd_run(&PathBuf::from("config.lock")) {
+                eprintln!("[ERROR] {}", e);
+                std::process::exit(1);
+            }
         }
     }
+}
+
+fn cmd_run(lock_path: &PathBuf) -> Result<(), String> {
+    use ruster::capture::AfPacketSocket;
+    use ruster::dataplane::Router;
+    use ruster::protocol::MacAddr;
+    use tokio::runtime::Runtime;
+    use tracing::{debug, error, warn};
+
+    info!("Loading {}...", lock_path.display());
+
+    // Read and parse lock file
+    let lock_content = std::fs::read_to_string(lock_path)
+        .map_err(|e| format!("Failed to read lock file: {}", e))?;
+    let lock: config::ConfigLock =
+        toml::from_str(&lock_content).map_err(|e| format!("Failed to parse lock file: {}", e))?;
+
+    // Create Tokio runtime
+    let rt = Runtime::new().map_err(|e| format!("Failed to create runtime: {}", e))?;
+
+    rt.block_on(async move {
+        let mut router = Router::new();
+
+        // Configure interfaces from lock file
+        for (name, iface_lock) in &lock.interfaces {
+            // Parse address if present
+            let (ip_addr, prefix_len) = if let Some(ref addr) = iface_lock.address {
+                parse_cidr(addr)?
+            } else {
+                (None, None)
+            };
+
+            // Parse MAC address
+            let mac_addr: MacAddr = iface_lock
+                .mac
+                .parse()
+                .unwrap_or_else(|_| get_interface_mac(name));
+
+            // Bind to interface
+            info!("Binding to interface {}...", name);
+            let socket = AfPacketSocket::bind(name).map_err(|e| {
+                format!(
+                    "Failed to bind to {}: {}. Run with root privileges.",
+                    name, e
+                )
+            })?;
+
+            router.add_interface(name.clone(), socket, mac_addr, ip_addr, prefix_len);
+            info!(
+                "  {} configured: MAC={}, IP={:?}/{}",
+                name,
+                mac_addr,
+                ip_addr,
+                prefix_len.unwrap_or(0)
+            );
+        }
+
+        // Add routes from lock file
+        for route_lock in &lock.routing.static_routes {
+            if let Some(route) = parse_route(route_lock) {
+                router.add_route(route);
+                debug!(
+                    "Added route: {} via {} ({})",
+                    route_lock.destination, route_lock.gateway, route_lock.source
+                );
+            }
+        }
+
+        info!("Router started, processing packets...");
+
+        // Create aging timer
+        let mut aging_timer = Router::aging_interval();
+
+        // Main loop
+        let interface_names: Vec<String> = router.interface_names();
+
+        if interface_names.is_empty() {
+            return Err("No interfaces configured".to_string());
+        }
+
+        // For simplicity, handle one interface at a time
+        // TODO: Use tokio::select! for multi-interface support
+        let iface_name = interface_names[0].clone();
+
+        let mut buf = vec![0u8; 2048];
+
+        loop {
+            tokio::select! {
+                _ = aging_timer.tick() => {
+                    router.run_aging();
+                }
+                result = async {
+                    // Receive packet from the first interface
+                    if let Some(iface) = router.get_interface_mut(&iface_name) {
+                        iface.socket.recv(&mut buf).await
+                    } else {
+                        Err(ruster::Error::InterfaceNotFound { name: iface_name.clone() })
+                    }
+                } => {
+                    match result {
+                        Ok(rx_info) => {
+                            let packet = &buf[..rx_info.len];
+                            let to_send = router.process_packet(&iface_name, packet);
+
+                            for (out_iface, frame) in to_send {
+                                if let Some(iface) = router.get_interface_mut(&out_iface) {
+                                    if let Err(e) = iface.socket.send(&frame).await {
+                                        warn!("Failed to send on {}: {}", out_iface, e);
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            error!("Receive error: {}", e);
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
+fn parse_cidr(cidr: &str) -> Result<(Option<std::net::Ipv4Addr>, Option<u8>), String> {
+    use std::net::Ipv4Addr;
+
+    let parts: Vec<&str> = cidr.split('/').collect();
+    if parts.len() != 2 {
+        return Err(format!("Invalid CIDR: {}", cidr));
+    }
+
+    let ip: Ipv4Addr = parts[0]
+        .parse()
+        .map_err(|_| format!("Invalid IP: {}", parts[0]))?;
+    let prefix: u8 = parts[1]
+        .parse()
+        .map_err(|_| format!("Invalid prefix: {}", parts[1]))?;
+
+    Ok((Some(ip), Some(prefix)))
+}
+
+fn get_interface_mac(name: &str) -> ruster::protocol::MacAddr {
+    // Read MAC from /sys/class/net/{name}/address
+    let path = format!("/sys/class/net/{}/address", name);
+    if let Ok(content) = std::fs::read_to_string(&path) {
+        if let Ok(mac) = content.trim().parse() {
+            return mac;
+        }
+    }
+    // Fallback to zero MAC
+    ruster::protocol::MacAddr::ZERO
+}
+
+fn parse_route(route_lock: &config::StaticRouteLock) -> Option<ruster::dataplane::Route> {
+    use ruster::dataplane::{Route, RouteSource};
+    use std::net::Ipv4Addr;
+
+    // Parse destination CIDR
+    let parts: Vec<&str> = route_lock.destination.split('/').collect();
+    if parts.len() != 2 {
+        return None;
+    }
+
+    let destination: Ipv4Addr = parts[0].parse().ok()?;
+    let prefix_len: u8 = parts[1].parse().ok()?;
+
+    // Parse next hop (None for connected routes)
+    let next_hop = if route_lock.gateway == "direct" {
+        None
+    } else {
+        route_lock.gateway.parse().ok()
+    };
+
+    let source = match route_lock.source.as_str() {
+        "auto" => RouteSource::Connected,
+        "config" => RouteSource::Static,
+        _ => RouteSource::Static,
+    };
+
+    Some(Route {
+        destination,
+        prefix_len,
+        next_hop,
+        interface: route_lock.interface.clone(),
+        metric: 0,
+        source,
+    })
 }
 
 fn cmd_config_generate(config_path: &PathBuf, output_path: &PathBuf) -> Result<(), String> {


### PR DESCRIPTION
## Summary

- Router構造体を追加し、FDB、Forwarder、ARPテーブルを統合
- `process_packet()` でL2/L3パケット処理を実装
- ICMP echo reply処理でping対応
- `config.lock` からのルーターデーモン起動機能を追加
- tokio timeフィーチャーでエージングタイマーを追加

## 変更ファイル

- `src/dataplane/router.rs` (新規): Router構造体とパケット処理パイプライン
- `src/dataplane/mod.rs`: Routerのエクスポート追加
- `src/main.rs`: `run` サブコマンドとメインループ
- `src/config/types.rs`: Lock型にDeserialize追加
- `Cargo.toml`: tokio time feature追加

## Test plan

- [x] `cargo test` 全157テスト通過
- [x] `cargo clippy` 警告なし
- [x] `cargo fmt` フォーマット済み

Closes #44