### PR TITLE
feat(config): Add VLAN (802.1Q) configuration support

### DIFF
--- a/src/dataplane/routing.rs
+++ b/src/dataplane/routing.rs
@@ -358,6 +358,8 @@ mod tests {
                 addressing: Addressing::Static,
                 address: Some("192.168.1.1/24".to_string()),
                 mtu: None,
+                vlan_mode: None,
+                vlan_config: None,
             },
         );
         interfaces.insert(
@@ -367,6 +369,8 @@ mod tests {
                 addressing: Addressing::Static,
                 address: Some("10.0.0.1/8".to_string()),
                 mtu: None,
+                vlan_mode: None,
+                vlan_config: None,
             },
         );
 


### PR DESCRIPTION
## Summary

- VlanMode enum (Access/Trunk) を追加
- VlanConfig struct でVLAN設定を定義
- VlanLockConfig でlock file対応
- VLAN設定のバリデーションを追加
- InterfaceConfig/InterfaceLock にVLANフィールド追加

## Test plan

- [x] `cargo test` 全テスト通過
- [x] `cargo clippy` 警告なし
- [x] `cargo fmt` フォーマット済み

Closes #10