### PR TITLE
feat(dhcp): Add DHCPv4 server support

### DIFF
--- a/src/dataplane/dhcp_server.rs
+++ b/src/dataplane/dhcp_server.rs
@@ -1,0 +1,894 @@
+//! DHCPv4 Server
+//!
+//! DHCP server implementation for automatic IP address assignment.
+//! Supports DISCOVER/OFFER/REQUEST/ACK flow (DORA) per RFC 2131.
+
+use crate::protocol::dhcp::{DhcpBuilder, DhcpHeader, DhcpMessageType};
+use crate::protocol::MacAddr;
+use std::collections::HashMap;
+use std::net::Ipv4Addr;
+use std::time::{Duration, Instant};
+use tracing::{debug, trace, warn};
+
+/// DHCP server processing result
+#[derive(Debug)]
+pub enum DhcpAction {
+    /// Send a DHCP reply
+    Reply {
+        /// Interface to send on
+        interface: String,
+        /// DHCP payload (to be wrapped in UDP/IP/Ethernet)
+        packet: Vec<u8>,
+        /// Destination IP (broadcast or unicast)
+        dst_ip: Ipv4Addr,
+        /// Destination MAC
+        dst_mac: MacAddr,
+    },
+    /// No action needed
+    None,
+}
+
+/// State of an IP address lease
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LeaseState {
+    /// Available for allocation
+    Available,
+    /// Offered but not yet confirmed (waiting for REQUEST)
+    Offered,
+    /// Actively leased to a client
+    Leased,
+}
+
+/// A single lease entry
+#[derive(Debug, Clone)]
+pub struct LeaseEntry {
+    /// Assigned IP address
+    pub ip_addr: Ipv4Addr,
+    /// Client MAC address
+    pub mac_addr: [u8; 6],
+    /// Current state
+    pub state: LeaseState,
+    /// When the offer was sent (for offer timeout)
+    pub offered_at: Option<Instant>,
+    /// When the lease was confirmed
+    pub leased_at: Option<Instant>,
+    /// When the lease expires
+    pub expires_at: Option<Instant>,
+    /// Client hostname (if provided)
+    pub hostname: Option<String>,
+}
+
+impl LeaseEntry {
+    fn new(ip_addr: Ipv4Addr) -> Self {
+        Self {
+            ip_addr,
+            mac_addr: [0; 6],
+            state: LeaseState::Available,
+            offered_at: None,
+            leased_at: None,
+            expires_at: None,
+            hostname: None,
+        }
+    }
+}
+
+/// DHCP pool configuration for a single interface
+#[derive(Debug, Clone)]
+pub struct DhcpPoolConfig {
+    /// Interface name
+    pub interface: String,
+    /// Start of IP range
+    pub range_start: Ipv4Addr,
+    /// End of IP range (inclusive)
+    pub range_end: Ipv4Addr,
+    /// Subnet mask
+    pub subnet_mask: Ipv4Addr,
+    /// Default gateway
+    pub gateway: Ipv4Addr,
+    /// DNS servers
+    pub dns_servers: Vec<Ipv4Addr>,
+    /// Lease time in seconds
+    pub lease_time: u32,
+    /// Offer timeout in seconds (how long to hold an offer)
+    pub offer_timeout: u64,
+}
+
+/// DHCP pool for a single interface
+#[derive(Debug)]
+pub struct DhcpPool {
+    config: DhcpPoolConfig,
+    /// IP -> LeaseEntry mapping
+    leases: HashMap<Ipv4Addr, LeaseEntry>,
+    /// MAC -> IP reverse mapping for quick lookup
+    mac_to_ip: HashMap<[u8; 6], Ipv4Addr>,
+}
+
+impl DhcpPool {
+    /// Create a new DHCP pool
+    pub fn new(config: DhcpPoolConfig) -> Self {
+        let mut leases = HashMap::new();
+
+        // Initialize all IPs in range as available
+        let start = u32::from(config.range_start);
+        let end = u32::from(config.range_end);
+
+        for ip_num in start..=end {
+            let ip = Ipv4Addr::from(ip_num);
+            leases.insert(ip, LeaseEntry::new(ip));
+        }
+
+        debug!(
+            "DHCP pool created for {} with {} addresses ({} - {})",
+            config.interface,
+            leases.len(),
+            config.range_start,
+            config.range_end
+        );
+
+        Self {
+            config,
+            leases,
+            mac_to_ip: HashMap::new(),
+        }
+    }
+
+    /// Find an existing lease for a MAC address
+    pub fn find_by_mac(&self, mac: &[u8; 6]) -> Option<Ipv4Addr> {
+        self.mac_to_ip.get(mac).copied()
+    }
+
+    /// Allocate an IP for a client
+    ///
+    /// Returns existing allocation if client already has one,
+    /// otherwise finds a free IP.
+    pub fn allocate_ip(&mut self, mac: [u8; 6]) -> Option<Ipv4Addr> {
+        // Check for existing allocation
+        if let Some(ip) = self.find_by_mac(&mac) {
+            return Some(ip);
+        }
+
+        // Find first available IP
+        let available_ip = self
+            .leases
+            .values()
+            .find(|e| e.state == LeaseState::Available)
+            .map(|e| e.ip_addr);
+
+        if let Some(ip) = available_ip {
+            // Mark as offered
+            if let Some(entry) = self.leases.get_mut(&ip) {
+                entry.mac_addr = mac;
+                entry.state = LeaseState::Offered;
+                entry.offered_at = Some(Instant::now());
+            }
+            self.mac_to_ip.insert(mac, ip);
+            debug!("Allocated IP {} for MAC {:02x?}", ip, mac);
+            Some(ip)
+        } else {
+            warn!("DHCP pool exhausted for {}", self.config.interface);
+            None
+        }
+    }
+
+    /// Confirm a lease (after REQUEST)
+    pub fn confirm_lease(&mut self, ip: Ipv4Addr, mac: [u8; 6]) -> bool {
+        if let Some(entry) = self.leases.get_mut(&ip) {
+            // Verify MAC matches
+            if entry.mac_addr != mac {
+                warn!("Lease confirmation failed: MAC mismatch for {}", ip);
+                return false;
+            }
+
+            // Only confirm if offered or already leased (renewal)
+            if entry.state == LeaseState::Offered || entry.state == LeaseState::Leased {
+                let now = Instant::now();
+                entry.state = LeaseState::Leased;
+                entry.leased_at = Some(now);
+                entry.expires_at = Some(now + Duration::from_secs(self.config.lease_time as u64));
+                debug!("Lease confirmed for IP {} MAC {:02x?}", ip, mac);
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Release a lease
+    pub fn release(&mut self, ip: Ipv4Addr, mac: [u8; 6]) {
+        if let Some(entry) = self.leases.get_mut(&ip) {
+            if entry.mac_addr == mac {
+                self.mac_to_ip.remove(&mac);
+                *entry = LeaseEntry::new(ip);
+                debug!("Lease released for IP {}", ip);
+            }
+        }
+    }
+
+    /// Check if an IP is valid for a specific MAC
+    pub fn is_valid_for_mac(&self, ip: Ipv4Addr, mac: &[u8; 6]) -> bool {
+        if let Some(entry) = self.leases.get(&ip) {
+            // IP must be offered or leased to this MAC
+            (entry.state == LeaseState::Offered || entry.state == LeaseState::Leased)
+                && entry.mac_addr == *mac
+        } else {
+            false
+        }
+    }
+
+    /// Expire old offers and leases
+    pub fn run_maintenance(&mut self) {
+        let now = Instant::now();
+        let offer_timeout = Duration::from_secs(self.config.offer_timeout);
+
+        let mut expired_macs = Vec::new();
+
+        for entry in self.leases.values_mut() {
+            let should_expire = match entry.state {
+                LeaseState::Offered => {
+                    // Expire offers that weren't confirmed
+                    entry
+                        .offered_at
+                        .is_some_and(|t| now.duration_since(t) > offer_timeout)
+                }
+                LeaseState::Leased => {
+                    // Expire old leases
+                    entry.expires_at.is_some_and(|t| now > t)
+                }
+                LeaseState::Available => false,
+            };
+
+            if should_expire {
+                trace!("Expiring lease for IP {}", entry.ip_addr);
+                expired_macs.push(entry.mac_addr);
+                *entry = LeaseEntry::new(entry.ip_addr);
+            }
+        }
+
+        // Clean up reverse mapping
+        for mac in expired_macs {
+            self.mac_to_ip.remove(&mac);
+        }
+    }
+
+    /// Get number of available addresses
+    pub fn available_count(&self) -> usize {
+        self.leases
+            .values()
+            .filter(|e| e.state == LeaseState::Available)
+            .count()
+    }
+
+    /// Get number of leased addresses
+    pub fn leased_count(&self) -> usize {
+        self.leases
+            .values()
+            .filter(|e| e.state == LeaseState::Leased)
+            .count()
+    }
+
+    /// Get the config
+    pub fn config(&self) -> &DhcpPoolConfig {
+        &self.config
+    }
+}
+
+/// DHCP Server supporting multiple interfaces
+#[derive(Debug, Default)]
+pub struct DhcpServer {
+    /// Interface name -> pool mapping
+    pools: HashMap<String, DhcpPool>,
+}
+
+impl DhcpServer {
+    /// Create a new DHCP server
+    pub fn new() -> Self {
+        Self {
+            pools: HashMap::new(),
+        }
+    }
+
+    /// Add a DHCP pool for an interface
+    pub fn add_pool(&mut self, config: DhcpPoolConfig) {
+        let interface = config.interface.clone();
+        self.pools.insert(interface, DhcpPool::new(config));
+    }
+
+    /// Remove a DHCP pool
+    pub fn remove_pool(&mut self, interface: &str) {
+        self.pools.remove(interface);
+    }
+
+    /// Check if DHCP is enabled for an interface
+    pub fn has_pool(&self, interface: &str) -> bool {
+        self.pools.contains_key(interface)
+    }
+
+    /// Process a DHCP packet
+    ///
+    /// # Arguments
+    /// * `interface` - The interface the packet arrived on
+    /// * `server_ip` - Our IP address on this interface
+    /// * `dhcp_payload` - The DHCP message (UDP payload)
+    pub fn process_dhcp(
+        &mut self,
+        interface: &str,
+        server_ip: Ipv4Addr,
+        dhcp_payload: &[u8],
+    ) -> DhcpAction {
+        // Parse DHCP message
+        let msg = match DhcpHeader::parse(dhcp_payload) {
+            Ok(m) => m,
+            Err(e) => {
+                debug!("Failed to parse DHCP message: {}", e);
+                return DhcpAction::None;
+            }
+        };
+
+        // Must be a request (client -> server)
+        if msg.op() != 1 {
+            return DhcpAction::None;
+        }
+
+        // Get message type
+        let msg_type = match msg.message_type() {
+            Some(t) => t,
+            None => {
+                debug!("DHCP message without message type");
+                return DhcpAction::None;
+            }
+        };
+
+        // Get pool for this interface
+        let pool = match self.pools.get_mut(interface) {
+            Some(p) => p,
+            None => {
+                debug!("No DHCP pool for interface {}", interface);
+                return DhcpAction::None;
+            }
+        };
+
+        debug!(
+            "Processing DHCP {:?} from {:02x?} on {}",
+            msg_type,
+            msg.client_mac(),
+            interface
+        );
+
+        match msg_type {
+            DhcpMessageType::Discover => Self::handle_discover(pool, interface, server_ip, &msg),
+            DhcpMessageType::Request => Self::handle_request(pool, interface, server_ip, &msg),
+            DhcpMessageType::Release => {
+                Self::handle_release(pool, &msg);
+                DhcpAction::None
+            }
+            DhcpMessageType::Decline => {
+                Self::handle_decline(pool, &msg);
+                DhcpAction::None
+            }
+            DhcpMessageType::Inform => {
+                // INFORM: Client has IP, just wants config
+                Self::handle_inform(pool, interface, server_ip, &msg)
+            }
+            _ => {
+                // Other message types (OFFER, ACK, NAK) are server->client
+                DhcpAction::None
+            }
+        }
+    }
+
+    /// Handle DHCP DISCOVER - allocate and offer an IP
+    fn handle_discover(
+        pool: &mut DhcpPool,
+        interface: &str,
+        server_ip: Ipv4Addr,
+        msg: &DhcpHeader,
+    ) -> DhcpAction {
+        let client_mac = msg.client_mac();
+
+        // Allocate an IP for this client
+        let offered_ip = match pool.allocate_ip(client_mac) {
+            Some(ip) => ip,
+            None => return DhcpAction::None,
+        };
+
+        // Build OFFER
+        let config = pool.config();
+        let packet = DhcpBuilder::reply(msg)
+            .message_type(DhcpMessageType::Offer)
+            .yiaddr(offered_ip)
+            .siaddr(server_ip)
+            .server_id(server_ip)
+            .subnet_mask(config.subnet_mask)
+            .router(&[config.gateway])
+            .dns(&config.dns_servers)
+            .lease_time(config.lease_time)
+            .renewal_time(config.lease_time / 2)
+            .rebinding_time(config.lease_time * 7 / 8)
+            .build();
+
+        debug!("Sending DHCP OFFER: {} to {:02x?}", offered_ip, client_mac);
+
+        // Determine destination
+        let (dst_ip, dst_mac) = if msg.is_broadcast() || msg.ciaddr() == Ipv4Addr::UNSPECIFIED {
+            // Broadcast
+            (
+                Ipv4Addr::BROADCAST,
+                MacAddr([0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
+            )
+        } else {
+            // Unicast to client
+            (msg.ciaddr(), MacAddr(client_mac))
+        };
+
+        DhcpAction::Reply {
+            interface: interface.to_string(),
+            packet,
+            dst_ip,
+            dst_mac,
+        }
+    }
+
+    /// Handle DHCP REQUEST - confirm or reject the lease
+    fn handle_request(
+        pool: &mut DhcpPool,
+        interface: &str,
+        server_ip: Ipv4Addr,
+        msg: &DhcpHeader,
+    ) -> DhcpAction {
+        let client_mac = msg.client_mac();
+
+        // Check if this request is for us
+        if let Some(requested_server) = msg.server_id() {
+            if requested_server != server_ip {
+                // Request is for another server, ignore
+                debug!("DHCP REQUEST for different server: {}", requested_server);
+                return DhcpAction::None;
+            }
+        }
+
+        // Determine requested IP
+        let requested_ip = msg.requested_ip().or_else(|| {
+            // During renewal, client uses ciaddr
+            let ci = msg.ciaddr();
+            if ci != Ipv4Addr::UNSPECIFIED {
+                Some(ci)
+            } else {
+                None
+            }
+        });
+
+        let requested_ip = match requested_ip {
+            Some(ip) => ip,
+            None => {
+                debug!("DHCP REQUEST without requested IP");
+                return Self::send_nak(pool, interface, server_ip, msg);
+            }
+        };
+
+        // Verify the request is valid
+        if !pool.is_valid_for_mac(requested_ip, &client_mac) {
+            debug!(
+                "DHCP REQUEST for invalid IP {} from {:02x?}",
+                requested_ip, client_mac
+            );
+            return Self::send_nak(pool, interface, server_ip, msg);
+        }
+
+        // Confirm the lease
+        if !pool.confirm_lease(requested_ip, client_mac) {
+            return Self::send_nak(pool, interface, server_ip, msg);
+        }
+
+        // Build ACK
+        let config = pool.config();
+        let packet = DhcpBuilder::reply(msg)
+            .message_type(DhcpMessageType::Ack)
+            .yiaddr(requested_ip)
+            .siaddr(server_ip)
+            .server_id(server_ip)
+            .subnet_mask(config.subnet_mask)
+            .router(&[config.gateway])
+            .dns(&config.dns_servers)
+            .lease_time(config.lease_time)
+            .renewal_time(config.lease_time / 2)
+            .rebinding_time(config.lease_time * 7 / 8)
+            .build();
+
+        debug!("Sending DHCP ACK: {} to {:02x?}", requested_ip, client_mac);
+
+        // Determine destination
+        let (dst_ip, dst_mac) = if msg.is_broadcast() || msg.ciaddr() == Ipv4Addr::UNSPECIFIED {
+            (
+                Ipv4Addr::BROADCAST,
+                MacAddr([0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
+            )
+        } else {
+            (msg.ciaddr(), MacAddr(client_mac))
+        };
+
+        DhcpAction::Reply {
+            interface: interface.to_string(),
+            packet,
+            dst_ip,
+            dst_mac,
+        }
+    }
+
+    /// Send a DHCP NAK
+    fn send_nak(
+        pool: &DhcpPool,
+        interface: &str,
+        server_ip: Ipv4Addr,
+        msg: &DhcpHeader,
+    ) -> DhcpAction {
+        let _ = pool; // unused but kept for consistency
+
+        let packet = DhcpBuilder::reply(msg)
+            .message_type(DhcpMessageType::Nak)
+            .server_id(server_ip)
+            .build();
+
+        debug!("Sending DHCP NAK to {:02x?}", msg.client_mac());
+
+        // NAK is always broadcast
+        DhcpAction::Reply {
+            interface: interface.to_string(),
+            packet,
+            dst_ip: Ipv4Addr::BROADCAST,
+            dst_mac: MacAddr([0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
+        }
+    }
+
+    /// Handle DHCP RELEASE
+    fn handle_release(pool: &mut DhcpPool, msg: &DhcpHeader) {
+        let client_mac = msg.client_mac();
+        let client_ip = msg.ciaddr();
+
+        if client_ip != Ipv4Addr::UNSPECIFIED {
+            debug!("DHCP RELEASE: {} from {:02x?}", client_ip, client_mac);
+            pool.release(client_ip, client_mac);
+        }
+    }
+
+    /// Handle DHCP DECLINE
+    fn handle_decline(pool: &mut DhcpPool, msg: &DhcpHeader) {
+        // Client detected IP conflict - mark as unavailable
+        if let Some(ip) = msg.requested_ip() {
+            warn!("DHCP DECLINE for {} - IP conflict detected", ip);
+            // For simplicity, we just release it
+            // A production server might mark it as "bad" for a while
+            pool.release(ip, msg.client_mac());
+        }
+    }
+
+    /// Handle DHCP INFORM - client has IP, just wants config
+    fn handle_inform(
+        pool: &mut DhcpPool,
+        interface: &str,
+        server_ip: Ipv4Addr,
+        msg: &DhcpHeader,
+    ) -> DhcpAction {
+        let config = pool.config();
+
+        // INFORM response: ACK without yiaddr or lease time
+        let packet = DhcpBuilder::reply(msg)
+            .message_type(DhcpMessageType::Ack)
+            .siaddr(server_ip)
+            .server_id(server_ip)
+            .subnet_mask(config.subnet_mask)
+            .router(&[config.gateway])
+            .dns(&config.dns_servers)
+            .build();
+
+        debug!("Sending DHCP ACK (INFORM) to {:02x?}", msg.client_mac());
+
+        // INFORM response is unicast to ciaddr
+        let client_ip = msg.ciaddr();
+        let (dst_ip, dst_mac) = if client_ip != Ipv4Addr::UNSPECIFIED {
+            (client_ip, MacAddr(msg.client_mac()))
+        } else {
+            (
+                Ipv4Addr::BROADCAST,
+                MacAddr([0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
+            )
+        };
+
+        DhcpAction::Reply {
+            interface: interface.to_string(),
+            packet,
+            dst_ip,
+            dst_mac,
+        }
+    }
+
+    /// Run maintenance on all pools (expire old leases)
+    pub fn run_maintenance(&mut self) {
+        for pool in self.pools.values_mut() {
+            pool.run_maintenance();
+        }
+    }
+
+    /// Get statistics for an interface
+    pub fn get_stats(&self, interface: &str) -> Option<(usize, usize)> {
+        self.pools
+            .get(interface)
+            .map(|p| (p.available_count(), p.leased_count()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_pool_config() -> DhcpPoolConfig {
+        DhcpPoolConfig {
+            interface: "eth0".to_string(),
+            range_start: Ipv4Addr::new(192, 168, 1, 100),
+            range_end: Ipv4Addr::new(192, 168, 1, 110),
+            subnet_mask: Ipv4Addr::new(255, 255, 255, 0),
+            gateway: Ipv4Addr::new(192, 168, 1, 1),
+            dns_servers: vec![Ipv4Addr::new(8, 8, 8, 8)],
+            lease_time: 3600,
+            offer_timeout: 60,
+        }
+    }
+
+    fn make_discover(mac: [u8; 6]) -> Vec<u8> {
+        let mut packet = vec![0u8; 300];
+        packet[0] = 1; // BOOTREQUEST
+        packet[1] = 1; // Ethernet
+        packet[2] = 6; // MAC length
+        packet[4..8].copy_from_slice(&0x12345678u32.to_be_bytes());
+        packet[10..12].copy_from_slice(&0x8000u16.to_be_bytes()); // Broadcast
+        packet[28..34].copy_from_slice(&mac);
+        packet[236..240].copy_from_slice(&[99, 130, 83, 99]); // Magic cookie
+        packet[240] = 53; // Message type option
+        packet[241] = 1;
+        packet[242] = 1; // DISCOVER
+        packet[243] = 255; // END
+        packet
+    }
+
+    fn make_request(mac: [u8; 6], requested_ip: Ipv4Addr, server_id: Ipv4Addr) -> Vec<u8> {
+        let mut packet = vec![0u8; 300];
+        packet[0] = 1; // BOOTREQUEST
+        packet[1] = 1;
+        packet[2] = 6;
+        packet[4..8].copy_from_slice(&0x12345678u32.to_be_bytes());
+        packet[10..12].copy_from_slice(&0x8000u16.to_be_bytes());
+        packet[28..34].copy_from_slice(&mac);
+        packet[236..240].copy_from_slice(&[99, 130, 83, 99]);
+
+        let mut pos = 240;
+        // Message type = REQUEST
+        packet[pos] = 53;
+        packet[pos + 1] = 1;
+        packet[pos + 2] = 3;
+        pos += 3;
+        // Requested IP
+        packet[pos] = 50;
+        packet[pos + 1] = 4;
+        packet[pos + 2..pos + 6].copy_from_slice(&requested_ip.octets());
+        pos += 6;
+        // Server ID
+        packet[pos] = 54;
+        packet[pos + 1] = 4;
+        packet[pos + 2..pos + 6].copy_from_slice(&server_id.octets());
+        pos += 6;
+        // END
+        packet[pos] = 255;
+
+        packet
+    }
+
+    #[test]
+    fn test_pool_allocate() {
+        let config = make_pool_config();
+        let mut pool = DhcpPool::new(config);
+
+        let mac = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55];
+        let ip = pool.allocate_ip(mac).unwrap();
+
+        assert!(ip >= Ipv4Addr::new(192, 168, 1, 100));
+        assert!(ip <= Ipv4Addr::new(192, 168, 1, 110));
+
+        // Same MAC should get same IP
+        let ip2 = pool.allocate_ip(mac).unwrap();
+        assert_eq!(ip, ip2);
+
+        // Different MAC should get different IP
+        let mac2 = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff];
+        let ip3 = pool.allocate_ip(mac2).unwrap();
+        assert_ne!(ip, ip3);
+    }
+
+    #[test]
+    fn test_pool_exhaust() {
+        let mut config = make_pool_config();
+        config.range_start = Ipv4Addr::new(192, 168, 1, 100);
+        config.range_end = Ipv4Addr::new(192, 168, 1, 101); // Only 2 IPs
+        let mut pool = DhcpPool::new(config);
+
+        let mac1 = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55];
+        let mac2 = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff];
+        let mac3 = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66];
+
+        assert!(pool.allocate_ip(mac1).is_some());
+        assert!(pool.allocate_ip(mac2).is_some());
+        assert!(pool.allocate_ip(mac3).is_none()); // Pool exhausted
+    }
+
+    #[test]
+    fn test_pool_confirm_lease() {
+        let config = make_pool_config();
+        let mut pool = DhcpPool::new(config);
+
+        let mac = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55];
+        let ip = pool.allocate_ip(mac).unwrap();
+
+        // Should be offered, not leased
+        assert_eq!(pool.leased_count(), 0);
+
+        // Confirm the lease
+        assert!(pool.confirm_lease(ip, mac));
+        assert_eq!(pool.leased_count(), 1);
+
+        // Wrong MAC should fail
+        let wrong_mac = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff];
+        assert!(!pool.confirm_lease(ip, wrong_mac));
+    }
+
+    #[test]
+    fn test_pool_release() {
+        let config = make_pool_config();
+        let mut pool = DhcpPool::new(config);
+
+        let mac = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55];
+        let ip = pool.allocate_ip(mac).unwrap();
+        pool.confirm_lease(ip, mac);
+
+        assert_eq!(pool.leased_count(), 1);
+
+        pool.release(ip, mac);
+        assert_eq!(pool.leased_count(), 0);
+        assert!(pool.find_by_mac(&mac).is_none());
+    }
+
+    #[test]
+    fn test_server_discover_offer() {
+        let config = make_pool_config();
+        let mut server = DhcpServer::new();
+        server.add_pool(config);
+
+        let mac = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55];
+        let discover = make_discover(mac);
+        let server_ip = Ipv4Addr::new(192, 168, 1, 1);
+
+        let action = server.process_dhcp("eth0", server_ip, &discover);
+
+        match action {
+            DhcpAction::Reply { packet, dst_ip, .. } => {
+                assert_eq!(dst_ip, Ipv4Addr::BROADCAST);
+                let header = DhcpHeader::parse(&packet).unwrap();
+                assert_eq!(header.message_type(), Some(DhcpMessageType::Offer));
+                assert!(header.yiaddr() >= Ipv4Addr::new(192, 168, 1, 100));
+            }
+            _ => panic!("Expected Reply action"),
+        }
+    }
+
+    #[test]
+    fn test_server_request_ack() {
+        let config = make_pool_config();
+        let mut server = DhcpServer::new();
+        server.add_pool(config);
+
+        let mac = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55];
+        let server_ip = Ipv4Addr::new(192, 168, 1, 1);
+
+        // First, DISCOVER
+        let discover = make_discover(mac);
+        let offer_action = server.process_dhcp("eth0", server_ip, &discover);
+        let offered_ip = match offer_action {
+            DhcpAction::Reply { packet, .. } => DhcpHeader::parse(&packet).unwrap().yiaddr(),
+            _ => panic!("Expected offer"),
+        };
+
+        // Then, REQUEST
+        let request = make_request(mac, offered_ip, server_ip);
+        let ack_action = server.process_dhcp("eth0", server_ip, &request);
+
+        match ack_action {
+            DhcpAction::Reply { packet, .. } => {
+                let header = DhcpHeader::parse(&packet).unwrap();
+                assert_eq!(header.message_type(), Some(DhcpMessageType::Ack));
+                assert_eq!(header.yiaddr(), offered_ip);
+            }
+            _ => panic!("Expected ACK"),
+        }
+    }
+
+    #[test]
+    fn test_server_request_wrong_server() {
+        let config = make_pool_config();
+        let mut server = DhcpServer::new();
+        server.add_pool(config);
+
+        let mac = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55];
+        let server_ip = Ipv4Addr::new(192, 168, 1, 1);
+        let other_server = Ipv4Addr::new(192, 168, 1, 2);
+
+        // First, DISCOVER
+        let discover = make_discover(mac);
+        server.process_dhcp("eth0", server_ip, &discover);
+
+        // REQUEST for different server
+        let request = make_request(mac, Ipv4Addr::new(192, 168, 1, 100), other_server);
+        let action = server.process_dhcp("eth0", server_ip, &request);
+
+        // Should be ignored (not for us)
+        match action {
+            DhcpAction::None => {}
+            _ => panic!("Expected None for request to different server"),
+        }
+    }
+
+    #[test]
+    fn test_server_request_invalid_ip() {
+        let config = make_pool_config();
+        let mut server = DhcpServer::new();
+        server.add_pool(config);
+
+        let mac = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55];
+        let server_ip = Ipv4Addr::new(192, 168, 1, 1);
+
+        // REQUEST without DISCOVER (invalid IP)
+        let request = make_request(mac, Ipv4Addr::new(192, 168, 1, 100), server_ip);
+        let action = server.process_dhcp("eth0", server_ip, &request);
+
+        match action {
+            DhcpAction::Reply { packet, .. } => {
+                let header = DhcpHeader::parse(&packet).unwrap();
+                assert_eq!(header.message_type(), Some(DhcpMessageType::Nak));
+            }
+            _ => panic!("Expected NAK"),
+        }
+    }
+
+    #[test]
+    fn test_server_no_pool() {
+        let mut server = DhcpServer::new();
+        let mac = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55];
+        let discover = make_discover(mac);
+
+        let action = server.process_dhcp("eth0", Ipv4Addr::new(192, 168, 1, 1), &discover);
+
+        match action {
+            DhcpAction::None => {}
+            _ => panic!("Expected None for interface without pool"),
+        }
+    }
+
+    #[test]
+    fn test_pool_maintenance() {
+        let mut config = make_pool_config();
+        config.offer_timeout = 0; // Immediate timeout for test
+        let mut pool = DhcpPool::new(config);
+
+        let mac = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55];
+        let ip = pool.allocate_ip(mac).unwrap();
+
+        // Should be offered
+        assert!(pool.find_by_mac(&mac).is_some());
+
+        // Wait a tiny bit and run maintenance
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        pool.run_maintenance();
+
+        // Should be expired
+        assert!(pool.find_by_mac(&mac).is_none());
+
+        // IP should be available again
+        let ip2 = pool.allocate_ip(mac).unwrap();
+        assert_eq!(ip, ip2);
+    }
+}

