### PR TITLE
feat(dns): Add DNS forwarder with caching support

### DIFF
--- a/src/dataplane/dns_forwarder.rs
+++ b/src/dataplane/dns_forwarder.rs
@@ -1,0 +1,671 @@
+//! DNS Forwarder
+//!
+//! DNS forwarder implementation with caching support.
+//! Forwards DNS queries to upstream servers and caches responses.
+
+use crate::protocol::dns::{DnsHeader, DnsPacket, DnsRcode};
+use std::collections::HashMap;
+use std::net::Ipv4Addr;
+use std::time::{Duration, Instant};
+use tracing::{debug, trace, warn};
+
+/// DNS forwarder processing result
+#[derive(Debug)]
+pub enum DnsAction {
+    /// Send a DNS reply to client
+    Reply {
+        /// Interface to send on
+        interface: String,
+        /// DNS payload (to be wrapped in UDP/IP/Ethernet)
+        packet: Vec<u8>,
+        /// Destination IP
+        dst_ip: Ipv4Addr,
+        /// Destination port
+        dst_port: u16,
+    },
+    /// Forward query to upstream server
+    Forward {
+        /// Upstream server IP
+        upstream: Ipv4Addr,
+        /// DNS packet with new transaction ID
+        packet: Vec<u8>,
+        /// Original transaction ID for response matching
+        original_id: u16,
+    },
+    /// No action needed
+    None,
+}
+
+/// Pending query entry awaiting upstream response
+#[derive(Debug, Clone)]
+pub struct PendingQuery {
+    /// Original transaction ID from client
+    pub original_id: u16,
+    /// Client IP address
+    pub client_ip: Ipv4Addr,
+    /// Client port
+    pub client_port: u16,
+    /// Interface the query arrived on
+    pub interface: String,
+    /// When the query was forwarded
+    pub forwarded_at: Instant,
+}
+
+/// Cache entry with TTL
+#[derive(Debug, Clone)]
+pub struct CacheEntry {
+    /// Full DNS response packet (ID will be replaced on cache hit)
+    pub response: Vec<u8>,
+    /// When this entry expires
+    pub expires_at: Instant,
+    /// When this entry was inserted
+    pub inserted_at: Instant,
+}
+
+impl CacheEntry {
+    fn is_expired(&self) -> bool {
+        Instant::now() >= self.expires_at
+    }
+}
+
+/// DNS forwarder configuration
+#[derive(Debug, Clone)]
+pub struct DnsForwarderConfig {
+    /// Upstream DNS servers
+    pub upstream_servers: Vec<Ipv4Addr>,
+    /// Maximum cache entries
+    pub cache_size: usize,
+    /// Query timeout in seconds
+    pub query_timeout_secs: u64,
+    /// Negative response cache TTL (for NXDOMAIN)
+    pub negative_cache_ttl: u32,
+}
+
+impl Default for DnsForwarderConfig {
+    fn default() -> Self {
+        Self {
+            upstream_servers: vec![Ipv4Addr::new(8, 8, 8, 8), Ipv4Addr::new(1, 1, 1, 1)],
+            cache_size: 1000,
+            query_timeout_secs: 5,
+            negative_cache_ttl: 60,
+        }
+    }
+}
+
+/// DNS forwarder service
+#[derive(Debug)]
+pub struct DnsForwarder {
+    config: DnsForwarderConfig,
+    /// Cache: (qname_lowercase, qtype) -> CacheEntry
+    cache: HashMap<(String, u16), CacheEntry>,
+    /// Pending queries: forwarded_id -> PendingQuery
+    pending: HashMap<u16, PendingQuery>,
+    /// Next ID for upstream queries
+    next_id: u16,
+    /// Round-robin index for upstream selection
+    upstream_index: usize,
+    /// Cache hit counter
+    cache_hits: u64,
+    /// Cache miss counter
+    cache_misses: u64,
+}
+
+impl DnsForwarder {
+    /// Create a new DNS forwarder
+    pub fn new(config: DnsForwarderConfig) -> Self {
+        debug!(
+            "DNS forwarder created with {} upstream servers, cache_size={}",
+            config.upstream_servers.len(),
+            config.cache_size
+        );
+
+        Self {
+            config,
+            cache: HashMap::new(),
+            pending: HashMap::new(),
+            next_id: 1,
+            upstream_index: 0,
+            cache_hits: 0,
+            cache_misses: 0,
+        }
+    }
+
+    /// Process incoming DNS query from client
+    pub fn process_query(
+        &mut self,
+        interface: &str,
+        client_ip: Ipv4Addr,
+        client_port: u16,
+        dns_payload: &[u8],
+    ) -> DnsAction {
+        // Parse DNS header
+        let header = match DnsHeader::parse(dns_payload) {
+            Ok(h) => h,
+            Err(e) => {
+                trace!("Failed to parse DNS query: {}", e);
+                return DnsAction::None;
+            }
+        };
+
+        // Only handle queries
+        if header.is_response() {
+            trace!("Ignoring DNS response packet");
+            return DnsAction::None;
+        }
+
+        let original_id = header.id();
+
+        // Parse question to get cache key
+        let packet = match DnsPacket::from_bytes(dns_payload) {
+            Ok(p) => p,
+            Err(e) => {
+                trace!("Failed to parse DNS packet: {}", e);
+                return DnsAction::None;
+            }
+        };
+
+        let questions = match packet.questions() {
+            Ok(q) => q,
+            Err(e) => {
+                trace!("Failed to parse DNS questions: {}", e);
+                return DnsAction::None;
+            }
+        };
+
+        if questions.is_empty() {
+            trace!("DNS query with no questions");
+            return DnsAction::None;
+        }
+
+        let question = &questions[0];
+        let cache_key = (question.name.to_lowercase(), question.qtype);
+
+        debug!(
+            "DNS query from {}:{} for {} (type {})",
+            client_ip, client_port, question.name, question.qtype
+        );
+
+        // Check cache
+        if let Some(entry) = self.cache.get(&cache_key) {
+            if !entry.is_expired() {
+                self.cache_hits += 1;
+                debug!("Cache hit for {}", question.name);
+
+                // Clone response and replace transaction ID
+                let mut response = entry.response.clone();
+                if response.len() >= 2 {
+                    response[0..2].copy_from_slice(&original_id.to_be_bytes());
+                }
+
+                return DnsAction::Reply {
+                    interface: interface.to_string(),
+                    packet: response,
+                    dst_ip: client_ip,
+                    dst_port: client_port,
+                };
+            } else {
+                // Remove expired entry
+                self.cache.remove(&cache_key);
+            }
+        }
+
+        self.cache_misses += 1;
+
+        // Get upstream server (round-robin)
+        let upstream = match self.next_upstream() {
+            Some(ip) => ip,
+            None => {
+                warn!("No upstream DNS servers configured");
+                return DnsAction::None;
+            }
+        };
+
+        // Generate new transaction ID for upstream
+        let forwarded_id = self.generate_id();
+
+        // Create forwarded packet with new ID
+        let mut forwarded_packet = dns_payload.to_vec();
+        if forwarded_packet.len() >= 2 {
+            forwarded_packet[0..2].copy_from_slice(&forwarded_id.to_be_bytes());
+        }
+
+        // Store pending query
+        self.pending.insert(
+            forwarded_id,
+            PendingQuery {
+                original_id,
+                client_ip,
+                client_port,
+                interface: interface.to_string(),
+                forwarded_at: Instant::now(),
+            },
+        );
+
+        debug!(
+            "Forwarding query for {} to {} (id {} -> {})",
+            question.name, upstream, original_id, forwarded_id
+        );
+
+        DnsAction::Forward {
+            upstream,
+            packet: forwarded_packet,
+            original_id,
+        }
+    }
+
+    /// Process response from upstream DNS server
+    pub fn process_response(&mut self, upstream_ip: Ipv4Addr, dns_payload: &[u8]) -> DnsAction {
+        // Parse DNS header
+        let header = match DnsHeader::parse(dns_payload) {
+            Ok(h) => h,
+            Err(e) => {
+                trace!("Failed to parse DNS response: {}", e);
+                return DnsAction::None;
+            }
+        };
+
+        // Only handle responses
+        if header.is_query() {
+            trace!("Ignoring DNS query packet from upstream");
+            return DnsAction::None;
+        }
+
+        let response_id = header.id();
+
+        // Look up pending query
+        let pending = match self.pending.remove(&response_id) {
+            Some(p) => p,
+            None => {
+                trace!("No pending query for response id {}", response_id);
+                return DnsAction::None;
+            }
+        };
+
+        debug!(
+            "Received response from {} for query {} (client {}:{})",
+            upstream_ip, response_id, pending.client_ip, pending.client_port
+        );
+
+        // Cache the response
+        self.cache_response(dns_payload);
+
+        // Replace transaction ID with original
+        let mut response = dns_payload.to_vec();
+        if response.len() >= 2 {
+            response[0..2].copy_from_slice(&pending.original_id.to_be_bytes());
+        }
+
+        DnsAction::Reply {
+            interface: pending.interface,
+            packet: response,
+            dst_ip: pending.client_ip,
+            dst_port: pending.client_port,
+        }
+    }
+
+    /// Cache a DNS response
+    fn cache_response(&mut self, dns_payload: &[u8]) {
+        if self.config.cache_size == 0 {
+            return;
+        }
+
+        let packet = match DnsPacket::from_bytes(dns_payload) {
+            Ok(p) => p,
+            Err(_) => return,
+        };
+
+        // Get question for cache key
+        let questions = match packet.questions() {
+            Ok(q) => q,
+            Err(_) => return,
+        };
+
+        if questions.is_empty() {
+            return;
+        }
+
+        let question = &questions[0];
+        let cache_key = (question.name.to_lowercase(), question.qtype);
+
+        // Determine TTL
+        let ttl = if packet.rcode() == DnsRcode::NameError as u8 {
+            // NXDOMAIN - use negative cache TTL
+            self.config.negative_cache_ttl
+        } else {
+            // Use minimum TTL from answers, or default
+            packet.min_ttl().unwrap_or(300)
+        };
+
+        // Evict if cache is full
+        if self.cache.len() >= self.config.cache_size {
+            self.evict_oldest();
+        }
+
+        let now = Instant::now();
+        self.cache.insert(
+            cache_key,
+            CacheEntry {
+                response: dns_payload.to_vec(),
+                expires_at: now + Duration::from_secs(ttl as u64),
+                inserted_at: now,
+            },
+        );
+
+        trace!("Cached DNS response for {} with TTL {}", question.name, ttl);
+    }
+
+    /// Evict the oldest cache entry
+    fn evict_oldest(&mut self) {
+        if let Some(oldest_key) = self
+            .cache
+            .iter()
+            .min_by_key(|(_, entry)| entry.inserted_at)
+            .map(|(key, _)| key.clone())
+        {
+            self.cache.remove(&oldest_key);
+        }
+    }
+
+    /// Get next upstream server (round-robin)
+    fn next_upstream(&mut self) -> Option<Ipv4Addr> {
+        if self.config.upstream_servers.is_empty() {
+            return None;
+        }
+
+        let server = self.config.upstream_servers[self.upstream_index];
+        self.upstream_index = (self.upstream_index + 1) % self.config.upstream_servers.len();
+        Some(server)
+    }
+
+    /// Generate a unique transaction ID
+    fn generate_id(&mut self) -> u16 {
+        let id = self.next_id;
+        self.next_id = self.next_id.wrapping_add(1);
+        if self.next_id == 0 {
+            self.next_id = 1; // Skip 0
+        }
+        id
+    }
+
+    /// Check if a given IP is one of our upstream servers
+    pub fn is_upstream(&self, ip: &Ipv4Addr) -> bool {
+        self.config.upstream_servers.contains(ip)
+    }
+
+    /// Run maintenance tasks (expire old entries, timeout queries)
+    pub fn run_maintenance(&mut self) {
+        let now = Instant::now();
+        let timeout = Duration::from_secs(self.config.query_timeout_secs);
+
+        // Expire old cache entries
+        self.cache.retain(|_, entry| !entry.is_expired());
+
+        // Timeout pending queries
+        let timed_out: Vec<u16> = self
+            .pending
+            .iter()
+            .filter(|(_, query)| now.duration_since(query.forwarded_at) > timeout)
+            .map(|(id, _)| *id)
+            .collect();
+
+        for id in timed_out {
+            if let Some(query) = self.pending.remove(&id) {
+                debug!(
+                    "DNS query timeout for client {}:{} (id {})",
+                    query.client_ip, query.client_port, id
+                );
+            }
+        }
+    }
+
+    /// Get cache statistics
+    pub fn cache_stats(&self) -> (usize, u64, u64) {
+        (self.cache.len(), self.cache_hits, self.cache_misses)
+    }
+
+    /// Get number of pending queries
+    pub fn pending_count(&self) -> usize {
+        self.pending.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_query_packet(id: u16, name: &str) -> Vec<u8> {
+        use crate::protocol::dns::{encode_domain_name, DnsClass, DnsType};
+
+        let mut buffer = Vec::new();
+
+        // Header
+        buffer.extend_from_slice(&id.to_be_bytes());
+        buffer.extend_from_slice(&0x0100u16.to_be_bytes()); // Flags: RD=1
+        buffer.extend_from_slice(&1u16.to_be_bytes()); // QDCOUNT
+        buffer.extend_from_slice(&0u16.to_be_bytes()); // ANCOUNT
+        buffer.extend_from_slice(&0u16.to_be_bytes()); // NSCOUNT
+        buffer.extend_from_slice(&0u16.to_be_bytes()); // ARCOUNT
+
+        // Question
+        buffer.extend(encode_domain_name(name));
+        buffer.extend_from_slice(&(DnsType::A as u16).to_be_bytes());
+        buffer.extend_from_slice(&(DnsClass::IN as u16).to_be_bytes());
+
+        buffer
+    }
+
+    fn make_response_packet(id: u16, name: &str, ttl: u32) -> Vec<u8> {
+        use crate::protocol::dns::{encode_domain_name, DnsClass, DnsType};
+
+        let mut buffer = Vec::new();
+
+        // Header
+        buffer.extend_from_slice(&id.to_be_bytes());
+        buffer.extend_from_slice(&0x8180u16.to_be_bytes()); // Flags: QR=1, RD=1, RA=1
+        buffer.extend_from_slice(&1u16.to_be_bytes()); // QDCOUNT
+        buffer.extend_from_slice(&1u16.to_be_bytes()); // ANCOUNT
+        buffer.extend_from_slice(&0u16.to_be_bytes()); // NSCOUNT
+        buffer.extend_from_slice(&0u16.to_be_bytes()); // ARCOUNT
+
+        // Question
+        buffer.extend(encode_domain_name(name));
+        buffer.extend_from_slice(&(DnsType::A as u16).to_be_bytes());
+        buffer.extend_from_slice(&(DnsClass::IN as u16).to_be_bytes());
+
+        // Answer (using name directly, no compression for simplicity)
+        buffer.extend(encode_domain_name(name));
+        buffer.extend_from_slice(&(DnsType::A as u16).to_be_bytes());
+        buffer.extend_from_slice(&(DnsClass::IN as u16).to_be_bytes());
+        buffer.extend_from_slice(&ttl.to_be_bytes());
+        buffer.extend_from_slice(&4u16.to_be_bytes()); // RDLENGTH
+        buffer.extend_from_slice(&[93, 184, 216, 34]); // RDATA: 93.184.216.34
+
+        buffer
+    }
+
+    #[test]
+    fn test_forwarder_new() {
+        let config = DnsForwarderConfig::default();
+        let forwarder = DnsForwarder::new(config);
+
+        assert_eq!(forwarder.cache.len(), 0);
+        assert_eq!(forwarder.pending.len(), 0);
+    }
+
+    #[test]
+    fn test_process_query_cache_miss() {
+        let config = DnsForwarderConfig::default();
+        let mut forwarder = DnsForwarder::new(config);
+
+        let query = make_query_packet(0x1234, "example.com");
+        let action =
+            forwarder.process_query("eth0", Ipv4Addr::new(192, 168, 1, 100), 12345, &query);
+
+        match action {
+            DnsAction::Forward {
+                upstream,
+                packet,
+                original_id,
+            } => {
+                assert!(
+                    upstream == Ipv4Addr::new(8, 8, 8, 8) || upstream == Ipv4Addr::new(1, 1, 1, 1)
+                );
+                assert_eq!(original_id, 0x1234);
+                // Packet should have different ID
+                let new_id = u16::from_be_bytes([packet[0], packet[1]]);
+                assert_ne!(new_id, 0x1234);
+            }
+            _ => panic!("Expected Forward action"),
+        }
+
+        assert_eq!(forwarder.pending.len(), 1);
+    }
+
+    #[test]
+    fn test_process_response_pending() {
+        let config = DnsForwarderConfig::default();
+        let mut forwarder = DnsForwarder::new(config);
+
+        // First, process a query
+        let query = make_query_packet(0x1234, "example.com");
+        let forward_action =
+            forwarder.process_query("eth0", Ipv4Addr::new(192, 168, 1, 100), 12345, &query);
+
+        let forwarded_id = match forward_action {
+            DnsAction::Forward { packet, .. } => u16::from_be_bytes([packet[0], packet[1]]),
+            _ => panic!("Expected Forward action"),
+        };
+
+        // Now process a response with the forwarded ID
+        let response = make_response_packet(forwarded_id, "example.com", 300);
+        let reply_action = forwarder.process_response(Ipv4Addr::new(8, 8, 8, 8), &response);
+
+        match reply_action {
+            DnsAction::Reply {
+                interface,
+                packet,
+                dst_ip,
+                dst_port,
+            } => {
+                assert_eq!(interface, "eth0");
+                assert_eq!(dst_ip, Ipv4Addr::new(192, 168, 1, 100));
+                assert_eq!(dst_port, 12345);
+                // ID should be restored to original
+                let id = u16::from_be_bytes([packet[0], packet[1]]);
+                assert_eq!(id, 0x1234);
+            }
+            _ => panic!("Expected Reply action"),
+        }
+
+        assert_eq!(forwarder.pending.len(), 0);
+    }
+
+    #[test]
+    fn test_cache_hit() {
+        let config = DnsForwarderConfig::default();
+        let mut forwarder = DnsForwarder::new(config);
+
+        // Process query -> forward
+        let query = make_query_packet(0x1234, "example.com");
+        let forward_action =
+            forwarder.process_query("eth0", Ipv4Addr::new(192, 168, 1, 100), 12345, &query);
+
+        let forwarded_id = match forward_action {
+            DnsAction::Forward { packet, .. } => u16::from_be_bytes([packet[0], packet[1]]),
+            _ => panic!("Expected Forward action"),
+        };
+
+        // Process response -> caches
+        let response = make_response_packet(forwarded_id, "example.com", 300);
+        forwarder.process_response(Ipv4Addr::new(8, 8, 8, 8), &response);
+
+        assert_eq!(forwarder.cache.len(), 1);
+
+        // Second query should hit cache
+        let query2 = make_query_packet(0x5678, "example.com");
+        let cache_action =
+            forwarder.process_query("eth0", Ipv4Addr::new(192, 168, 1, 101), 54321, &query2);
+
+        match cache_action {
+            DnsAction::Reply {
+                packet,
+                dst_ip,
+                dst_port,
+                ..
+            } => {
+                assert_eq!(dst_ip, Ipv4Addr::new(192, 168, 1, 101));
+                assert_eq!(dst_port, 54321);
+                // ID should be the new query's ID
+                let id = u16::from_be_bytes([packet[0], packet[1]]);
+                assert_eq!(id, 0x5678);
+            }
+            _ => panic!("Expected Reply action from cache"),
+        }
+
+        let (_, hits, misses) = forwarder.cache_stats();
+        assert_eq!(hits, 1);
+        assert_eq!(misses, 1);
+    }
+
+    #[test]
+    fn test_process_response_unknown_id() {
+        let config = DnsForwarderConfig::default();
+        let mut forwarder = DnsForwarder::new(config);
+
+        // Process response with unknown ID
+        let response = make_response_packet(0x9999, "example.com", 300);
+        let action = forwarder.process_response(Ipv4Addr::new(8, 8, 8, 8), &response);
+
+        match action {
+            DnsAction::None => {}
+            _ => panic!("Expected None action for unknown ID"),
+        }
+    }
+
+    #[test]
+    fn test_upstream_round_robin() {
+        let config = DnsForwarderConfig {
+            upstream_servers: vec![Ipv4Addr::new(8, 8, 8, 8), Ipv4Addr::new(1, 1, 1, 1)],
+            ..Default::default()
+        };
+        let mut forwarder = DnsForwarder::new(config);
+
+        let first = forwarder.next_upstream();
+        let second = forwarder.next_upstream();
+        let third = forwarder.next_upstream();
+
+        assert_eq!(first, Some(Ipv4Addr::new(8, 8, 8, 8)));
+        assert_eq!(second, Some(Ipv4Addr::new(1, 1, 1, 1)));
+        assert_eq!(third, Some(Ipv4Addr::new(8, 8, 8, 8)));
+    }
+
+    #[test]
+    fn test_is_upstream() {
+        let config = DnsForwarderConfig::default();
+        let forwarder = DnsForwarder::new(config);
+
+        assert!(forwarder.is_upstream(&Ipv4Addr::new(8, 8, 8, 8)));
+        assert!(forwarder.is_upstream(&Ipv4Addr::new(1, 1, 1, 1)));
+        assert!(!forwarder.is_upstream(&Ipv4Addr::new(192, 168, 1, 1)));
+    }
+
+    #[test]
+    fn test_maintenance_timeout() {
+        let config = DnsForwarderConfig {
+            query_timeout_secs: 0, // Immediate timeout
+            ..Default::default()
+        };
+        let mut forwarder = DnsForwarder::new(config);
+
+        // Add a query
+        let query = make_query_packet(0x1234, "example.com");
+        forwarder.process_query("eth0", Ipv4Addr::new(192, 168, 1, 100), 12345, &query);
+
+        assert_eq!(forwarder.pending.len(), 1);
+
+        // Run maintenance - should timeout the query
+        forwarder.run_maintenance();
+
+        assert_eq!(forwarder.pending.len(), 0);
+    }
+}

--- a/src/dataplane/mod.rs
+++ b/src/dataplane/mod.rs
@@ -8,6 +8,7 @@ mod conntrack;
 mod dhcp6_client;
 mod dhcp_client;
 mod dhcp_server;
+mod dns_forwarder;
 mod fdb;
 mod filter;
 mod firewall;
@@ -26,6 +27,7 @@ pub use dhcp6_client::{
 };
 pub use dhcp_client::{DhcpClient, DhcpClientAction, DhcpClientState, DhcpLease};
 pub use dhcp_server::{DhcpAction, DhcpPool, DhcpPoolConfig, DhcpServer, LeaseEntry, LeaseState};
+pub use dns_forwarder::{DnsAction, DnsForwarder, DnsForwarderConfig, PendingQuery};
 pub use fdb::Fdb;
 pub use filter::{
     icmpv6_type, protocol, Action, Chain, FilterContext, FilterRule, IpAddr as FilterIpAddr,

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,6 +237,27 @@ fn cmd_run(lock_path: &PathBuf) -> Result<(), String> {
             }
         }
 
+        // Enable DNS forwarder if configured
+        if let Some(ref dns_lock) = lock.dns_forwarder {
+            if dns_lock.enabled {
+                use ruster::dataplane::DnsForwarderConfig;
+
+                let config = DnsForwarderConfig {
+                    upstream_servers: dns_lock.upstream.clone(),
+                    cache_size: dns_lock.cache_size,
+                    query_timeout_secs: dns_lock.query_timeout,
+                    negative_cache_ttl: 60,
+                };
+
+                router.enable_dns_forwarder(config);
+                info!(
+                    "DNS forwarder enabled with {} upstream servers, cache_size={}",
+                    dns_lock.upstream.len(),
+                    dns_lock.cache_size
+                );
+            }
+        }
+
         info!("Router started, processing packets...");
 
         // Create aging timer

--- a/src/protocol/dns.rs
+++ b/src/protocol/dns.rs
@@ -1,0 +1,781 @@
+//! DNS protocol - RFC 1035
+//!
+//! DNS message parsing and building for DNS forwarder functionality.
+
+use crate::{Error, Result};
+
+/// DNS server/client port
+pub const DNS_PORT: u16 = 53;
+
+/// DNS header size (fixed at 12 bytes)
+pub const DNS_HEADER_SIZE: usize = 12;
+
+/// Maximum UDP DNS message size (RFC 1035)
+pub const MAX_UDP_SIZE: usize = 512;
+
+/// DNS operation codes
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum DnsOpcode {
+    Query = 0,
+    IQuery = 1,
+    Status = 2,
+}
+
+impl DnsOpcode {
+    pub fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            0 => Some(DnsOpcode::Query),
+            1 => Some(DnsOpcode::IQuery),
+            2 => Some(DnsOpcode::Status),
+            _ => None,
+        }
+    }
+}
+
+/// DNS response codes (RCODE)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum DnsRcode {
+    NoError = 0,
+    FormatError = 1,
+    ServerFailure = 2,
+    NameError = 3,
+    NotImplemented = 4,
+    Refused = 5,
+}
+
+impl DnsRcode {
+    pub fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            0 => Some(DnsRcode::NoError),
+            1 => Some(DnsRcode::FormatError),
+            2 => Some(DnsRcode::ServerFailure),
+            3 => Some(DnsRcode::NameError),
+            4 => Some(DnsRcode::NotImplemented),
+            5 => Some(DnsRcode::Refused),
+            _ => None,
+        }
+    }
+}
+
+/// DNS record types
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u16)]
+pub enum DnsType {
+    A = 1,
+    NS = 2,
+    CNAME = 5,
+    SOA = 6,
+    PTR = 12,
+    MX = 15,
+    TXT = 16,
+    AAAA = 28,
+    SRV = 33,
+    ANY = 255,
+}
+
+impl DnsType {
+    pub fn from_u16(value: u16) -> Option<Self> {
+        match value {
+            1 => Some(DnsType::A),
+            2 => Some(DnsType::NS),
+            5 => Some(DnsType::CNAME),
+            6 => Some(DnsType::SOA),
+            12 => Some(DnsType::PTR),
+            15 => Some(DnsType::MX),
+            16 => Some(DnsType::TXT),
+            28 => Some(DnsType::AAAA),
+            33 => Some(DnsType::SRV),
+            255 => Some(DnsType::ANY),
+            _ => None,
+        }
+    }
+}
+
+/// DNS record class
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u16)]
+pub enum DnsClass {
+    IN = 1,
+    CH = 3,
+    HS = 4,
+    ANY = 255,
+}
+
+impl DnsClass {
+    pub fn from_u16(value: u16) -> Option<Self> {
+        match value {
+            1 => Some(DnsClass::IN),
+            3 => Some(DnsClass::CH),
+            4 => Some(DnsClass::HS),
+            255 => Some(DnsClass::ANY),
+            _ => None,
+        }
+    }
+}
+
+/// Parsed DNS question
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DnsQuestion {
+    pub name: String,
+    pub qtype: u16,
+    pub qclass: u16,
+}
+
+/// Parsed DNS resource record
+#[derive(Debug, Clone)]
+pub struct DnsRecord {
+    pub name: String,
+    pub rtype: u16,
+    pub rclass: u16,
+    pub ttl: u32,
+    pub rdata: Vec<u8>,
+}
+
+/// Zero-copy DNS header parser
+#[derive(Debug)]
+pub struct DnsHeader<'a> {
+    buffer: &'a [u8],
+}
+
+impl<'a> DnsHeader<'a> {
+    /// Parse DNS header from buffer
+    pub fn parse(buffer: &'a [u8]) -> Result<Self> {
+        if buffer.len() < DNS_HEADER_SIZE {
+            return Err(Error::Parse("DNS header too short".into()));
+        }
+        Ok(Self { buffer })
+    }
+
+    /// Transaction ID (offset 0-1)
+    pub fn id(&self) -> u16 {
+        u16::from_be_bytes([self.buffer[0], self.buffer[1]])
+    }
+
+    /// Flags (offset 2-3)
+    fn flags(&self) -> u16 {
+        u16::from_be_bytes([self.buffer[2], self.buffer[3]])
+    }
+
+    /// Query/Response flag (bit 15)
+    /// false = query, true = response
+    pub fn is_response(&self) -> bool {
+        self.flags() & 0x8000 != 0
+    }
+
+    /// Is this a query?
+    pub fn is_query(&self) -> bool {
+        !self.is_response()
+    }
+
+    /// Opcode (bits 11-14)
+    pub fn opcode(&self) -> u8 {
+        ((self.flags() >> 11) & 0x0F) as u8
+    }
+
+    /// Authoritative Answer flag (bit 10)
+    pub fn is_authoritative(&self) -> bool {
+        self.flags() & 0x0400 != 0
+    }
+
+    /// Truncated flag (bit 9)
+    pub fn is_truncated(&self) -> bool {
+        self.flags() & 0x0200 != 0
+    }
+
+    /// Recursion Desired flag (bit 8)
+    pub fn recursion_desired(&self) -> bool {
+        self.flags() & 0x0100 != 0
+    }
+
+    /// Recursion Available flag (bit 7)
+    pub fn recursion_available(&self) -> bool {
+        self.flags() & 0x0080 != 0
+    }
+
+    /// Response code (bits 0-3)
+    pub fn rcode(&self) -> u8 {
+        (self.flags() & 0x000F) as u8
+    }
+
+    /// Question count (offset 4-5)
+    pub fn question_count(&self) -> u16 {
+        u16::from_be_bytes([self.buffer[4], self.buffer[5]])
+    }
+
+    /// Answer count (offset 6-7)
+    pub fn answer_count(&self) -> u16 {
+        u16::from_be_bytes([self.buffer[6], self.buffer[7]])
+    }
+
+    /// Authority count (offset 8-9)
+    pub fn authority_count(&self) -> u16 {
+        u16::from_be_bytes([self.buffer[8], self.buffer[9]])
+    }
+
+    /// Additional count (offset 10-11)
+    pub fn additional_count(&self) -> u16 {
+        u16::from_be_bytes([self.buffer[10], self.buffer[11]])
+    }
+
+    /// Raw bytes
+    pub fn as_bytes(&self) -> &[u8] {
+        self.buffer
+    }
+}
+
+/// Mutable DNS packet for manipulation
+#[derive(Debug, Clone)]
+pub struct DnsPacket {
+    buffer: Vec<u8>,
+}
+
+impl DnsPacket {
+    /// Create from raw bytes
+    pub fn from_bytes(data: &[u8]) -> Result<Self> {
+        if data.len() < DNS_HEADER_SIZE {
+            return Err(Error::Parse("DNS packet too short".into()));
+        }
+        Ok(Self {
+            buffer: data.to_vec(),
+        })
+    }
+
+    /// Transaction ID
+    pub fn id(&self) -> u16 {
+        u16::from_be_bytes([self.buffer[0], self.buffer[1]])
+    }
+
+    /// Set transaction ID
+    pub fn set_id(&mut self, id: u16) {
+        self.buffer[0..2].copy_from_slice(&id.to_be_bytes());
+    }
+
+    /// Is this a response?
+    pub fn is_response(&self) -> bool {
+        self.buffer[2] & 0x80 != 0
+    }
+
+    /// Question count
+    pub fn question_count(&self) -> u16 {
+        u16::from_be_bytes([self.buffer[4], self.buffer[5]])
+    }
+
+    /// Answer count
+    pub fn answer_count(&self) -> u16 {
+        u16::from_be_bytes([self.buffer[6], self.buffer[7]])
+    }
+
+    /// Response code
+    pub fn rcode(&self) -> u8 {
+        self.buffer[3] & 0x0F
+    }
+
+    /// Parse questions from the packet
+    pub fn questions(&self) -> Result<Vec<DnsQuestion>> {
+        let mut questions = Vec::new();
+        let count = self.question_count();
+        let mut offset = DNS_HEADER_SIZE;
+
+        for _ in 0..count {
+            let (name, new_offset) = parse_domain_name(&self.buffer, offset)?;
+            offset = new_offset;
+
+            if offset + 4 > self.buffer.len() {
+                return Err(Error::Parse("DNS question truncated".into()));
+            }
+
+            let qtype = u16::from_be_bytes([self.buffer[offset], self.buffer[offset + 1]]);
+            let qclass = u16::from_be_bytes([self.buffer[offset + 2], self.buffer[offset + 3]]);
+            offset += 4;
+
+            questions.push(DnsQuestion {
+                name,
+                qtype,
+                qclass,
+            });
+        }
+
+        Ok(questions)
+    }
+
+    /// Parse answer records from the packet
+    pub fn answers(&self) -> Result<Vec<DnsRecord>> {
+        // Skip header and questions to get to answers
+        let mut offset = DNS_HEADER_SIZE;
+        let q_count = self.question_count();
+
+        // Skip questions
+        for _ in 0..q_count {
+            let (_, new_offset) = parse_domain_name(&self.buffer, offset)?;
+            offset = new_offset + 4; // Skip QTYPE and QCLASS
+        }
+
+        // Parse answers
+        let a_count = self.answer_count();
+        let mut answers = Vec::new();
+
+        for _ in 0..a_count {
+            let (name, new_offset) = parse_domain_name(&self.buffer, offset)?;
+            offset = new_offset;
+
+            if offset + 10 > self.buffer.len() {
+                return Err(Error::Parse("DNS answer truncated".into()));
+            }
+
+            let rtype = u16::from_be_bytes([self.buffer[offset], self.buffer[offset + 1]]);
+            let rclass = u16::from_be_bytes([self.buffer[offset + 2], self.buffer[offset + 3]]);
+            let ttl = u32::from_be_bytes([
+                self.buffer[offset + 4],
+                self.buffer[offset + 5],
+                self.buffer[offset + 6],
+                self.buffer[offset + 7],
+            ]);
+            let rdlength =
+                u16::from_be_bytes([self.buffer[offset + 8], self.buffer[offset + 9]]) as usize;
+            offset += 10;
+
+            if offset + rdlength > self.buffer.len() {
+                return Err(Error::Parse("DNS RDATA truncated".into()));
+            }
+
+            let rdata = self.buffer[offset..offset + rdlength].to_vec();
+            offset += rdlength;
+
+            answers.push(DnsRecord {
+                name,
+                rtype,
+                rclass,
+                ttl,
+                rdata,
+            });
+        }
+
+        Ok(answers)
+    }
+
+    /// Get minimum TTL from answer records (for caching)
+    pub fn min_ttl(&self) -> Option<u32> {
+        self.answers().ok()?.iter().map(|r| r.ttl).min()
+    }
+
+    /// Consume and return the buffer
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.buffer
+    }
+
+    /// Get reference to buffer
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.buffer
+    }
+}
+
+/// Parse a domain name from DNS wire format
+///
+/// Handles both label format and compression pointers (RFC 1035 section 4.1.4)
+pub fn parse_domain_name(buffer: &[u8], start: usize) -> Result<(String, usize)> {
+    let mut labels: Vec<String> = Vec::new();
+    let mut offset = start;
+    let mut jumped = false;
+    let mut final_offset = start;
+    let mut jumps = 0;
+    const MAX_JUMPS: usize = 128;
+
+    loop {
+        if jumps > MAX_JUMPS {
+            return Err(Error::Parse("DNS name compression loop detected".into()));
+        }
+
+        if offset >= buffer.len() {
+            return Err(Error::Parse("DNS name truncated".into()));
+        }
+
+        let len = buffer[offset] as usize;
+
+        if len == 0 {
+            // End of name
+            if !jumped {
+                final_offset = offset + 1;
+            }
+            break;
+        } else if len & 0xC0 == 0xC0 {
+            // Compression pointer
+            if offset + 1 >= buffer.len() {
+                return Err(Error::Parse("DNS compression pointer truncated".into()));
+            }
+
+            if !jumped {
+                final_offset = offset + 2;
+            }
+
+            let pointer = ((len & 0x3F) << 8) | (buffer[offset + 1] as usize);
+            offset = pointer;
+            jumped = true;
+            jumps += 1;
+        } else {
+            // Normal label
+            offset += 1;
+            if offset + len > buffer.len() {
+                return Err(Error::Parse("DNS label truncated".into()));
+            }
+
+            let label = std::str::from_utf8(&buffer[offset..offset + len])
+                .map_err(|_| Error::Parse("DNS label not valid UTF-8".into()))?;
+            labels.push(label.to_string());
+            offset += len;
+
+            if !jumped {
+                final_offset = offset;
+            }
+        }
+    }
+
+    let name = if labels.is_empty() {
+        ".".to_string()
+    } else {
+        labels.join(".")
+    };
+
+    Ok((name, final_offset))
+}
+
+/// Encode a domain name to DNS wire format
+pub fn encode_domain_name(name: &str) -> Vec<u8> {
+    let mut result = Vec::new();
+
+    // Handle root domain
+    if name == "." || name.is_empty() {
+        result.push(0);
+        return result;
+    }
+
+    // Remove trailing dot if present
+    let name = name.trim_end_matches('.');
+
+    for label in name.split('.') {
+        if label.is_empty() {
+            continue;
+        }
+        result.push(label.len() as u8);
+        result.extend_from_slice(label.as_bytes());
+    }
+    result.push(0); // Terminating zero
+
+    result
+}
+
+/// DNS query builder
+#[derive(Debug, Clone, Default)]
+pub struct DnsBuilder {
+    id: u16,
+    flags: u16,
+    questions: Vec<DnsQuestion>,
+}
+
+impl DnsBuilder {
+    /// Create a new DNS builder
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set transaction ID
+    pub fn id(mut self, id: u16) -> Self {
+        self.id = id;
+        self
+    }
+
+    /// Set as query (QR=0)
+    pub fn query(mut self) -> Self {
+        self.flags &= !0x8000;
+        self
+    }
+
+    /// Set as response (QR=1)
+    pub fn response(mut self) -> Self {
+        self.flags |= 0x8000;
+        self
+    }
+
+    /// Set recursion desired flag
+    pub fn recursion_desired(mut self, rd: bool) -> Self {
+        if rd {
+            self.flags |= 0x0100;
+        } else {
+            self.flags &= !0x0100;
+        }
+        self
+    }
+
+    /// Set recursion available flag
+    pub fn recursion_available(mut self, ra: bool) -> Self {
+        if ra {
+            self.flags |= 0x0080;
+        } else {
+            self.flags &= !0x0080;
+        }
+        self
+    }
+
+    /// Set response code
+    pub fn rcode(mut self, rcode: DnsRcode) -> Self {
+        self.flags = (self.flags & !0x000F) | (rcode as u16);
+        self
+    }
+
+    /// Add a question
+    pub fn add_question(mut self, name: &str, qtype: DnsType, qclass: DnsClass) -> Self {
+        self.questions.push(DnsQuestion {
+            name: name.to_string(),
+            qtype: qtype as u16,
+            qclass: qclass as u16,
+        });
+        self
+    }
+
+    /// Build the DNS packet
+    pub fn build(self) -> Vec<u8> {
+        let mut buffer = Vec::new();
+
+        // Header
+        buffer.extend_from_slice(&self.id.to_be_bytes());
+        buffer.extend_from_slice(&self.flags.to_be_bytes());
+        buffer.extend_from_slice(&(self.questions.len() as u16).to_be_bytes()); // QDCOUNT
+        buffer.extend_from_slice(&0u16.to_be_bytes()); // ANCOUNT
+        buffer.extend_from_slice(&0u16.to_be_bytes()); // NSCOUNT
+        buffer.extend_from_slice(&0u16.to_be_bytes()); // ARCOUNT
+
+        // Questions
+        for q in &self.questions {
+            buffer.extend(encode_domain_name(&q.name));
+            buffer.extend_from_slice(&q.qtype.to_be_bytes());
+            buffer.extend_from_slice(&q.qclass.to_be_bytes());
+        }
+
+        buffer
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Create a simple DNS query packet for testing
+    fn make_query_packet() -> Vec<u8> {
+        // DNS query for "example.com" type A, class IN
+        vec![
+            0x12, 0x34, // ID = 0x1234
+            0x01, 0x00, // Flags: QR=0 (query), RD=1
+            0x00, 0x01, // QDCOUNT = 1
+            0x00, 0x00, // ANCOUNT = 0
+            0x00, 0x00, // NSCOUNT = 0
+            0x00, 0x00, // ARCOUNT = 0
+            // Question: example.com
+            0x07, b'e', b'x', b'a', b'm', b'p', b'l', b'e', 0x03, b'c', b'o', b'm',
+            0x00, // Terminating zero
+            0x00, 0x01, // QTYPE = A
+            0x00, 0x01, // QCLASS = IN
+        ]
+    }
+
+    /// Create a DNS response packet for testing
+    fn make_response_packet() -> Vec<u8> {
+        vec![
+            0x12, 0x34, // ID = 0x1234
+            0x81, 0x80, // Flags: QR=1 (response), RD=1, RA=1
+            0x00, 0x01, // QDCOUNT = 1
+            0x00, 0x01, // ANCOUNT = 1
+            0x00, 0x00, // NSCOUNT = 0
+            0x00, 0x00, // ARCOUNT = 0
+            // Question: example.com
+            0x07, b'e', b'x', b'a', b'm', b'p', b'l', b'e', 0x03, b'c', b'o', b'm', 0x00, 0x00,
+            0x01, // QTYPE = A
+            0x00, 0x01, // QCLASS = IN
+            // Answer: example.com (using compression pointer)
+            0xc0, 0x0c, // Pointer to offset 12 (example.com)
+            0x00, 0x01, // TYPE = A
+            0x00, 0x01, // CLASS = IN
+            0x00, 0x00, 0x01, 0x2c, // TTL = 300
+            0x00, 0x04, // RDLENGTH = 4
+            0x5d, 0xb8, 0xd8, 0x22, // RDATA = 93.184.216.34
+        ]
+    }
+
+    #[test]
+    fn test_dns_header_parse() {
+        let packet = make_query_packet();
+        let header = DnsHeader::parse(&packet).unwrap();
+
+        assert_eq!(header.id(), 0x1234);
+        assert!(header.is_query());
+        assert!(!header.is_response());
+        assert!(header.recursion_desired());
+        assert_eq!(header.question_count(), 1);
+        assert_eq!(header.answer_count(), 0);
+    }
+
+    #[test]
+    fn test_dns_header_parse_too_short() {
+        let packet = vec![0u8; 11];
+        assert!(DnsHeader::parse(&packet).is_err());
+    }
+
+    #[test]
+    fn test_dns_header_response() {
+        let packet = make_response_packet();
+        let header = DnsHeader::parse(&packet).unwrap();
+
+        assert!(header.is_response());
+        assert!(!header.is_query());
+        assert!(header.recursion_desired());
+        assert!(header.recursion_available());
+        assert_eq!(header.rcode(), 0); // NoError
+        assert_eq!(header.question_count(), 1);
+        assert_eq!(header.answer_count(), 1);
+    }
+
+    #[test]
+    fn test_parse_domain_name_simple() {
+        // "example.com" in wire format
+        let buffer = [
+            0x07, b'e', b'x', b'a', b'm', b'p', b'l', b'e', 0x03, b'c', b'o', b'm', 0x00,
+        ];
+        let (name, offset) = parse_domain_name(&buffer, 0).unwrap();
+
+        assert_eq!(name, "example.com");
+        assert_eq!(offset, 13);
+    }
+
+    #[test]
+    fn test_parse_domain_name_with_pointer() {
+        let packet = make_response_packet();
+        // Answer section starts at offset 29, name is compression pointer at 0xc00c
+        let (name, _) = parse_domain_name(&packet, 29).unwrap();
+        assert_eq!(name, "example.com");
+    }
+
+    #[test]
+    fn test_parse_domain_name_root() {
+        let buffer = [0x00];
+        let (name, offset) = parse_domain_name(&buffer, 0).unwrap();
+        assert_eq!(name, ".");
+        assert_eq!(offset, 1);
+    }
+
+    #[test]
+    fn test_encode_domain_name() {
+        let encoded = encode_domain_name("example.com");
+        let expected = vec![
+            0x07, b'e', b'x', b'a', b'm', b'p', b'l', b'e', 0x03, b'c', b'o', b'm', 0x00,
+        ];
+        assert_eq!(encoded, expected);
+    }
+
+    #[test]
+    fn test_encode_domain_name_with_trailing_dot() {
+        let encoded = encode_domain_name("example.com.");
+        let expected = vec![
+            0x07, b'e', b'x', b'a', b'm', b'p', b'l', b'e', 0x03, b'c', b'o', b'm', 0x00,
+        ];
+        assert_eq!(encoded, expected);
+    }
+
+    #[test]
+    fn test_encode_domain_name_root() {
+        let encoded = encode_domain_name(".");
+        assert_eq!(encoded, vec![0x00]);
+    }
+
+    #[test]
+    fn test_dns_packet_questions() {
+        let packet = DnsPacket::from_bytes(&make_query_packet()).unwrap();
+        let questions = packet.questions().unwrap();
+
+        assert_eq!(questions.len(), 1);
+        assert_eq!(questions[0].name, "example.com");
+        assert_eq!(questions[0].qtype, DnsType::A as u16);
+        assert_eq!(questions[0].qclass, DnsClass::IN as u16);
+    }
+
+    #[test]
+    fn test_dns_packet_answers() {
+        let packet = DnsPacket::from_bytes(&make_response_packet()).unwrap();
+        let answers = packet.answers().unwrap();
+
+        assert_eq!(answers.len(), 1);
+        assert_eq!(answers[0].name, "example.com");
+        assert_eq!(answers[0].rtype, DnsType::A as u16);
+        assert_eq!(answers[0].ttl, 300);
+        assert_eq!(answers[0].rdata, vec![0x5d, 0xb8, 0xd8, 0x22]);
+    }
+
+    #[test]
+    fn test_dns_packet_min_ttl() {
+        let packet = DnsPacket::from_bytes(&make_response_packet()).unwrap();
+        assert_eq!(packet.min_ttl(), Some(300));
+    }
+
+    #[test]
+    fn test_dns_packet_set_id() {
+        let mut packet = DnsPacket::from_bytes(&make_query_packet()).unwrap();
+        assert_eq!(packet.id(), 0x1234);
+
+        packet.set_id(0xABCD);
+        assert_eq!(packet.id(), 0xABCD);
+    }
+
+    #[test]
+    fn test_dns_builder_query() {
+        let packet = DnsBuilder::new()
+            .id(0x5678)
+            .query()
+            .recursion_desired(true)
+            .add_question("test.example.com", DnsType::A, DnsClass::IN)
+            .build();
+
+        let header = DnsHeader::parse(&packet).unwrap();
+        assert_eq!(header.id(), 0x5678);
+        assert!(header.is_query());
+        assert!(header.recursion_desired());
+        assert_eq!(header.question_count(), 1);
+
+        let pkt = DnsPacket::from_bytes(&packet).unwrap();
+        let questions = pkt.questions().unwrap();
+        assert_eq!(questions[0].name, "test.example.com");
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let original = make_query_packet();
+        let packet = DnsPacket::from_bytes(&original).unwrap();
+        let questions = packet.questions().unwrap();
+
+        let rebuilt = DnsBuilder::new()
+            .id(packet.id())
+            .query()
+            .recursion_desired(true)
+            .add_question(&questions[0].name, DnsType::A, DnsClass::IN)
+            .build();
+
+        // Parse both and compare
+        let orig_hdr = DnsHeader::parse(&original).unwrap();
+        let new_hdr = DnsHeader::parse(&rebuilt).unwrap();
+
+        assert_eq!(orig_hdr.id(), new_hdr.id());
+        assert_eq!(orig_hdr.question_count(), new_hdr.question_count());
+    }
+
+    #[test]
+    fn test_dns_rcode() {
+        assert_eq!(DnsRcode::from_u8(0), Some(DnsRcode::NoError));
+        assert_eq!(DnsRcode::from_u8(3), Some(DnsRcode::NameError));
+        assert_eq!(DnsRcode::from_u8(10), None);
+    }
+
+    #[test]
+    fn test_dns_type() {
+        assert_eq!(DnsType::from_u16(1), Some(DnsType::A));
+        assert_eq!(DnsType::from_u16(28), Some(DnsType::AAAA));
+        assert_eq!(DnsType::from_u16(999), None);
+    }
+}

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -5,6 +5,7 @@
 pub mod arp;
 pub mod dhcp;
 pub mod dhcpv6;
+pub mod dns;
 pub mod ethernet;
 pub mod icmp;
 pub mod icmpv6;


### PR DESCRIPTION
## Summary
- DNSプロトコルパーサー/ビルダーを実装 (RFC 1035)
- DNSフォワーダーサービスを追加:
  - 上流DNSサーバーへのクエリ転送
  - TTLベースのレスポンスキャッシュ (LRUエビクション)
  - クライアント分離のためのTransaction ID書き換え
- `config.toml` でDNSフォワーダーを設定可能

## Test plan
- [x] `cargo test` - 全ユニットテスト通過
- [x] `cargo clippy` - 警告なし

Closes #22