### PR TITLE
feat(telemetry): Add logging and metrics infrastructure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ toml = "0.8"
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 sha2 = "0.10"

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -30,10 +30,10 @@ impl ValidationResult {
 
     pub fn print_diagnostics(&self) {
         for warning in &self.warnings {
-            println!("[WARN] {}", warning);
+            eprintln!("[WARN] {}", warning);
         }
         for error in &self.errors {
-            println!("[ERROR] {}", error);
+            eprintln!("[ERROR] {}", error);
         }
     }
 }
@@ -276,6 +276,7 @@ mod tests {
 
     fn make_config() -> Config {
         Config {
+            logging: None,
             interfaces: HashMap::new(),
             dhcp: HashMap::new(),
             nat: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,5 +8,6 @@ pub mod config;
 pub mod dataplane;
 pub mod error;
 pub mod protocol;
+pub mod telemetry;
 
 pub use error::{Error, Result};

--- a/src/telemetry/logging.rs
+++ b/src/telemetry/logging.rs
@@ -1,0 +1,126 @@
+//! Logging configuration and initialization.
+//!
+//! Provides flexible logging setup with support for:
+//! - Environment variable (RUST_LOG) configuration
+//! - config.toml configuration file
+//! - Multiple output formats (pretty, compact, json)
+
+use tracing::Level;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::EnvFilter;
+
+/// Logging configuration from config.toml.
+#[derive(Debug, Clone, Default)]
+pub struct LogConfig {
+    /// Log level: error, warn, info, debug, trace
+    pub level: String,
+    /// Output format: pretty, compact, json
+    pub format: String,
+}
+
+impl LogConfig {
+    /// Creates a new LogConfig with default values.
+    pub fn new() -> Self {
+        Self {
+            level: "info".to_string(),
+            format: "pretty".to_string(),
+        }
+    }
+}
+
+/// Initializes the logging system.
+///
+/// Priority:
+/// 1. RUST_LOG environment variable (if set)
+/// 2. config parameter (if provided)
+/// 3. Default: info level, pretty format
+///
+/// # Examples
+///
+/// ```ignore
+/// // Use environment variable
+/// std::env::set_var("RUST_LOG", "debug");
+/// init_logging(None);
+///
+/// // Use config file settings
+/// let config = LogConfig { level: "debug".into(), format: "json".into() };
+/// init_logging(Some(&config));
+/// ```
+pub fn init_logging(config: Option<&LogConfig>) {
+    // Determine log level filter
+    let env_filter = if std::env::var("RUST_LOG").is_ok() {
+        // RUST_LOG takes priority
+        EnvFilter::from_default_env()
+    } else if let Some(cfg) = config {
+        // Use config file setting
+        let level = parse_level(&cfg.level);
+        EnvFilter::new(level.as_str())
+    } else {
+        // Default to info
+        EnvFilter::new("info")
+    };
+
+    // Get format from config or default
+    let format = config.map(|c| c.format.as_str()).unwrap_or("pretty");
+
+    // Build and set subscriber based on format
+    match format {
+        "json" => {
+            let subscriber = tracing_subscriber::registry().with(env_filter).with(
+                tracing_subscriber::fmt::layer()
+                    .json()
+                    .with_span_events(FmtSpan::CLOSE),
+            );
+            let _ = tracing::subscriber::set_global_default(subscriber);
+        }
+        "compact" => {
+            let subscriber = tracing_subscriber::registry()
+                .with(env_filter)
+                .with(tracing_subscriber::fmt::layer().compact());
+            let _ = tracing::subscriber::set_global_default(subscriber);
+        }
+        _ => {
+            // "pretty" or default
+            let subscriber = tracing_subscriber::registry()
+                .with(env_filter)
+                .with(tracing_subscriber::fmt::layer());
+            let _ = tracing::subscriber::set_global_default(subscriber);
+        }
+    }
+}
+
+/// Parses a log level string into a Level.
+fn parse_level(level: &str) -> Level {
+    match level.to_lowercase().as_str() {
+        "error" => Level::ERROR,
+        "warn" => Level::WARN,
+        "info" => Level::INFO,
+        "debug" => Level::DEBUG,
+        "trace" => Level::TRACE,
+        _ => Level::INFO,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_level() {
+        assert_eq!(parse_level("error"), Level::ERROR);
+        assert_eq!(parse_level("warn"), Level::WARN);
+        assert_eq!(parse_level("info"), Level::INFO);
+        assert_eq!(parse_level("debug"), Level::DEBUG);
+        assert_eq!(parse_level("trace"), Level::TRACE);
+        assert_eq!(parse_level("INFO"), Level::INFO);
+        assert_eq!(parse_level("unknown"), Level::INFO);
+    }
+
+    #[test]
+    fn test_log_config_default() {
+        let config = LogConfig::new();
+        assert_eq!(config.level, "info");
+        assert_eq!(config.format, "pretty");
+    }
+}

--- a/src/telemetry/metrics.rs
+++ b/src/telemetry/metrics.rs
@@ -1,0 +1,274 @@
+//! Metrics collection for packet statistics.
+//!
+//! Provides thread-safe counters for tracking packet processing metrics
+//! at both the global and per-interface level.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::RwLock;
+
+/// Atomic counter for thread-safe increment operations.
+#[derive(Debug, Default)]
+pub struct Counter(AtomicU64);
+
+impl Counter {
+    /// Creates a new counter initialized to zero.
+    pub fn new() -> Self {
+        Self(AtomicU64::new(0))
+    }
+
+    /// Increments the counter by 1.
+    pub fn inc(&self) {
+        self.0.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Adds a value to the counter.
+    pub fn add(&self, val: u64) {
+        self.0.fetch_add(val, Ordering::Relaxed);
+    }
+
+    /// Gets the current value of the counter.
+    pub fn get(&self) -> u64 {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+/// Per-interface statistics.
+#[derive(Debug, Default)]
+pub struct InterfaceStats {
+    /// Number of packets received.
+    pub rx_packets: Counter,
+    /// Number of bytes received.
+    pub rx_bytes: Counter,
+    /// Number of packets transmitted.
+    pub tx_packets: Counter,
+    /// Number of bytes transmitted.
+    pub tx_bytes: Counter,
+    /// Number of receive drops.
+    pub rx_drops: Counter,
+    /// Number of receive errors.
+    pub rx_errors: Counter,
+    /// Number of transmit errors.
+    pub tx_errors: Counter,
+}
+
+impl InterfaceStats {
+    /// Creates new interface statistics initialized to zero.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Records a received packet.
+    pub fn record_rx(&self, bytes: usize) {
+        self.rx_packets.inc();
+        self.rx_bytes.add(bytes as u64);
+    }
+
+    /// Records a transmitted packet.
+    pub fn record_tx(&self, bytes: usize) {
+        self.tx_packets.inc();
+        self.tx_bytes.add(bytes as u64);
+    }
+
+    /// Records a receive error.
+    pub fn record_rx_error(&self) {
+        self.rx_errors.inc();
+    }
+
+    /// Records a transmit error.
+    pub fn record_tx_error(&self) {
+        self.tx_errors.inc();
+    }
+
+    /// Records a receive drop.
+    pub fn record_rx_drop(&self) {
+        self.rx_drops.inc();
+    }
+}
+
+/// Global metrics registry for the router.
+#[derive(Debug, Default)]
+pub struct MetricsRegistry {
+    /// Per-interface statistics.
+    interfaces: RwLock<HashMap<String, InterfaceStats>>,
+
+    // ARP metrics
+    /// Number of ARP requests sent.
+    pub arp_requests_sent: Counter,
+    /// Number of ARP replies sent.
+    pub arp_replies_sent: Counter,
+
+    // Forwarding metrics
+    /// Number of packets successfully forwarded.
+    pub packets_forwarded: Counter,
+    /// Number of packets dropped (no route, TTL expired, etc.).
+    pub packets_dropped: Counter,
+
+    // ICMP metrics
+    /// Number of ICMP echo replies sent.
+    pub icmp_echo_replies: Counter,
+
+    // Table size gauges (using AtomicU64 for gauges)
+    /// Current number of ARP table entries.
+    pub arp_table_size: AtomicU64,
+    /// Current number of FDB entries.
+    pub fdb_table_size: AtomicU64,
+    /// Current number of routing table entries.
+    pub route_count: AtomicU64,
+}
+
+impl MetricsRegistry {
+    /// Creates a new metrics registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers an interface for statistics tracking.
+    pub fn register_interface(&self, name: &str) {
+        let mut interfaces = self.interfaces.write().unwrap();
+        interfaces.entry(name.to_string()).or_default();
+    }
+
+    /// Records a received packet on an interface.
+    pub fn record_rx(&self, interface: &str, bytes: usize) {
+        if let Some(stats) = self.interfaces.read().unwrap().get(interface) {
+            stats.record_rx(bytes);
+        }
+    }
+
+    /// Records a transmitted packet on an interface.
+    pub fn record_tx(&self, interface: &str, bytes: usize) {
+        if let Some(stats) = self.interfaces.read().unwrap().get(interface) {
+            stats.record_tx(bytes);
+        }
+    }
+
+    /// Records a receive error on an interface.
+    pub fn record_rx_error(&self, interface: &str) {
+        if let Some(stats) = self.interfaces.read().unwrap().get(interface) {
+            stats.record_rx_error();
+        }
+    }
+
+    /// Records a transmit error on an interface.
+    pub fn record_tx_error(&self, interface: &str) {
+        if let Some(stats) = self.interfaces.read().unwrap().get(interface) {
+            stats.record_tx_error();
+        }
+    }
+
+    /// Updates the ARP table size gauge.
+    pub fn set_arp_table_size(&self, size: usize) {
+        self.arp_table_size.store(size as u64, Ordering::Relaxed);
+    }
+
+    /// Updates the FDB table size gauge.
+    pub fn set_fdb_table_size(&self, size: usize) {
+        self.fdb_table_size.store(size as u64, Ordering::Relaxed);
+    }
+
+    /// Updates the route count gauge.
+    pub fn set_route_count(&self, count: usize) {
+        self.route_count.store(count as u64, Ordering::Relaxed);
+    }
+
+    /// Exports all metrics as key-value pairs.
+    ///
+    /// This format is designed to be easily convertible to Prometheus format
+    /// in the future.
+    pub fn export(&self) -> Vec<(String, u64)> {
+        // Global counters and gauges
+        let mut result = vec![
+            ("arp_requests_sent".into(), self.arp_requests_sent.get()),
+            ("arp_replies_sent".into(), self.arp_replies_sent.get()),
+            ("packets_forwarded".into(), self.packets_forwarded.get()),
+            ("packets_dropped".into(), self.packets_dropped.get()),
+            ("icmp_echo_replies".into(), self.icmp_echo_replies.get()),
+            (
+                "arp_table_size".into(),
+                self.arp_table_size.load(Ordering::Relaxed),
+            ),
+            (
+                "fdb_table_size".into(),
+                self.fdb_table_size.load(Ordering::Relaxed),
+            ),
+            (
+                "route_count".into(),
+                self.route_count.load(Ordering::Relaxed),
+            ),
+        ];
+
+        // Per-interface metrics
+        let interfaces = self.interfaces.read().unwrap();
+        for (name, stats) in interfaces.iter() {
+            result.extend([
+                (format!("{}_rx_packets", name), stats.rx_packets.get()),
+                (format!("{}_rx_bytes", name), stats.rx_bytes.get()),
+                (format!("{}_tx_packets", name), stats.tx_packets.get()),
+                (format!("{}_tx_bytes", name), stats.tx_bytes.get()),
+                (format!("{}_rx_drops", name), stats.rx_drops.get()),
+                (format!("{}_rx_errors", name), stats.rx_errors.get()),
+                (format!("{}_tx_errors", name), stats.tx_errors.get()),
+            ]);
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_counter_basic() {
+        let counter = Counter::new();
+        assert_eq!(counter.get(), 0);
+
+        counter.inc();
+        assert_eq!(counter.get(), 1);
+
+        counter.add(10);
+        assert_eq!(counter.get(), 11);
+    }
+
+    #[test]
+    fn test_interface_stats() {
+        let stats = InterfaceStats::new();
+
+        stats.record_rx(100);
+        stats.record_rx(200);
+        stats.record_tx(150);
+
+        assert_eq!(stats.rx_packets.get(), 2);
+        assert_eq!(stats.rx_bytes.get(), 300);
+        assert_eq!(stats.tx_packets.get(), 1);
+        assert_eq!(stats.tx_bytes.get(), 150);
+    }
+
+    #[test]
+    fn test_metrics_registry() {
+        let registry = MetricsRegistry::new();
+
+        registry.register_interface("eth0");
+        registry.register_interface("eth1");
+
+        registry.record_rx("eth0", 100);
+        registry.record_tx("eth0", 200);
+        registry.record_rx("eth1", 50);
+
+        registry.packets_forwarded.inc();
+        registry.arp_requests_sent.add(5);
+
+        let metrics = registry.export();
+
+        // Check global metrics
+        assert!(metrics.contains(&("packets_forwarded".into(), 1)));
+        assert!(metrics.contains(&("arp_requests_sent".into(), 5)));
+
+        // Check interface metrics
+        assert!(metrics.contains(&("eth0_rx_packets".into(), 1)));
+        assert!(metrics.contains(&("eth0_rx_bytes".into(), 100)));
+        assert!(metrics.contains(&("eth1_rx_packets".into(), 1)));
+    }
+}

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1,0 +1,11 @@
+//! Telemetry module for logging and metrics.
+//!
+//! Provides:
+//! - Logging configuration and initialization
+//! - Metrics collection for packet statistics
+
+mod logging;
+mod metrics;
+
+pub use logging::{init_logging, LogConfig};
+pub use metrics::{Counter, InterfaceStats, MetricsRegistry};

--- a/tests/config_cli.rs
+++ b/tests/config_cli.rs
@@ -57,8 +57,8 @@ addressing = "static"
             .expect("Failed to execute command");
 
         assert!(!output.status.success());
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        assert!(stdout.contains("LAN interface requires static address"));
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("LAN interface requires static address"));
     }
 
     #[test]
@@ -88,9 +88,9 @@ lan = ["eth99"]  # eth99 doesn't exist
             .expect("Failed to execute command");
 
         assert!(!output.status.success());
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        assert!(stdout.contains("eth99"));
-        assert!(stdout.contains("not defined"));
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("eth99"));
+        assert!(stderr.contains("not defined"));
     }
 
     #[test]
@@ -117,9 +117,9 @@ address = "192.168.1.1/24"
             .expect("Failed to execute command");
 
         assert!(output.status.success());
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        assert!(stdout.contains("[WARN]"));
-        assert!(stdout.contains("mtu not specified"));
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("[WARN]"));
+        assert!(stderr.contains("mtu not specified"));
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `telemetry` module with metrics collection and logging configuration
- Implement thread-safe counters (AtomicU64-based) for packet statistics
- Support per-interface rx/tx metrics (packets, bytes, errors, drops)
- Add global router metrics (ARP, forwarding, ICMP)
- Configure logging via RUST_LOG env var or config.toml

## Changes

- `src/telemetry/metrics.rs`: Counter, InterfaceStats, MetricsRegistry
- `src/telemetry/logging.rs`: init_logging() with format options (pretty/compact/json)
- `src/config/types.rs`: LoggingConfig, LoggingLock
- `src/dataplane/router.rs`: Metrics integration
- `Cargo.toml`: tracing-subscriber features (env-filter, json)

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes (171 tests)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes

Closes #12