--- a/src/dataplane/mod.rs
+++ b/src/dataplane/mod.rs
@@ -5,6 +5,7 @@
 mod arp_processor;
 mod arp_table;
 mod conntrack;
+mod dhcp_server;
 mod fdb;
 mod filter;
 mod firewall;
@@ -18,6 +19,7 @@ mod routing;
 
 pub use arp_processor::{process_arp, ArpAction, ArpPendingQueue};
 pub use arp_table::{ArpState, ArpTable};
+pub use dhcp_server::{DhcpAction, DhcpPool, DhcpPoolConfig, DhcpServer, LeaseEntry, LeaseState};
 pub use fdb::Fdb;
 pub use filter::{
     icmpv6_type, protocol, Action, Chain, FilterContext, FilterRule, IpAddr as FilterIpAddr,

--- a/src/protocol/dhcp.rs
+++ b/src/protocol/dhcp.rs
@@ -1,0 +1,812 @@
+//! DHCP protocol - RFC 2131, 2132
+//!
+//! DHCPv4 message parsing and building for DHCP server functionality.
+
+use crate::{Error, Result};
+use std::net::Ipv4Addr;
+
+/// DHCP server port (bootps)
+pub const DHCP_SERVER_PORT: u16 = 67;
+
+/// DHCP client port (bootpc)
+pub const DHCP_CLIENT_PORT: u16 = 68;
+
+/// Fixed header size (before options)
+pub const DHCP_HEADER_SIZE: usize = 236;
+
+/// Magic cookie marking start of options
+pub const MAGIC_COOKIE: [u8; 4] = [99, 130, 83, 99];
+
+/// Minimum packet size (header + magic cookie + end option)
+pub const MIN_PACKET_SIZE: usize = DHCP_HEADER_SIZE + 4 + 1;
+
+/// BOOTP operation codes
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum BootpOp {
+    Request = 1,
+    Reply = 2,
+}
+
+impl BootpOp {
+    pub fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            1 => Some(BootpOp::Request),
+            2 => Some(BootpOp::Reply),
+            _ => None,
+        }
+    }
+}
+
+/// DHCP message types (Option 53)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum DhcpMessageType {
+    Discover = 1,
+    Offer = 2,
+    Request = 3,
+    Decline = 4,
+    Ack = 5,
+    Nak = 6,
+    Release = 7,
+    Inform = 8,
+}
+
+impl DhcpMessageType {
+    pub fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            1 => Some(DhcpMessageType::Discover),
+            2 => Some(DhcpMessageType::Offer),
+            3 => Some(DhcpMessageType::Request),
+            4 => Some(DhcpMessageType::Decline),
+            5 => Some(DhcpMessageType::Ack),
+            6 => Some(DhcpMessageType::Nak),
+            7 => Some(DhcpMessageType::Release),
+            8 => Some(DhcpMessageType::Inform),
+            _ => None,
+        }
+    }
+}
+
+/// DHCP option codes
+pub mod options {
+    pub const PAD: u8 = 0;
+    pub const SUBNET_MASK: u8 = 1;
+    pub const ROUTER: u8 = 3;
+    pub const DNS_SERVER: u8 = 6;
+    pub const HOSTNAME: u8 = 12;
+    pub const DOMAIN_NAME: u8 = 15;
+    pub const BROADCAST_ADDR: u8 = 28;
+    pub const REQUESTED_IP: u8 = 50;
+    pub const LEASE_TIME: u8 = 51;
+    pub const MESSAGE_TYPE: u8 = 53;
+    pub const SERVER_ID: u8 = 54;
+    pub const PARAMETER_REQUEST: u8 = 55;
+    pub const RENEWAL_TIME: u8 = 58;
+    pub const REBINDING_TIME: u8 = 59;
+    pub const CLIENT_ID: u8 = 61;
+    pub const END: u8 = 255;
+}
+
+/// Parsed DHCP header (zero-copy reference)
+#[derive(Debug)]
+pub struct DhcpHeader<'a> {
+    buffer: &'a [u8],
+}
+
+impl<'a> DhcpHeader<'a> {
+    /// Parse DHCP message from buffer
+    pub fn parse(buffer: &'a [u8]) -> Result<Self> {
+        if buffer.len() < MIN_PACKET_SIZE {
+            return Err(Error::Parse("DHCP message too short".into()));
+        }
+
+        // Verify magic cookie
+        let cookie = &buffer[236..240];
+        if cookie != MAGIC_COOKIE {
+            return Err(Error::Parse("Invalid DHCP magic cookie".into()));
+        }
+
+        Ok(Self { buffer })
+    }
+
+    /// Operation code (1=request, 2=reply)
+    pub fn op(&self) -> u8 {
+        self.buffer[0]
+    }
+
+    /// Hardware type (1=Ethernet)
+    pub fn htype(&self) -> u8 {
+        self.buffer[1]
+    }
+
+    /// Hardware address length (6 for Ethernet)
+    pub fn hlen(&self) -> u8 {
+        self.buffer[2]
+    }
+
+    /// Hop count
+    pub fn hops(&self) -> u8 {
+        self.buffer[3]
+    }
+
+    /// Transaction ID
+    pub fn xid(&self) -> u32 {
+        u32::from_be_bytes([
+            self.buffer[4],
+            self.buffer[5],
+            self.buffer[6],
+            self.buffer[7],
+        ])
+    }
+
+    /// Seconds elapsed since client began acquisition/renewal
+    pub fn secs(&self) -> u16 {
+        u16::from_be_bytes([self.buffer[8], self.buffer[9]])
+    }
+
+    /// Flags (bit 15 = broadcast)
+    pub fn flags(&self) -> u16 {
+        u16::from_be_bytes([self.buffer[10], self.buffer[11]])
+    }
+
+    /// Is broadcast flag set?
+    pub fn is_broadcast(&self) -> bool {
+        self.flags() & 0x8000 != 0
+    }
+
+    /// Client IP address (ciaddr)
+    pub fn ciaddr(&self) -> Ipv4Addr {
+        Ipv4Addr::new(
+            self.buffer[12],
+            self.buffer[13],
+            self.buffer[14],
+            self.buffer[15],
+        )
+    }
+
+    /// Your IP address (yiaddr) - assigned to client
+    pub fn yiaddr(&self) -> Ipv4Addr {
+        Ipv4Addr::new(
+            self.buffer[16],
+            self.buffer[17],
+            self.buffer[18],
+            self.buffer[19],
+        )
+    }
+
+    /// Server IP address (siaddr)
+    pub fn siaddr(&self) -> Ipv4Addr {
+        Ipv4Addr::new(
+            self.buffer[20],
+            self.buffer[21],
+            self.buffer[22],
+            self.buffer[23],
+        )
+    }
+
+    /// Gateway IP address (giaddr) - relay agent
+    pub fn giaddr(&self) -> Ipv4Addr {
+        Ipv4Addr::new(
+            self.buffer[24],
+            self.buffer[25],
+            self.buffer[26],
+            self.buffer[27],
+        )
+    }
+
+    /// Client hardware address (chaddr) - first 16 bytes
+    pub fn chaddr(&self) -> &[u8] {
+        &self.buffer[28..44]
+    }
+
+    /// Client MAC address (first 6 bytes of chaddr for Ethernet)
+    pub fn client_mac(&self) -> [u8; 6] {
+        let mut mac = [0u8; 6];
+        mac.copy_from_slice(&self.buffer[28..34]);
+        mac
+    }
+
+    /// Server hostname (sname) - 64 bytes
+    pub fn sname(&self) -> &[u8] {
+        &self.buffer[44..108]
+    }
+
+    /// Boot filename (file) - 128 bytes
+    pub fn file(&self) -> &[u8] {
+        &self.buffer[108..236]
+    }
+
+    /// Options section (after magic cookie)
+    pub fn options_raw(&self) -> &[u8] {
+        &self.buffer[240..]
+    }
+
+    /// Raw bytes
+    pub fn as_bytes(&self) -> &[u8] {
+        self.buffer
+    }
+
+    /// Get DHCP message type from options
+    pub fn message_type(&self) -> Option<DhcpMessageType> {
+        self.find_option(options::MESSAGE_TYPE)
+            .and_then(|data| data.first().copied())
+            .and_then(DhcpMessageType::from_u8)
+    }
+
+    /// Get requested IP address from options (Option 50)
+    pub fn requested_ip(&self) -> Option<Ipv4Addr> {
+        self.find_option(options::REQUESTED_IP).and_then(|data| {
+            if data.len() >= 4 {
+                Some(Ipv4Addr::new(data[0], data[1], data[2], data[3]))
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Get server identifier from options (Option 54)
+    pub fn server_id(&self) -> Option<Ipv4Addr> {
+        self.find_option(options::SERVER_ID).and_then(|data| {
+            if data.len() >= 4 {
+                Some(Ipv4Addr::new(data[0], data[1], data[2], data[3]))
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Get client identifier from options (Option 61)
+    pub fn client_id(&self) -> Option<&[u8]> {
+        self.find_option(options::CLIENT_ID)
+    }
+
+    /// Get hostname from options (Option 12)
+    pub fn hostname(&self) -> Option<&str> {
+        self.find_option(options::HOSTNAME)
+            .and_then(|data| std::str::from_utf8(data).ok())
+    }
+
+    /// Get parameter request list from options (Option 55)
+    pub fn parameter_request_list(&self) -> Option<&[u8]> {
+        self.find_option(options::PARAMETER_REQUEST)
+    }
+
+    /// Find option by code, returns option data (without code and length)
+    fn find_option(&self, code: u8) -> Option<&[u8]> {
+        let opts = self.options_raw();
+        let mut i = 0;
+
+        while i < opts.len() {
+            let opt_code = opts[i];
+
+            // Handle special options
+            if opt_code == options::PAD {
+                i += 1;
+                continue;
+            }
+            if opt_code == options::END {
+                break;
+            }
+
+            // Regular option: code + length + data
+            if i + 1 >= opts.len() {
+                break;
+            }
+            let opt_len = opts[i + 1] as usize;
+            let data_start = i + 2;
+            let data_end = data_start + opt_len;
+
+            if data_end > opts.len() {
+                break;
+            }
+
+            if opt_code == code {
+                return Some(&opts[data_start..data_end]);
+            }
+
+            i = data_end;
+        }
+
+        None
+    }
+
+    /// Iterate over all options
+    pub fn iter_options(&self) -> DhcpOptionIterator<'_> {
+        DhcpOptionIterator {
+            data: self.options_raw(),
+            pos: 0,
+        }
+    }
+}
+
+/// Iterator over DHCP options
+pub struct DhcpOptionIterator<'a> {
+    data: &'a [u8],
+    pos: usize,
+}
+
+/// A single DHCP option
+#[derive(Debug, Clone)]
+pub struct DhcpOption<'a> {
+    pub code: u8,
+    pub data: &'a [u8],
+}
+
+impl<'a> Iterator for DhcpOptionIterator<'a> {
+    type Item = DhcpOption<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.pos < self.data.len() {
+            let code = self.data[self.pos];
+
+            if code == options::PAD {
+                self.pos += 1;
+                continue;
+            }
+            if code == options::END {
+                return None;
+            }
+
+            if self.pos + 1 >= self.data.len() {
+                return None;
+            }
+            let len = self.data[self.pos + 1] as usize;
+            let data_start = self.pos + 2;
+            let data_end = data_start + len;
+
+            if data_end > self.data.len() {
+                return None;
+            }
+
+            self.pos = data_end;
+            return Some(DhcpOption {
+                code,
+                data: &self.data[data_start..data_end],
+            });
+        }
+        None
+    }
+}
+
+/// DHCP message builder for server responses
+#[derive(Debug, Clone)]
+pub struct DhcpBuilder {
+    op: u8,
+    htype: u8,
+    hlen: u8,
+    hops: u8,
+    xid: u32,
+    secs: u16,
+    flags: u16,
+    ciaddr: Ipv4Addr,
+    yiaddr: Ipv4Addr,
+    siaddr: Ipv4Addr,
+    giaddr: Ipv4Addr,
+    chaddr: [u8; 16],
+    options: Vec<u8>,
+}
+
+impl DhcpBuilder {
+    /// Create a new builder for a DHCP reply based on a request
+    pub fn reply(request: &DhcpHeader) -> Self {
+        let mut chaddr = [0u8; 16];
+        chaddr.copy_from_slice(request.chaddr());
+
+        Self {
+            op: BootpOp::Reply as u8,
+            htype: request.htype(),
+            hlen: request.hlen(),
+            hops: 0,
+            xid: request.xid(),
+            secs: 0,
+            flags: request.flags(),
+            ciaddr: Ipv4Addr::UNSPECIFIED,
+            yiaddr: Ipv4Addr::UNSPECIFIED,
+            siaddr: Ipv4Addr::UNSPECIFIED,
+            giaddr: request.giaddr(),
+            chaddr,
+            options: Vec::new(),
+        }
+    }
+
+    /// Create a new empty builder
+    pub fn new() -> Self {
+        Self {
+            op: BootpOp::Reply as u8,
+            htype: 1, // Ethernet
+            hlen: 6,
+            hops: 0,
+            xid: 0,
+            secs: 0,
+            flags: 0,
+            ciaddr: Ipv4Addr::UNSPECIFIED,
+            yiaddr: Ipv4Addr::UNSPECIFIED,
+            siaddr: Ipv4Addr::UNSPECIFIED,
+            giaddr: Ipv4Addr::UNSPECIFIED,
+            chaddr: [0u8; 16],
+            options: Vec::new(),
+        }
+    }
+
+    /// Set DHCP message type
+    pub fn message_type(mut self, msg_type: DhcpMessageType) -> Self {
+        self.add_option(options::MESSAGE_TYPE, &[msg_type as u8]);
+        self
+    }
+
+    /// Set assigned IP address (yiaddr)
+    pub fn yiaddr(mut self, ip: Ipv4Addr) -> Self {
+        self.yiaddr = ip;
+        self
+    }
+
+    /// Set server IP address (siaddr)
+    pub fn siaddr(mut self, ip: Ipv4Addr) -> Self {
+        self.siaddr = ip;
+        self
+    }
+
+    /// Set server identifier (Option 54)
+    pub fn server_id(mut self, ip: Ipv4Addr) -> Self {
+        self.add_option(options::SERVER_ID, &ip.octets());
+        self
+    }
+
+    /// Set subnet mask (Option 1)
+    pub fn subnet_mask(mut self, mask: Ipv4Addr) -> Self {
+        self.add_option(options::SUBNET_MASK, &mask.octets());
+        self
+    }
+
+    /// Set router/gateway (Option 3)
+    pub fn router(mut self, routers: &[Ipv4Addr]) -> Self {
+        let mut data = Vec::new();
+        for r in routers {
+            data.extend_from_slice(&r.octets());
+        }
+        self.add_option(options::ROUTER, &data);
+        self
+    }
+
+    /// Set DNS servers (Option 6)
+    pub fn dns(mut self, servers: &[Ipv4Addr]) -> Self {
+        let mut data = Vec::new();
+        for s in servers {
+            data.extend_from_slice(&s.octets());
+        }
+        self.add_option(options::DNS_SERVER, &data);
+        self
+    }
+
+    /// Set broadcast address (Option 28)
+    pub fn broadcast_addr(mut self, addr: Ipv4Addr) -> Self {
+        self.add_option(options::BROADCAST_ADDR, &addr.octets());
+        self
+    }
+
+    /// Set lease time in seconds (Option 51)
+    pub fn lease_time(mut self, seconds: u32) -> Self {
+        self.add_option(options::LEASE_TIME, &seconds.to_be_bytes());
+        self
+    }
+
+    /// Set renewal time T1 in seconds (Option 58)
+    pub fn renewal_time(mut self, seconds: u32) -> Self {
+        self.add_option(options::RENEWAL_TIME, &seconds.to_be_bytes());
+        self
+    }
+
+    /// Set rebinding time T2 in seconds (Option 59)
+    pub fn rebinding_time(mut self, seconds: u32) -> Self {
+        self.add_option(options::REBINDING_TIME, &seconds.to_be_bytes());
+        self
+    }
+
+    /// Set domain name (Option 15)
+    pub fn domain_name(mut self, domain: &str) -> Self {
+        self.add_option(options::DOMAIN_NAME, domain.as_bytes());
+        self
+    }
+
+    /// Add raw option
+    fn add_option(&mut self, code: u8, data: &[u8]) {
+        self.options.push(code);
+        self.options.push(data.len() as u8);
+        self.options.extend_from_slice(data);
+    }
+
+    /// Build the DHCP packet
+    pub fn build(mut self) -> Vec<u8> {
+        // Add END option
+        self.options.push(options::END);
+
+        // Calculate total size (header + magic cookie + options)
+        // Pad to minimum 300 bytes for compatibility
+        let options_len = self.options.len();
+        let total_len = DHCP_HEADER_SIZE + 4 + options_len;
+        let padded_len = total_len.max(300);
+
+        let mut buffer = vec![0u8; padded_len];
+
+        // Fixed header
+        buffer[0] = self.op;
+        buffer[1] = self.htype;
+        buffer[2] = self.hlen;
+        buffer[3] = self.hops;
+        buffer[4..8].copy_from_slice(&self.xid.to_be_bytes());
+        buffer[8..10].copy_from_slice(&self.secs.to_be_bytes());
+        buffer[10..12].copy_from_slice(&self.flags.to_be_bytes());
+        buffer[12..16].copy_from_slice(&self.ciaddr.octets());
+        buffer[16..20].copy_from_slice(&self.yiaddr.octets());
+        buffer[20..24].copy_from_slice(&self.siaddr.octets());
+        buffer[24..28].copy_from_slice(&self.giaddr.octets());
+        buffer[28..44].copy_from_slice(&self.chaddr);
+        // sname and file are left as zeros
+
+        // Magic cookie
+        buffer[236..240].copy_from_slice(&MAGIC_COOKIE);
+
+        // Options
+        buffer[240..240 + options_len].copy_from_slice(&self.options);
+
+        buffer
+    }
+}
+
+impl Default for DhcpBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_discover_packet() -> Vec<u8> {
+        let mut packet = vec![0u8; 300];
+
+        // BOOTP header
+        packet[0] = 1; // op = BOOTREQUEST
+        packet[1] = 1; // htype = Ethernet
+        packet[2] = 6; // hlen = 6
+        packet[3] = 0; // hops
+
+        // xid = 0x12345678
+        packet[4..8].copy_from_slice(&0x12345678u32.to_be_bytes());
+
+        // flags = 0x8000 (broadcast)
+        packet[10..12].copy_from_slice(&0x8000u16.to_be_bytes());
+
+        // chaddr = 00:11:22:33:44:55
+        packet[28] = 0x00;
+        packet[29] = 0x11;
+        packet[30] = 0x22;
+        packet[31] = 0x33;
+        packet[32] = 0x44;
+        packet[33] = 0x55;
+
+        // Magic cookie
+        packet[236..240].copy_from_slice(&MAGIC_COOKIE);
+
+        // Options
+        // Message Type = DISCOVER (53, 1, 1)
+        packet[240] = 53;
+        packet[241] = 1;
+        packet[242] = 1;
+
+        // Parameter Request List (55, 4, 1, 3, 6, 15)
+        packet[243] = 55;
+        packet[244] = 4;
+        packet[245] = 1; // subnet mask
+        packet[246] = 3; // router
+        packet[247] = 6; // dns
+        packet[248] = 15; // domain name
+
+        // End
+        packet[249] = 255;
+
+        packet
+    }
+
+    fn make_request_packet(requested_ip: Ipv4Addr, server_id: Ipv4Addr) -> Vec<u8> {
+        let mut packet = vec![0u8; 300];
+
+        packet[0] = 1; // op = BOOTREQUEST
+        packet[1] = 1; // htype = Ethernet
+        packet[2] = 6; // hlen = 6
+
+        // xid = 0xABCDEF00
+        packet[4..8].copy_from_slice(&0xABCDEF00u32.to_be_bytes());
+
+        // chaddr
+        packet[28..34].copy_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]);
+
+        // Magic cookie
+        packet[236..240].copy_from_slice(&MAGIC_COOKIE);
+
+        // Options
+        let mut pos = 240;
+
+        // Message Type = REQUEST (53, 1, 3)
+        packet[pos] = 53;
+        packet[pos + 1] = 1;
+        packet[pos + 2] = 3;
+        pos += 3;
+
+        // Requested IP (50, 4, ip)
+        packet[pos] = 50;
+        packet[pos + 1] = 4;
+        packet[pos + 2..pos + 6].copy_from_slice(&requested_ip.octets());
+        pos += 6;
+
+        // Server ID (54, 4, ip)
+        packet[pos] = 54;
+        packet[pos + 1] = 4;
+        packet[pos + 2..pos + 6].copy_from_slice(&server_id.octets());
+        pos += 6;
+
+        // End
+        packet[pos] = 255;
+
+        packet
+    }
+
+    #[test]
+    fn test_parse_discover() {
+        let packet = make_discover_packet();
+        let header = DhcpHeader::parse(&packet).unwrap();
+
+        assert_eq!(header.op(), 1);
+        assert_eq!(header.htype(), 1);
+        assert_eq!(header.hlen(), 6);
+        assert_eq!(header.xid(), 0x12345678);
+        assert!(header.is_broadcast());
+        assert_eq!(header.client_mac(), [0x00, 0x11, 0x22, 0x33, 0x44, 0x55]);
+        assert_eq!(header.message_type(), Some(DhcpMessageType::Discover));
+    }
+
+    #[test]
+    fn test_parse_request() {
+        let requested = Ipv4Addr::new(192, 168, 1, 100);
+        let server = Ipv4Addr::new(192, 168, 1, 1);
+        let packet = make_request_packet(requested, server);
+        let header = DhcpHeader::parse(&packet).unwrap();
+
+        assert_eq!(header.message_type(), Some(DhcpMessageType::Request));
+        assert_eq!(header.requested_ip(), Some(requested));
+        assert_eq!(header.server_id(), Some(server));
+        assert_eq!(header.client_mac(), [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]);
+    }
+
+    #[test]
+    fn test_parse_too_short() {
+        let packet = vec![0u8; 100];
+        assert!(DhcpHeader::parse(&packet).is_err());
+    }
+
+    #[test]
+    fn test_parse_invalid_magic() {
+        let mut packet = vec![0u8; 300];
+        packet[236..240].copy_from_slice(&[0, 0, 0, 0]); // Invalid magic
+        assert!(DhcpHeader::parse(&packet).is_err());
+    }
+
+    #[test]
+    fn test_option_iterator() {
+        let packet = make_discover_packet();
+        let header = DhcpHeader::parse(&packet).unwrap();
+
+        let options: Vec<_> = header.iter_options().collect();
+        assert_eq!(options.len(), 2); // MESSAGE_TYPE and PARAMETER_REQUEST
+
+        assert_eq!(options[0].code, 53);
+        assert_eq!(options[0].data, &[1]);
+
+        assert_eq!(options[1].code, 55);
+        assert_eq!(options[1].data, &[1, 3, 6, 15]);
+    }
+
+    #[test]
+    fn test_build_offer() {
+        let discover = make_discover_packet();
+        let request = DhcpHeader::parse(&discover).unwrap();
+
+        let server_ip = Ipv4Addr::new(192, 168, 1, 1);
+        let offer_ip = Ipv4Addr::new(192, 168, 1, 100);
+        let subnet = Ipv4Addr::new(255, 255, 255, 0);
+        let dns = vec![Ipv4Addr::new(8, 8, 8, 8)];
+
+        let offer = DhcpBuilder::reply(&request)
+            .message_type(DhcpMessageType::Offer)
+            .yiaddr(offer_ip)
+            .siaddr(server_ip)
+            .server_id(server_ip)
+            .subnet_mask(subnet)
+            .router(&[server_ip])
+            .dns(&dns)
+            .lease_time(86400)
+            .build();
+
+        // Parse and verify
+        let header = DhcpHeader::parse(&offer).unwrap();
+        assert_eq!(header.op(), 2); // BOOTREPLY
+        assert_eq!(header.xid(), 0x12345678);
+        assert_eq!(header.yiaddr(), offer_ip);
+        assert_eq!(header.siaddr(), server_ip);
+        assert_eq!(header.message_type(), Some(DhcpMessageType::Offer));
+        assert_eq!(header.server_id(), Some(server_ip));
+        assert!(header.is_broadcast()); // Preserved from request
+    }
+
+    #[test]
+    fn test_build_ack() {
+        let request_ip = Ipv4Addr::new(192, 168, 1, 100);
+        let server_ip = Ipv4Addr::new(192, 168, 1, 1);
+        let request = make_request_packet(request_ip, server_ip);
+        let req_header = DhcpHeader::parse(&request).unwrap();
+
+        let ack = DhcpBuilder::reply(&req_header)
+            .message_type(DhcpMessageType::Ack)
+            .yiaddr(request_ip)
+            .siaddr(server_ip)
+            .server_id(server_ip)
+            .subnet_mask(Ipv4Addr::new(255, 255, 255, 0))
+            .router(&[server_ip])
+            .lease_time(86400)
+            .renewal_time(43200)
+            .rebinding_time(75600)
+            .build();
+
+        let header = DhcpHeader::parse(&ack).unwrap();
+        assert_eq!(header.op(), 2);
+        assert_eq!(header.message_type(), Some(DhcpMessageType::Ack));
+        assert_eq!(header.yiaddr(), request_ip);
+    }
+
+    #[test]
+    fn test_build_nak() {
+        let request_ip = Ipv4Addr::new(192, 168, 1, 100);
+        let server_ip = Ipv4Addr::new(192, 168, 1, 1);
+        let request = make_request_packet(request_ip, server_ip);
+        let req_header = DhcpHeader::parse(&request).unwrap();
+
+        let nak = DhcpBuilder::reply(&req_header)
+            .message_type(DhcpMessageType::Nak)
+            .server_id(server_ip)
+            .build();
+
+        let header = DhcpHeader::parse(&nak).unwrap();
+        assert_eq!(header.message_type(), Some(DhcpMessageType::Nak));
+        assert_eq!(header.yiaddr(), Ipv4Addr::UNSPECIFIED);
+    }
+
+    #[test]
+    fn test_parameter_request_list() {
+        let packet = make_discover_packet();
+        let header = DhcpHeader::parse(&packet).unwrap();
+
+        let params = header.parameter_request_list().unwrap();
+        assert_eq!(params, &[1, 3, 6, 15]);
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let original = make_discover_packet();
+        let header = DhcpHeader::parse(&original).unwrap();
+
+        // Build a reply
+        let reply = DhcpBuilder::reply(&header)
+            .message_type(DhcpMessageType::Offer)
+            .yiaddr(Ipv4Addr::new(10, 0, 0, 100))
+            .build();
+
+        // Parse the reply
+        let reply_header = DhcpHeader::parse(&reply).unwrap();
+
+        // Verify xid and chaddr are preserved
+        assert_eq!(reply_header.xid(), header.xid());
+        assert_eq!(reply_header.chaddr(), header.chaddr());
+    }
+}

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -3,6 +3,7 @@
 //! All L2+ protocols are implemented from scratch for learning purposes.
 
 pub mod arp;
+pub mod dhcp;
 pub mod ethernet;
 pub mod icmp;
 pub mod icmpv6;


### PR DESCRIPTION
## Summary
- DHCPv4サーバー機能を実装
- DHCP DISCOVER/OFFER/REQUEST/ACK/NAK/RELEASE フローをサポート
- IPアドレスプール管理とリース追跡を実装

## Changes
- `src/protocol/dhcp.rs`: DHCPプロトコルパーサー・ビルダー (RFC 2131/2132)
- `src/dataplane/dhcp_server.rs`: DHCPサーバーロジック（プール管理、リース管理）
- `src/dataplane/router.rs`: UDP処理とDHCPサーバー統合
- `src/protocol/udp.rs`: UdpBuilder追加

## Test plan
- [x] `cargo test` - 346テスト全て成功
- [x] `cargo clippy` - 警告なし
- [x] `cargo fmt` - フォーマット適用済み

Closes #19