### PR TITLE
feat(pppoe): Add PPPoE client support

### DIFF
--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -486,6 +486,7 @@ mod tests {
             logging: None,
             interfaces: HashMap::new(),
             dhcp: HashMap::new(),
+            pppoe: HashMap::new(),
             nat: None,
             firewall: None,
             routing: RoutingConfig::default(),

--- a/src/dataplane/mod.rs
+++ b/src/dataplane/mod.rs
@@ -17,6 +17,7 @@ mod napt;
 mod ndp_processor;
 mod neighbor_table;
 mod pbr;
+mod pppoe_client;
 mod router;
 mod routing;
 
@@ -40,6 +41,7 @@ pub use ndp_processor::{
 };
 pub use neighbor_table::{NeighborState, NeighborTable};
 pub use pbr::{PacketKey, PolicyAction, PolicyMatch, PolicyResult, PolicyRouter, PolicyRule};
+pub use pppoe_client::{PppoeClient, PppoeClientAction, PppoeClientState, PppoeSession, PPPOE_MTU};
 pub use router::{Interface, Router};
 pub use routing::{network_address, LookupResult, Route, RouteSource, RoutingSystem, RoutingTable};
 

--- a/src/dataplane/pppoe_client.rs
+++ b/src/dataplane/pppoe_client.rs
@@ -1,0 +1,1514 @@
+//! PPPoE client implementation
+//!
+//! Implements RFC 2516 PPPoE client state machine for establishing PPP sessions.
+
+use crate::protocol::chap::{self, calculate_chap_md5, ChapBuilder, ChapPacket};
+use crate::protocol::ethernet::FrameBuilder;
+use crate::protocol::ipcp::{self, IpcpBuilder, IpcpPacket};
+use crate::protocol::lcp::{self, LcpBuilder, LcpPacket};
+use crate::protocol::pap::{PapBuilder, PapPacket};
+use crate::protocol::ppp::{self, PppBuilder, PppFrame};
+use crate::protocol::pppoe::{self, codes as pppoe_codes, tags, PppoeBuilder, PppoeFrame};
+use crate::protocol::MacAddr;
+use std::net::Ipv4Addr;
+use std::time::{Duration, Instant};
+use tracing::{debug, info, warn};
+
+/// Maximum retries before giving up
+const MAX_RETRIES: u8 = 10;
+
+/// Discovery timeout in seconds
+const DISCOVERY_TIMEOUT_SECS: u64 = 5;
+
+/// LCP/IPCP timeout in seconds
+const LCP_TIMEOUT_SECS: u64 = 3;
+
+/// Authentication timeout in seconds
+const AUTH_TIMEOUT_SECS: u64 = 10;
+
+/// LCP Echo interval in seconds
+const ECHO_INTERVAL_SECS: u64 = 30;
+
+/// Maximum missed Echo-Reply before terminating
+const ECHO_FAILURE_COUNT: u8 = 3;
+
+/// PPPoE MTU (1500 - 8 PPPoE header)
+pub const PPPOE_MTU: u16 = 1492;
+
+/// PPPoE client state
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PppoeClientState {
+    /// Initial state
+    Init,
+    /// PADI sent, waiting for PADO
+    PadiSent,
+    /// PADR sent, waiting for PADS
+    PadrSent,
+    /// LCP negotiation in progress
+    LcpNegotiating,
+    /// Authentication in progress (PAP or CHAP)
+    Authenticating,
+    /// IPCP negotiation in progress
+    IpcpNegotiating,
+    /// Session established
+    Opened,
+    /// Terminating session
+    Terminating,
+}
+
+/// PPPoE session information
+#[derive(Debug, Clone)]
+pub struct PppoeSession {
+    /// Assigned IP address
+    pub ip_addr: Ipv4Addr,
+    /// Peer IP address (for point-to-point link)
+    pub peer_ip: Ipv4Addr,
+    /// Primary DNS server
+    pub dns1: Option<Ipv4Addr>,
+    /// Secondary DNS server
+    pub dns2: Option<Ipv4Addr>,
+    /// Session ID
+    pub session_id: u16,
+    /// When session was established
+    pub established_at: Instant,
+}
+
+/// Actions the PPPoE client needs the router to perform
+#[derive(Debug)]
+pub enum PppoeClientAction {
+    /// Send a PPPoE Discovery packet
+    SendDiscovery { interface: String, packet: Vec<u8> },
+    /// Send a PPPoE Session packet
+    SendSession { interface: String, packet: Vec<u8> },
+    /// Configure interface with obtained IP
+    ConfigureInterface {
+        interface: String,
+        ip_addr: Ipv4Addr,
+        peer_ip: Ipv4Addr,
+        dns_servers: Vec<Ipv4Addr>,
+    },
+    /// Remove interface IP configuration
+    DeconfigureInterface { interface: String },
+    /// Session terminated
+    SessionTerminated { interface: String, reason: String },
+    /// No action needed
+    None,
+}
+
+/// Authentication method negotiated via LCP
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AuthMethod {
+    None,
+    Pap,
+    ChapMd5,
+}
+
+/// PPPoE client for a single interface
+#[derive(Debug)]
+pub struct PppoeClient {
+    // Basic info
+    interface: String,
+    mac_addr: MacAddr,
+
+    // Credentials
+    username: String,
+    password: String,
+    service_name: Option<String>,
+
+    // State
+    state: PppoeClientState,
+    session_id: u16,
+    ac_mac: MacAddr,
+
+    // Discovery state
+    host_uniq: [u8; 4],
+    ac_cookie: Option<Vec<u8>>,
+
+    // LCP state
+    lcp_identifier: u8,
+    lcp_our_magic: u32,
+    lcp_peer_magic: u32,
+    lcp_our_config_acked: bool,
+    lcp_peer_config_acked: bool,
+    auth_method: AuthMethod,
+
+    // Authentication state
+    auth_identifier: u8,
+
+    // IPCP state
+    ipcp_identifier: u8,
+    ipcp_our_config_acked: bool,
+    ipcp_peer_config_acked: bool,
+    assigned_ip: Ipv4Addr,
+    peer_ip: Ipv4Addr,
+    dns1: Ipv4Addr,
+    dns2: Ipv4Addr,
+
+    // Session info
+    session: Option<PppoeSession>,
+
+    // Timers
+    last_sent: Option<Instant>,
+    retries: u8,
+
+    // Echo keepalive
+    echo_identifier: u8,
+    echo_pending: bool,
+    echo_failures: u8,
+    last_echo_sent: Option<Instant>,
+}
+
+impl PppoeClient {
+    /// Create a new PPPoE client
+    pub fn new(
+        interface: String,
+        mac_addr: MacAddr,
+        username: String,
+        password: String,
+        service_name: Option<String>,
+    ) -> Self {
+        Self {
+            interface,
+            mac_addr,
+            username,
+            password,
+            service_name,
+            state: PppoeClientState::Init,
+            session_id: 0,
+            ac_mac: MacAddr::ZERO,
+            host_uniq: Self::generate_host_uniq(),
+            ac_cookie: None,
+            lcp_identifier: 0,
+            lcp_our_magic: Self::generate_magic(),
+            lcp_peer_magic: 0,
+            lcp_our_config_acked: false,
+            lcp_peer_config_acked: false,
+            auth_method: AuthMethod::None,
+            auth_identifier: 0,
+            ipcp_identifier: 0,
+            ipcp_our_config_acked: false,
+            ipcp_peer_config_acked: false,
+            assigned_ip: Ipv4Addr::UNSPECIFIED,
+            peer_ip: Ipv4Addr::UNSPECIFIED,
+            dns1: Ipv4Addr::UNSPECIFIED,
+            dns2: Ipv4Addr::UNSPECIFIED,
+            session: None,
+            last_sent: None,
+            retries: 0,
+            echo_identifier: 0,
+            echo_pending: false,
+            echo_failures: 0,
+            last_echo_sent: None,
+        }
+    }
+
+    /// Get interface name
+    pub fn interface(&self) -> &str {
+        &self.interface
+    }
+
+    /// Get current state
+    pub fn state(&self) -> PppoeClientState {
+        self.state
+    }
+
+    /// Get current session info
+    pub fn session(&self) -> Option<&PppoeSession> {
+        self.session.as_ref()
+    }
+
+    /// Get session ID (0 if not connected)
+    pub fn session_id(&self) -> u16 {
+        self.session_id
+    }
+
+    /// Generate random host_uniq
+    fn generate_host_uniq() -> [u8; 4] {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let seed = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u32;
+        seed.wrapping_mul(1103515245)
+            .wrapping_add(12345)
+            .to_be_bytes()
+    }
+
+    /// Generate random magic number
+    fn generate_magic() -> u32 {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let seed = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u32;
+        seed.wrapping_mul(1664525).wrapping_add(1013904223)
+    }
+
+    /// Start PPPoE discovery
+    pub fn start(&mut self) -> PppoeClientAction {
+        info!("PPPoE client starting on {}", self.interface);
+        self.reset_state();
+        self.send_padi()
+    }
+
+    /// Reset all state for new connection attempt
+    fn reset_state(&mut self) {
+        self.state = PppoeClientState::Init;
+        self.session_id = 0;
+        self.ac_mac = MacAddr::ZERO;
+        self.host_uniq = Self::generate_host_uniq();
+        self.ac_cookie = None;
+        self.lcp_identifier = 0;
+        self.lcp_our_magic = Self::generate_magic();
+        self.lcp_peer_magic = 0;
+        self.lcp_our_config_acked = false;
+        self.lcp_peer_config_acked = false;
+        self.auth_method = AuthMethod::None;
+        self.auth_identifier = 0;
+        self.ipcp_identifier = 0;
+        self.ipcp_our_config_acked = false;
+        self.ipcp_peer_config_acked = false;
+        self.assigned_ip = Ipv4Addr::UNSPECIFIED;
+        self.peer_ip = Ipv4Addr::UNSPECIFIED;
+        self.dns1 = Ipv4Addr::UNSPECIFIED;
+        self.dns2 = Ipv4Addr::UNSPECIFIED;
+        self.session = None;
+        self.last_sent = None;
+        self.retries = 0;
+        self.echo_identifier = 0;
+        self.echo_pending = false;
+        self.echo_failures = 0;
+        self.last_echo_sent = None;
+    }
+
+    /// Send PADI (PPPoE Active Discovery Initiation)
+    fn send_padi(&mut self) -> PppoeClientAction {
+        debug!("PPPoE: Sending PADI on {}", self.interface);
+        self.state = PppoeClientState::PadiSent;
+        self.last_sent = Some(Instant::now());
+
+        let pppoe = self.build_padi();
+        let frame = self.wrap_discovery_frame(&pppoe, MacAddr::BROADCAST);
+
+        PppoeClientAction::SendDiscovery {
+            interface: self.interface.clone(),
+            packet: frame,
+        }
+    }
+
+    /// Build PADI packet
+    fn build_padi(&self) -> Vec<u8> {
+        let mut builder = PppoeBuilder::discovery()
+            .code(pppoe_codes::PADI)
+            .host_uniq(&self.host_uniq);
+
+        if let Some(ref name) = self.service_name {
+            builder = builder.service_name(name);
+        } else {
+            builder = builder.service_name_any();
+        }
+
+        builder.build()
+    }
+
+    /// Send PADR (PPPoE Active Discovery Request)
+    fn send_padr(&mut self) -> PppoeClientAction {
+        debug!(
+            "PPPoE: Sending PADR to {:?} on {}",
+            self.ac_mac, self.interface
+        );
+        self.state = PppoeClientState::PadrSent;
+        self.last_sent = Some(Instant::now());
+        self.retries = 0;
+
+        let pppoe = self.build_padr();
+        let frame = self.wrap_discovery_frame(&pppoe, self.ac_mac);
+
+        PppoeClientAction::SendDiscovery {
+            interface: self.interface.clone(),
+            packet: frame,
+        }
+    }
+
+    /// Build PADR packet
+    fn build_padr(&self) -> Vec<u8> {
+        let mut builder = PppoeBuilder::discovery()
+            .code(pppoe_codes::PADR)
+            .host_uniq(&self.host_uniq);
+
+        if let Some(ref name) = self.service_name {
+            builder = builder.service_name(name);
+        } else {
+            builder = builder.service_name_any();
+        }
+
+        if let Some(ref cookie) = self.ac_cookie {
+            builder = builder.ac_cookie(cookie);
+        }
+
+        builder.build()
+    }
+
+    /// Send PADT (PPPoE Active Discovery Terminate)
+    fn send_padt(&mut self, reason: &str) -> PppoeClientAction {
+        debug!("PPPoE: Sending PADT on {} ({})", self.interface, reason);
+
+        if self.session_id == 0 {
+            return PppoeClientAction::SessionTerminated {
+                interface: self.interface.clone(),
+                reason: reason.to_string(),
+            };
+        }
+
+        let pppoe = PppoeBuilder::discovery()
+            .code(pppoe_codes::PADT)
+            .session_id(self.session_id)
+            .build();
+        let frame = self.wrap_discovery_frame(&pppoe, self.ac_mac);
+
+        self.state = PppoeClientState::Terminating;
+
+        PppoeClientAction::SendDiscovery {
+            interface: self.interface.clone(),
+            packet: frame,
+        }
+    }
+
+    /// Wrap PPPoE in Ethernet frame for Discovery
+    fn wrap_discovery_frame(&self, pppoe: &[u8], dst_mac: MacAddr) -> Vec<u8> {
+        FrameBuilder::new()
+            .dst_mac(dst_mac)
+            .src_mac(self.mac_addr)
+            .ethertype(pppoe::PPPOE_DISCOVERY_ETHERTYPE)
+            .payload(pppoe)
+            .build()
+    }
+
+    /// Wrap PPPoE in Ethernet frame for Session
+    fn wrap_session_frame(&self, pppoe: &[u8]) -> Vec<u8> {
+        FrameBuilder::new()
+            .dst_mac(self.ac_mac)
+            .src_mac(self.mac_addr)
+            .ethertype(pppoe::PPPOE_SESSION_ETHERTYPE)
+            .payload(pppoe)
+            .build()
+    }
+
+    /// Wrap PPP in PPPoE Session frame
+    fn wrap_ppp_in_pppoe(&self, ppp: &[u8]) -> Vec<u8> {
+        PppoeBuilder::session(self.session_id).payload(ppp).build()
+    }
+
+    /// Process received PPPoE Discovery packet
+    pub fn process_discovery(&mut self, src_mac: MacAddr, pppoe: &PppoeFrame) -> PppoeClientAction {
+        match pppoe.code() {
+            pppoe_codes::PADO => self.handle_pado(src_mac, pppoe),
+            pppoe_codes::PADS => self.handle_pads(pppoe),
+            pppoe_codes::PADT => self.handle_padt(),
+            _ => {
+                debug!("PPPoE: Ignoring discovery code 0x{:02x}", pppoe.code());
+                PppoeClientAction::None
+            }
+        }
+    }
+
+    /// Handle PADO (PPPoE Active Discovery Offer)
+    fn handle_pado(&mut self, src_mac: MacAddr, pppoe: &PppoeFrame) -> PppoeClientAction {
+        if self.state != PppoeClientState::PadiSent {
+            debug!("PPPoE: Ignoring PADO in state {:?}", self.state);
+            return PppoeClientAction::None;
+        }
+
+        // Verify Host-Uniq matches
+        if let Some(uniq) = pppoe.find_tag(tags::HOST_UNIQ) {
+            if uniq != self.host_uniq {
+                debug!("PPPoE: PADO Host-Uniq mismatch");
+                return PppoeClientAction::None;
+            }
+        }
+
+        // Store AC info
+        self.ac_mac = src_mac;
+        self.ac_cookie = pppoe.find_tag(tags::AC_COOKIE).map(|c| c.to_vec());
+
+        let ac_name = pppoe
+            .find_tag(tags::AC_NAME)
+            .and_then(|n| std::str::from_utf8(n).ok())
+            .unwrap_or("unknown");
+
+        info!(
+            "PPPoE: Received PADO from {} (AC: {}) on {}",
+            src_mac, ac_name, self.interface
+        );
+
+        self.send_padr()
+    }
+
+    /// Handle PADS (PPPoE Active Discovery Session-confirmation)
+    fn handle_pads(&mut self, pppoe: &PppoeFrame) -> PppoeClientAction {
+        if self.state != PppoeClientState::PadrSent {
+            debug!("PPPoE: Ignoring PADS in state {:?}", self.state);
+            return PppoeClientAction::None;
+        }
+
+        // Check for errors
+        if let Some(err) = pppoe.find_tag(tags::SERVICE_NAME_ERROR) {
+            let msg = std::str::from_utf8(err).unwrap_or("unknown error");
+            warn!("PPPoE: PADS Service-Name-Error: {}", msg);
+            return self.send_padt(msg);
+        }
+        if let Some(err) = pppoe.find_tag(tags::AC_SYSTEM_ERROR) {
+            let msg = std::str::from_utf8(err).unwrap_or("unknown error");
+            warn!("PPPoE: PADS AC-System-Error: {}", msg);
+            return self.send_padt(msg);
+        }
+        if let Some(err) = pppoe.find_tag(tags::GENERIC_ERROR) {
+            let msg = std::str::from_utf8(err).unwrap_or("unknown error");
+            warn!("PPPoE: PADS Generic-Error: {}", msg);
+            return self.send_padt(msg);
+        }
+
+        self.session_id = pppoe.session_id();
+
+        if self.session_id == 0 {
+            warn!("PPPoE: PADS with session_id=0");
+            return self.send_padt("invalid session_id");
+        }
+
+        info!(
+            "PPPoE: Session established (id=0x{:04x}) on {}",
+            self.session_id, self.interface
+        );
+
+        // Start LCP negotiation
+        self.start_lcp()
+    }
+
+    /// Handle PADT (PPPoE Active Discovery Terminate)
+    fn handle_padt(&mut self) -> PppoeClientAction {
+        info!("PPPoE: Received PADT on {}", self.interface);
+        let old_state = self.state;
+        self.reset_state();
+
+        if old_state == PppoeClientState::Opened {
+            PppoeClientAction::DeconfigureInterface {
+                interface: self.interface.clone(),
+            }
+        } else {
+            PppoeClientAction::SessionTerminated {
+                interface: self.interface.clone(),
+                reason: "PADT received".to_string(),
+            }
+        }
+    }
+
+    /// Process received PPPoE Session packet
+    pub fn process_session(&mut self, pppoe: &PppoeFrame) -> PppoeClientAction {
+        // Verify session ID
+        if pppoe.session_id() != self.session_id {
+            debug!(
+                "PPPoE: Session ID mismatch (got 0x{:04x}, expected 0x{:04x})",
+                pppoe.session_id(),
+                self.session_id
+            );
+            return PppoeClientAction::None;
+        }
+
+        // Parse PPP frame
+        let ppp = match PppFrame::parse(pppoe.payload()) {
+            Ok(p) => p,
+            Err(e) => {
+                debug!("PPPoE: Failed to parse PPP: {}", e);
+                return PppoeClientAction::None;
+            }
+        };
+
+        match ppp.protocol() {
+            ppp::protocols::LCP => self.handle_lcp(ppp.payload()),
+            ppp::protocols::PAP => self.handle_pap(ppp.payload()),
+            ppp::protocols::CHAP => self.handle_chap(ppp.payload()),
+            ppp::protocols::IPCP => self.handle_ipcp(ppp.payload()),
+            _ => {
+                debug!("PPPoE: Ignoring PPP protocol 0x{:04x}", ppp.protocol());
+                PppoeClientAction::None
+            }
+        }
+    }
+
+    /// Start LCP negotiation
+    fn start_lcp(&mut self) -> PppoeClientAction {
+        debug!("PPPoE: Starting LCP negotiation on {}", self.interface);
+        self.state = PppoeClientState::LcpNegotiating;
+        self.lcp_identifier = self.lcp_identifier.wrapping_add(1);
+        self.lcp_our_config_acked = false;
+        self.lcp_peer_config_acked = false;
+        self.last_sent = Some(Instant::now());
+        self.retries = 0;
+
+        self.send_lcp_config_request()
+    }
+
+    /// Send LCP Configure-Request
+    fn send_lcp_config_request(&mut self) -> PppoeClientAction {
+        let lcp = LcpBuilder::configure_request(self.lcp_identifier)
+            .mru(PPPOE_MTU)
+            .magic_number(self.lcp_our_magic)
+            .build();
+
+        let ppp = PppBuilder::lcp().payload(&lcp).build();
+        let pppoe = self.wrap_ppp_in_pppoe(&ppp);
+        let frame = self.wrap_session_frame(&pppoe);
+
+        debug!(
+            "PPPoE: Sending LCP Configure-Request (id={}) on {}",
+            self.lcp_identifier, self.interface
+        );
+
+        PppoeClientAction::SendSession {
+            interface: self.interface.clone(),
+            packet: frame,
+        }
+    }
+
+    /// Handle LCP packet
+    fn handle_lcp(&mut self, payload: &[u8]) -> PppoeClientAction {
+        let lcp = match LcpPacket::parse(payload) {
+            Ok(l) => l,
+            Err(e) => {
+                debug!("PPPoE: Failed to parse LCP: {}", e);
+                return PppoeClientAction::None;
+            }
+        };
+
+        debug!(
+            "PPPoE: Received LCP code={} id={} on {}",
+            lcp.code(),
+            lcp.identifier(),
+            self.interface
+        );
+
+        match lcp.code() {
+            lcp::codes::CONFIGURE_REQUEST => self.handle_lcp_config_request(&lcp),
+            lcp::codes::CONFIGURE_ACK => self.handle_lcp_config_ack(&lcp),
+            lcp::codes::CONFIGURE_NAK => self.handle_lcp_config_nak(&lcp),
+            lcp::codes::CONFIGURE_REJECT => self.handle_lcp_config_reject(&lcp),
+            lcp::codes::TERMINATE_REQUEST => self.handle_lcp_terminate_request(&lcp),
+            lcp::codes::TERMINATE_ACK => self.handle_lcp_terminate_ack(),
+            lcp::codes::ECHO_REQUEST => self.handle_lcp_echo_request(&lcp),
+            lcp::codes::ECHO_REPLY => self.handle_lcp_echo_reply(&lcp),
+            _ => {
+                debug!("PPPoE: Ignoring LCP code {}", lcp.code());
+                PppoeClientAction::None
+            }
+        }
+    }
+
+    /// Handle LCP Configure-Request from peer
+    fn handle_lcp_config_request(&mut self, lcp: &LcpPacket) -> PppoeClientAction {
+        // Check for options we don't support
+        let mut reject_options = Vec::new();
+        let mut nak_options = Vec::new();
+
+        for opt in lcp.iter_options() {
+            match opt.opt_type {
+                lcp::options::MRU => {
+                    // Accept any MRU
+                }
+                lcp::options::MAGIC_NUMBER => {
+                    if opt.data.len() >= 4 {
+                        self.lcp_peer_magic = u32::from_be_bytes([
+                            opt.data[0],
+                            opt.data[1],
+                            opt.data[2],
+                            opt.data[3],
+                        ]);
+                    }
+                }
+                lcp::options::AUTH_PROTOCOL => {
+                    if opt.data.len() >= 2 {
+                        let proto = u16::from_be_bytes([opt.data[0], opt.data[1]]);
+                        match proto {
+                            lcp::auth::PAP => {
+                                self.auth_method = AuthMethod::Pap;
+                            }
+                            lcp::auth::CHAP => {
+                                if opt.data.len() >= 3 && opt.data[2] == lcp::auth::CHAP_MD5 {
+                                    self.auth_method = AuthMethod::ChapMd5;
+                                } else {
+                                    // NAK with CHAP MD5
+                                    nak_options.push((opt.opt_type, vec![0xc2, 0x23, 0x05]));
+                                }
+                            }
+                            _ => {
+                                // NAK with PAP (simpler)
+                                nak_options.push((opt.opt_type, vec![0xc0, 0x23]));
+                            }
+                        }
+                    }
+                }
+                lcp::options::PFC | lcp::options::ACFC => {
+                    // Reject compression options for PPPoE
+                    reject_options.push((opt.opt_type, opt.data.to_vec()));
+                }
+                _ => {
+                    // Reject unknown options
+                    reject_options.push((opt.opt_type, opt.data.to_vec()));
+                }
+            }
+        }
+
+        // Send Configure-Reject if any options rejected
+        if !reject_options.is_empty() {
+            return self.send_lcp_config_reject(lcp.identifier(), &reject_options);
+        }
+
+        // Send Configure-Nak if any options need modification
+        if !nak_options.is_empty() {
+            return self.send_lcp_config_nak(lcp.identifier(), &nak_options);
+        }
+
+        // Send Configure-Ack
+        self.send_lcp_config_ack(lcp)
+    }
+
+    /// Send LCP Configure-Ack
+    fn send_lcp_config_ack(&mut self, lcp: &LcpPacket) -> PppoeClientAction {
+        self.lcp_peer_config_acked = true;
+
+        let ack = LcpBuilder::configure_ack(lcp.identifier())
+            .raw_data(lcp.data())
+            .build();
+
+        let ppp = PppBuilder::lcp().payload(&ack).build();
+        let pppoe = self.wrap_ppp_in_pppoe(&ppp);
+        let frame = self.wrap_session_frame(&pppoe);
+
+        debug!(
+            "PPPoE: Sending LCP Configure-Ack (id={}) on {}",
+            lcp.identifier(),
+            self.interface
+        );
+
+        // Check if LCP is now open
+        if self.lcp_our_config_acked && self.lcp_peer_config_acked {
+            // LCP opened, but we need to send the Ack first
+            // The transition will happen in the next tick or when processing continues
+        }
+
+        PppoeClientAction::SendSession {
+            interface: self.interface.clone(),
+            packet: frame,
+        }
+    }
+
+    /// Send LCP Configure-Nak
+    fn send_lcp_config_nak(&self, identifier: u8, options: &[(u8, Vec<u8>)]) -> PppoeClientAction {
+        let mut builder = LcpBuilder::configure_nak(identifier);
+        for (opt_type, data) in options {
+            builder = builder.add_option(*opt_type, data);
+        }
+        let nak = builder.build();
+
+        let ppp = PppBuilder::lcp().payload(&nak).build();
+        let pppoe = self.wrap_ppp_in_pppoe(&ppp);
+        let frame = self.wrap_session_frame(&pppoe);
+
+        debug!(
+            "PPPoE: Sending LCP Configure-Nak (id={}) on {}",
+            identifier, self.interface
+        );
+
+        PppoeClientAction::SendSession {
+            interface: self.interface.clone(),
+            packet: frame,
+        }
+    }
+
+    /// Send LCP Configure-Reject
+    fn send_lcp_config_reject(
+        &self,
+        identifier: u8,
+        options: &[(u8, Vec<u8>)],
+    ) -> PppoeClientAction {
+        let mut builder = LcpBuilder::configure_reject(identifier);
+        for (opt_type, data) in options {
+            builder = builder.add_option(*opt_type, data);
+        }
+        let reject = builder.build();
+
+        let ppp = PppBuilder::lcp().payload(&reject).build();
+        let pppoe = self.wrap_ppp_in_pppoe(&ppp);
+        let frame = self.wrap_session_frame(&pppoe);
+
+        debug!(
+            "PPPoE: Sending LCP Configure-Reject (id={}) on {}",
+            identifier, self.interface
+        );
+
+        PppoeClientAction::SendSession {
+            interface: self.interface.clone(),
+            packet: frame,
+        }
+    }
+
+    /// Handle LCP Configure-Ack from peer
+    fn handle_lcp_config_ack(&mut self, lcp: &LcpPacket) -> PppoeClientAction {
+        if lcp.identifier() != self.lcp_identifier {
+            debug!("PPPoE: LCP Configure-Ack identifier mismatch");
+            return PppoeClientAction::None;
+        }
+
+        debug!("PPPoE: LCP Configure-Ack received on {}", self.interface);
+        self.lcp_our_config_acked = true;
+
+        self.check_lcp_opened()
+    }
+
+    /// Handle LCP Configure-Nak from peer
+    fn handle_lcp_config_nak(&mut self, _lcp: &LcpPacket) -> PppoeClientAction {
+        debug!("PPPoE: LCP Configure-Nak received on {}", self.interface);
+
+        // Server suggests different values - we'll just retry with same values
+        // In a real implementation, we'd adjust our config
+        self.lcp_identifier = self.lcp_identifier.wrapping_add(1);
+        self.last_sent = Some(Instant::now());
+        self.send_lcp_config_request()
+    }
+
+    /// Handle LCP Configure-Reject from peer
+    fn handle_lcp_config_reject(&mut self, _lcp: &LcpPacket) -> PppoeClientAction {
+        debug!("PPPoE: LCP Configure-Reject received on {}", self.interface);
+
+        // Server rejected some options - for now just retry
+        // In a real implementation, we'd remove rejected options
+        self.lcp_identifier = self.lcp_identifier.wrapping_add(1);
+        self.last_sent = Some(Instant::now());
+        self.send_lcp_config_request()
+    }
+
+    /// Handle LCP Terminate-Request
+    fn handle_lcp_terminate_request(&mut self, lcp: &LcpPacket) -> PppoeClientAction {
+        info!(
+            "PPPoE: LCP Terminate-Request received on {}",
+            self.interface
+        );
+
+        // Send Terminate-Ack
+        let ack = LcpBuilder::terminate_ack(lcp.identifier()).build();
+        let ppp = PppBuilder::lcp().payload(&ack).build();
+        let pppoe = self.wrap_ppp_in_pppoe(&ppp);
+        let frame = self.wrap_session_frame(&pppoe);
+
+        let old_state = self.state;
+        self.reset_state();
+
+        // Return both the Ack and termination notification
+        // For simplicity, we just send the Ack
+        if old_state == PppoeClientState::Opened {
+            // Should also deconfigure interface, but for now just send Ack
+        }
+
+        PppoeClientAction::SendSession {
+            interface: self.interface.clone(),
+            packet: frame,
+        }
+    }
+
+    /// Handle LCP Terminate-Ack
+    fn handle_lcp_terminate_ack(&mut self) -> PppoeClientAction {
+        debug!("PPPoE: LCP Terminate-Ack received on {}", self.interface);
+        let old_state = self.state;
+        self.reset_state();
+
+        if old_state == PppoeClientState::Opened {
+            PppoeClientAction::DeconfigureInterface {
+                interface: self.interface.clone(),
+            }
+        } else {
+            PppoeClientAction::SessionTerminated {
+                interface: self.interface.clone(),
+                reason: "LCP terminated".to_string(),
+            }
+        }
+    }
+
+    /// Handle LCP Echo-Request
+    fn handle_lcp_echo_request(&mut self, lcp: &LcpPacket) -> PppoeClientAction {
+        // Reply with our magic number
+        let reply = LcpBuilder::echo_reply(lcp.identifier(), self.lcp_our_magic).build();
+        let ppp = PppBuilder::lcp().payload(&reply).build();
+        let pppoe = self.wrap_ppp_in_pppoe(&ppp);
+        let frame = self.wrap_session_frame(&pppoe);
+
+        PppoeClientAction::SendSession {
+            interface: self.interface.clone(),
+            packet: frame,
+        }
+    }
+
+    /// Handle LCP Echo-Reply
+    fn handle_lcp_echo_reply(&mut self, lcp: &LcpPacket) -> PppoeClientAction {
+        if lcp.identifier() == self.echo_identifier {
+            self.echo_pending = false;
+            self.echo_failures = 0;
+            debug!("PPPoE: Echo-Reply received on {}", self.interface);
+        }
+        PppoeClientAction::None
+    }
+
+    /// Check if LCP is now opened
+    fn check_lcp_opened(&mut self) -> PppoeClientAction {
+        if self.lcp_our_config_acked && self.lcp_peer_config_acked {
+            info!(
+                "PPPoE: LCP opened (auth={:?}) on {}",
+                self.auth_method, self.interface
+            );
+
+            match self.auth_method {
+                AuthMethod::None => {
+                    // No auth required, go straight to IPCP
+                    self.start_ipcp()
+                }
+                AuthMethod::Pap => {
+                    // Start PAP authentication
+                    self.start_pap()
+                }
+                AuthMethod::ChapMd5 => {
+                    // Wait for CHAP Challenge from server
+                    self.state = PppoeClientState::Authenticating;
+                    self.last_sent = Some(Instant::now());
+                    PppoeClientAction::None
+                }
+            }
+        } else {
+            PppoeClientAction::None
+        }
+    }
+
+    /// Start PAP authentication
+    fn start_pap(&mut self) -> PppoeClientAction {
+        debug!("PPPoE: Starting PAP authentication on {}", self.interface);
+        self.state = PppoeClientState::Authenticating;
+        self.auth_identifier = self.auth_identifier.wrapping_add(1);
+        self.last_sent = Some(Instant::now());
+        self.retries = 0;
+
+        let pap =
+            PapBuilder::authenticate_request(self.auth_identifier, &self.username, &self.password)
+                .build();
+
+        let ppp = PppBuilder::pap().payload(&pap).build();
+        let pppoe = self.wrap_ppp_in_pppoe(&ppp);
+        let frame = self.wrap_session_frame(&pppoe);
+
+        debug!(
+            "PPPoE: Sending PAP Authenticate-Request on {}",
+            self.interface
+        );
+
+        PppoeClientAction::SendSession {
+            interface: self.interface.clone(),
+            packet: frame,
+        }
+    }
+
+    /// Handle PAP packet
+    fn handle_pap(&mut self, payload: &[u8]) -> PppoeClientAction {
+        let pap = match PapPacket::parse(payload) {
+            Ok(p) => p,
+            Err(e) => {
+                debug!("PPPoE: Failed to parse PAP: {}", e);
+                return PppoeClientAction::None;
+            }
+        };
+
+        if pap.is_success() {
+            let msg = pap
+                .message()
+                .and_then(|m| std::str::from_utf8(m).ok())
+                .unwrap_or("");
+            info!(
+                "PPPoE: PAP authentication success: {} on {}",
+                msg, self.interface
+            );
+            self.start_ipcp()
+        } else if pap.is_failure() {
+            let msg = pap
+                .message()
+                .and_then(|m| std::str::from_utf8(m).ok())
+                .unwrap_or("unknown");
+            warn!(
+                "PPPoE: PAP authentication failed: {} on {}",
+                msg, self.interface
+            );
+            self.send_padt(&format!("PAP auth failed: {}", msg))
+        } else {
+            PppoeClientAction::None
+        }
+    }
+
+    /// Handle CHAP packet
+    fn handle_chap(&mut self, payload: &[u8]) -> PppoeClientAction {
+        let chap = match ChapPacket::parse(payload) {
+            Ok(c) => c,
+            Err(e) => {
+                debug!("PPPoE: Failed to parse CHAP: {}", e);
+                return PppoeClientAction::None;
+            }
+        };
+
+        match chap.code() {
+            chap::codes::CHALLENGE => self.handle_chap_challenge(&chap),
+            chap::codes::SUCCESS => self.handle_chap_success(&chap),
+            chap::codes::FAILURE => self.handle_chap_failure(&chap),
+            _ => {
+                debug!("PPPoE: Ignoring CHAP code {}", chap.code());
+                PppoeClientAction::None
+            }
+        }
+    }
+
+    /// Handle CHAP Challenge
+    fn handle_chap_challenge(&mut self, chap: &ChapPacket) -> PppoeClientAction {
+        if self.state != PppoeClientState::Authenticating {
+            debug!("PPPoE: CHAP Challenge in unexpected state {:?}", self.state);
+            return PppoeClientAction::None;
+        }
+
+        let challenge = match chap.value() {
+            Some(v) => v,
+            None => {
+                debug!("PPPoE: CHAP Challenge missing value");
+                return PppoeClientAction::None;
+            }
+        };
+
+        let server_name = chap
+            .name()
+            .and_then(|n| std::str::from_utf8(n).ok())
+            .unwrap_or("server");
+
+        debug!(
+            "PPPoE: CHAP Challenge from {} (id={}) on {}",
+            server_name,
+            chap.identifier(),
+            self.interface
+        );
+
+        // Calculate MD5 response
+        let response = calculate_chap_md5(chap.identifier(), &self.password, challenge);
+
+        let resp_packet =
+            ChapBuilder::response(chap.identifier(), &response, &self.username).build();
+
+        let ppp = PppBuilder::chap().payload(&resp_packet).build();
+        let pppoe = self.wrap_ppp_in_pppoe(&ppp);
+        let frame = self.wrap_session_frame(&pppoe);
+
+        debug!("PPPoE: Sending CHAP Response on {}", self.interface);
+
+        PppoeClientAction::SendSession {
+            interface: self.interface.clone(),
+            packet: frame,
+        }
+    }
+
+    /// Handle CHAP Success
+    fn handle_chap_success(&mut self, chap: &ChapPacket) -> PppoeClientAction {
+        let msg = chap
+            .message()
+            .and_then(|m| std::str::from_utf8(m).ok())
+            .unwrap_or("");
+        info!(
+            "PPPoE: CHAP authentication success: {} on {}",
+            msg, self.interface
+        );
+        self.start_ipcp()
+    }
+
+    /// Handle CHAP Failure
+    fn handle_chap_failure(&mut self, chap: &ChapPacket) -> PppoeClientAction {
+        let msg = chap
+            .message()
+            .and_then(|m| std::str::from_utf8(m).ok())
+            .unwrap_or("unknown");
+        warn!(
+            "PPPoE: CHAP authentication failed: {} on {}",
+            msg, self.interface
+        );
+        self.send_padt(&format!("CHAP auth failed: {}", msg))
+    }
+
+    /// Start IPCP negotiation
+    fn start_ipcp(&mut self) -> PppoeClientAction {
+        debug!("PPPoE: Starting IPCP negotiation on {}", self.interface);
+        self.state = PppoeClientState::IpcpNegotiating;
+        self.ipcp_identifier = self.ipcp_identifier.wrapping_add(1);
+        self.ipcp_our_config_acked = false;
+        self.ipcp_peer_config_acked = false;
+        self.last_sent = Some(Instant::now());
+        self.retries = 0;
+
+        self.send_ipcp_config_request()
+    }
+
+    /// Send IPCP Configure-Request
+    fn send_ipcp_config_request(&mut self) -> PppoeClientAction {
+        let ipcp = IpcpBuilder::configure_request(self.ipcp_identifier)
+            .ip_address(self.assigned_ip)
+            .primary_dns(self.dns1)
+            .secondary_dns(self.dns2)
+            .build();
+
+        let ppp = PppBuilder::ipcp().payload(&ipcp).build();
+        let pppoe = self.wrap_ppp_in_pppoe(&ppp);
+        let frame = self.wrap_session_frame(&pppoe);
+
+        debug!(
+            "PPPoE: Sending IPCP Configure-Request (id={}) on {}",
+            self.ipcp_identifier, self.interface
+        );
+
+        PppoeClientAction::SendSession {
+            interface: self.interface.clone(),
+            packet: frame,
+        }
+    }
+
+    /// Handle IPCP packet
+    fn handle_ipcp(&mut self, payload: &[u8]) -> PppoeClientAction {
+        let ipcp = match IpcpPacket::parse(payload) {
+            Ok(i) => i,
+            Err(e) => {
+                debug!("PPPoE: Failed to parse IPCP: {}", e);
+                return PppoeClientAction::None;
+            }
+        };
+
+        debug!(
+            "PPPoE: Received IPCP code={} id={} on {}",
+            ipcp.code(),
+            ipcp.identifier(),
+            self.interface
+        );
+
+        match ipcp.code() {
+            ipcp::codes::CONFIGURE_REQUEST => self.handle_ipcp_config_request(&ipcp),
+            ipcp::codes::CONFIGURE_ACK => self.handle_ipcp_config_ack(&ipcp),
+            ipcp::codes::CONFIGURE_NAK => self.handle_ipcp_config_nak(&ipcp),
+            ipcp::codes::CONFIGURE_REJECT => self.handle_ipcp_config_reject(&ipcp),
+            _ => {
+                debug!("PPPoE: Ignoring IPCP code {}", ipcp.code());
+                PppoeClientAction::None
+            }
+        }
+    }
+
+    /// Handle IPCP Configure-Request from peer
+    fn handle_ipcp_config_request(&mut self, ipcp: &IpcpPacket) -> PppoeClientAction {
+        // Server wants to configure its side - we just accept
+        // Store peer's IP if provided
+        if let Some(ip) = ipcp.ip_address() {
+            self.peer_ip = ip;
+        }
+
+        self.ipcp_peer_config_acked = true;
+
+        let ack = IpcpBuilder::configure_ack(ipcp.identifier())
+            .raw_data(ipcp.data())
+            .build();
+
+        let ppp = PppBuilder::ipcp().payload(&ack).build();
+        let pppoe = self.wrap_ppp_in_pppoe(&ppp);
+        let frame = self.wrap_session_frame(&pppoe);
+
+        debug!(
+            "PPPoE: Sending IPCP Configure-Ack (id={}) on {}",
+            ipcp.identifier(),
+            self.interface
+        );
+
+        // Check if IPCP is now open
+        if self.ipcp_our_config_acked && self.ipcp_peer_config_acked {
+            // Will open session after sending this Ack
+        }
+
+        PppoeClientAction::SendSession {
+            interface: self.interface.clone(),
+            packet: frame,
+        }
+    }
+
+    /// Handle IPCP Configure-Ack from peer
+    fn handle_ipcp_config_ack(&mut self, ipcp: &IpcpPacket) -> PppoeClientAction {
+        if ipcp.identifier() != self.ipcp_identifier {
+            debug!("PPPoE: IPCP Configure-Ack identifier mismatch");
+            return PppoeClientAction::None;
+        }
+
+        debug!("PPPoE: IPCP Configure-Ack received on {}", self.interface);
+        self.ipcp_our_config_acked = true;
+
+        self.check_ipcp_opened()
+    }
+
+    /// Handle IPCP Configure-Nak from peer
+    fn handle_ipcp_config_nak(&mut self, ipcp: &IpcpPacket) -> PppoeClientAction {
+        debug!("PPPoE: IPCP Configure-Nak received on {}", self.interface);
+
+        // Server suggests different values - accept them
+        if let Some(ip) = ipcp.ip_address() {
+            self.assigned_ip = ip;
+            debug!("PPPoE: Server suggests IP: {}", ip);
+        }
+        if let Some(dns) = ipcp.primary_dns() {
+            self.dns1 = dns;
+            debug!("PPPoE: Server suggests DNS1: {}", dns);
+        }
+        if let Some(dns) = ipcp.secondary_dns() {
+            self.dns2 = dns;
+            debug!("PPPoE: Server suggests DNS2: {}", dns);
+        }
+
+        // Send new request with suggested values
+        self.ipcp_identifier = self.ipcp_identifier.wrapping_add(1);
+        self.last_sent = Some(Instant::now());
+        self.send_ipcp_config_request()
+    }
+
+    /// Handle IPCP Configure-Reject from peer
+    fn handle_ipcp_config_reject(&mut self, _ipcp: &IpcpPacket) -> PppoeClientAction {
+        debug!(
+            "PPPoE: IPCP Configure-Reject received on {}",
+            self.interface
+        );
+
+        // Server rejected some options - for now just retry
+        self.ipcp_identifier = self.ipcp_identifier.wrapping_add(1);
+        self.last_sent = Some(Instant::now());
+        self.send_ipcp_config_request()
+    }
+
+    /// Check if IPCP is now opened
+    fn check_ipcp_opened(&mut self) -> PppoeClientAction {
+        if self.ipcp_our_config_acked && self.ipcp_peer_config_acked {
+            info!(
+                "PPPoE: Session opened - IP={}, DNS={},{} on {}",
+                self.assigned_ip, self.dns1, self.dns2, self.interface
+            );
+
+            self.state = PppoeClientState::Opened;
+            self.session = Some(PppoeSession {
+                ip_addr: self.assigned_ip,
+                peer_ip: self.peer_ip,
+                dns1: if self.dns1.is_unspecified() {
+                    None
+                } else {
+                    Some(self.dns1)
+                },
+                dns2: if self.dns2.is_unspecified() {
+                    None
+                } else {
+                    Some(self.dns2)
+                },
+                session_id: self.session_id,
+                established_at: Instant::now(),
+            });
+
+            self.last_echo_sent = None;
+            self.echo_pending = false;
+            self.echo_failures = 0;
+
+            let mut dns_servers = Vec::new();
+            if !self.dns1.is_unspecified() {
+                dns_servers.push(self.dns1);
+            }
+            if !self.dns2.is_unspecified() {
+                dns_servers.push(self.dns2);
+            }
+
+            PppoeClientAction::ConfigureInterface {
+                interface: self.interface.clone(),
+                ip_addr: self.assigned_ip,
+                peer_ip: self.peer_ip,
+                dns_servers,
+            }
+        } else {
+            PppoeClientAction::None
+        }
+    }
+
+    /// Timer tick - handle retransmits and keepalives
+    pub fn tick(&mut self) -> PppoeClientAction {
+        let now = Instant::now();
+
+        match self.state {
+            PppoeClientState::Init => PppoeClientAction::None,
+
+            PppoeClientState::PadiSent | PppoeClientState::PadrSent => {
+                if let Some(last) = self.last_sent {
+                    if now.duration_since(last) >= Duration::from_secs(DISCOVERY_TIMEOUT_SECS) {
+                        self.retries += 1;
+                        if self.retries > MAX_RETRIES {
+                            warn!("PPPoE: Discovery timeout on {}", self.interface);
+                            return PppoeClientAction::SessionTerminated {
+                                interface: self.interface.clone(),
+                                reason: "Discovery timeout".to_string(),
+                            };
+                        }
+                        debug!(
+                            "PPPoE: Retransmitting (attempt {}) on {}",
+                            self.retries, self.interface
+                        );
+                        return if self.state == PppoeClientState::PadiSent {
+                            self.send_padi()
+                        } else {
+                            self.send_padr()
+                        };
+                    }
+                }
+                PppoeClientAction::None
+            }
+
+            PppoeClientState::LcpNegotiating => {
+                if let Some(last) = self.last_sent {
+                    if now.duration_since(last) >= Duration::from_secs(LCP_TIMEOUT_SECS) {
+                        self.retries += 1;
+                        if self.retries > MAX_RETRIES {
+                            warn!("PPPoE: LCP timeout on {}", self.interface);
+                            return self.send_padt("LCP timeout");
+                        }
+                        self.lcp_identifier = self.lcp_identifier.wrapping_add(1);
+                        self.last_sent = Some(now);
+                        return self.send_lcp_config_request();
+                    }
+                }
+                PppoeClientAction::None
+            }
+
+            PppoeClientState::Authenticating => {
+                if let Some(last) = self.last_sent {
+                    if now.duration_since(last) >= Duration::from_secs(AUTH_TIMEOUT_SECS) {
+                        self.retries += 1;
+                        if self.retries > MAX_RETRIES {
+                            warn!("PPPoE: Authentication timeout on {}", self.interface);
+                            return self.send_padt("Auth timeout");
+                        }
+                        if self.auth_method == AuthMethod::Pap {
+                            return self.start_pap();
+                        }
+                        // For CHAP, wait for server challenge
+                    }
+                }
+                PppoeClientAction::None
+            }
+
+            PppoeClientState::IpcpNegotiating => {
+                if let Some(last) = self.last_sent {
+                    if now.duration_since(last) >= Duration::from_secs(LCP_TIMEOUT_SECS) {
+                        self.retries += 1;
+                        if self.retries > MAX_RETRIES {
+                            warn!("PPPoE: IPCP timeout on {}", self.interface);
+                            return self.send_padt("IPCP timeout");
+                        }
+                        self.ipcp_identifier = self.ipcp_identifier.wrapping_add(1);
+                        self.last_sent = Some(now);
+                        return self.send_ipcp_config_request();
+                    }
+                }
+                PppoeClientAction::None
+            }
+
+            PppoeClientState::Opened => {
+                // Send LCP Echo for keepalive
+                let should_send_echo = match self.last_echo_sent {
+                    None => true,
+                    Some(last) => {
+                        now.duration_since(last) >= Duration::from_secs(ECHO_INTERVAL_SECS)
+                    }
+                };
+
+                if should_send_echo {
+                    if self.echo_pending {
+                        self.echo_failures += 1;
+                        if self.echo_failures >= ECHO_FAILURE_COUNT {
+                            warn!(
+                                "PPPoE: Echo timeout ({} failures) on {}",
+                                self.echo_failures, self.interface
+                            );
+                            return self.send_padt("Echo timeout");
+                        }
+                    }
+
+                    self.echo_identifier = self.echo_identifier.wrapping_add(1);
+                    self.echo_pending = true;
+                    self.last_echo_sent = Some(now);
+
+                    let echo =
+                        LcpBuilder::echo_request(self.echo_identifier, self.lcp_our_magic).build();
+                    let ppp = PppBuilder::lcp().payload(&echo).build();
+                    let pppoe = self.wrap_ppp_in_pppoe(&ppp);
+                    let frame = self.wrap_session_frame(&pppoe);
+
+                    return PppoeClientAction::SendSession {
+                        interface: self.interface.clone(),
+                        packet: frame,
+                    };
+                }
+
+                PppoeClientAction::None
+            }
+
+            PppoeClientState::Terminating => {
+                // Already sent PADT, just wait
+                PppoeClientAction::None
+            }
+        }
+    }
+
+    /// Gracefully terminate the session
+    pub fn terminate(&mut self) -> PppoeClientAction {
+        info!("PPPoE: Terminating session on {}", self.interface);
+        self.send_padt("user request")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_test_client() -> PppoeClient {
+        PppoeClient::new(
+            "eth0".to_string(),
+            MacAddr([0x00, 0x11, 0x22, 0x33, 0x44, 0x55]),
+            "testuser".to_string(),
+            "testpass".to_string(),
+            None,
+        )
+    }
+
+    #[test]
+    fn test_initial_state() {
+        let client = create_test_client();
+        assert_eq!(client.state(), PppoeClientState::Init);
+        assert_eq!(client.session_id(), 0);
+    }
+
+    #[test]
+    fn test_start_sends_padi() {
+        let mut client = create_test_client();
+        let action = client.start();
+
+        assert_eq!(client.state(), PppoeClientState::PadiSent);
+        match action {
+            PppoeClientAction::SendDiscovery { interface, packet } => {
+                assert_eq!(interface, "eth0");
+                assert!(!packet.is_empty());
+            }
+            _ => panic!("Expected SendDiscovery action"),
+        }
+    }
+
+    #[test]
+    fn test_pado_transitions_to_padr_sent() {
+        let mut client = create_test_client();
+        client.start();
+
+        // Simulate PADO
+        let pado = PppoeBuilder::discovery()
+            .code(pppoe_codes::PADO)
+            .host_uniq(&client.host_uniq)
+            .ac_cookie(&[0x01, 0x02, 0x03, 0x04])
+            .build();
+
+        let pppoe = PppoeFrame::parse(&pado).unwrap();
+        let ac_mac = MacAddr([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+        let action = client.process_discovery(ac_mac, &pppoe);
+
+        assert_eq!(client.state(), PppoeClientState::PadrSent);
+        assert_eq!(client.ac_mac, ac_mac);
+        match action {
+            PppoeClientAction::SendDiscovery { .. } => {}
+            _ => panic!("Expected SendDiscovery action for PADR"),
+        }
+    }
+
+    #[test]
+    fn test_pads_starts_lcp() {
+        let mut client = create_test_client();
+        client.start();
+
+        // Move to PadrSent state
+        client.state = PppoeClientState::PadrSent;
+        client.ac_mac = MacAddr([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+
+        // Simulate PADS
+        let pads = PppoeBuilder::discovery()
+            .code(pppoe_codes::PADS)
+            .session_id(0x1234)
+            .build();
+
+        let pppoe = PppoeFrame::parse(&pads).unwrap();
+        let action = client.process_discovery(MacAddr::ZERO, &pppoe);
+
+        assert_eq!(client.state(), PppoeClientState::LcpNegotiating);
+        assert_eq!(client.session_id(), 0x1234);
+        match action {
+            PppoeClientAction::SendSession { .. } => {}
+            _ => panic!("Expected SendSession action for LCP"),
+        }
+    }
+
+    #[test]
+    fn test_padt_resets_state() {
+        let mut client = create_test_client();
+        client.state = PppoeClientState::Opened;
+        client.session_id = 0x1234;
+
+        let padt = PppoeBuilder::discovery()
+            .code(pppoe_codes::PADT)
+            .session_id(0x1234)
+            .build();
+
+        let pppoe = PppoeFrame::parse(&padt).unwrap();
+        let action = client.process_discovery(MacAddr::ZERO, &pppoe);
+
+        assert_eq!(client.state(), PppoeClientState::Init);
+        match action {
+            PppoeClientAction::DeconfigureInterface { .. } => {}
+            _ => panic!("Expected DeconfigureInterface action"),
+        }
+    }
+
+    #[test]
+    fn test_tick_retransmit() {
+        let mut client = create_test_client();
+        client.start();
+
+        // Set last_sent to past
+        client.last_sent = Some(Instant::now() - Duration::from_secs(10));
+
+        let action = client.tick();
+        match action {
+            PppoeClientAction::SendDiscovery { .. } => {}
+            _ => panic!("Expected SendDiscovery action for retransmit"),
+        }
+        assert_eq!(client.retries, 1);
+    }
+
+    #[test]
+    fn test_terminate() {
+        let mut client = create_test_client();
+        client.state = PppoeClientState::Opened;
+        client.session_id = 0x1234;
+        client.ac_mac = MacAddr([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+
+        let action = client.terminate();
+
+        assert_eq!(client.state(), PppoeClientState::Terminating);
+        match action {
+            PppoeClientAction::SendDiscovery { .. } => {}
+            _ => panic!("Expected SendDiscovery action for PADT"),
+        }
+    }
+}

--- a/src/dataplane/routing.rs
+++ b/src/dataplane/routing.rs
@@ -106,6 +106,11 @@ impl RoutingTable {
         self.routes.retain(|r| r.source != source);
     }
 
+    /// Remove all routes using a specific interface
+    pub fn remove_by_interface(&mut self, interface: &str) {
+        self.routes.retain(|r| r.interface != interface);
+    }
+
     /// Load static routes from config
     pub fn load_static_routes(&mut self, config: &RoutingConfig) {
         for static_route in &config.static_routes {

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,15 +114,20 @@ fn cmd_run(lock_path: &PathBuf) -> Result<(), String> {
         let metrics = Arc::new(MetricsRegistry::new());
         let mut router = Router::new(metrics.clone());
 
-        // Track interfaces that need DHCP client
+        // Track interfaces that need DHCP or PPPoE client
         let mut dhcp_client_interfaces: Vec<String> = Vec::new();
+        let mut pppoe_client_interfaces: Vec<String> = Vec::new();
 
         // Configure interfaces from lock file
         for (name, iface_lock) in &lock.interfaces {
-            // Parse address if present (skip for DHCP addressing)
+            // Parse address if present (skip for DHCP/PPPoE addressing)
             let (ip_addr, prefix_len) = if iface_lock.addressing == "dhcp" {
                 // DHCP interface: no static IP
                 dhcp_client_interfaces.push(name.clone());
+                (None, None)
+            } else if iface_lock.addressing == "pppoe" {
+                // PPPoE interface: no static IP
+                pppoe_client_interfaces.push(name.clone());
                 (None, None)
             } else if let Some(ref addr) = iface_lock.address {
                 parse_cidr(addr)?
@@ -254,6 +259,33 @@ fn cmd_run(lock_path: &PathBuf) -> Result<(), String> {
                     "DNS forwarder enabled with {} upstream servers, cache_size={}",
                     dns_lock.upstream.len(),
                     dns_lock.cache_size
+                );
+            }
+        }
+
+        // Enable PPPoE clients for interfaces with addressing=pppoe
+        for iface_name in &pppoe_client_interfaces {
+            // Get PPPoE config from lock file
+            if let Some(pppoe_config) = lock.pppoe.get(iface_name) {
+                info!("Starting PPPoE client on {}...", iface_name);
+                let packets = router.enable_pppoe_client(
+                    iface_name,
+                    pppoe_config.username.clone(),
+                    pppoe_config.password.clone(),
+                    pppoe_config.service_name.clone(),
+                );
+                // Send initial PADI packets
+                for (out_iface, frame) in packets {
+                    if let Some(iface) = router.get_interface_mut(&out_iface) {
+                        if let Err(e) = iface.socket.send(&frame).await {
+                            warn!("Failed to send PPPoE PADI on {}: {}", out_iface, e);
+                        }
+                    }
+                }
+            } else {
+                warn!(
+                    "Interface {} has addressing=pppoe but no [pppoe.{}] section in config",
+                    iface_name, iface_name
                 );
             }
         }

--- a/src/protocol/chap.rs
+++ b/src/protocol/chap.rs
@@ -1,0 +1,506 @@
+//! CHAP protocol - RFC 1994
+//!
+//! Challenge Handshake Authentication Protocol for secure authentication.
+
+use crate::{Error, Result};
+
+/// CHAP header size (code + identifier + length)
+pub const CHAP_HEADER_SIZE: usize = 4;
+
+/// CHAP packet codes
+pub mod codes {
+    /// Challenge from authenticator
+    pub const CHALLENGE: u8 = 1;
+    /// Response from peer
+    pub const RESPONSE: u8 = 2;
+    /// Authentication success
+    pub const SUCCESS: u8 = 3;
+    /// Authentication failure
+    pub const FAILURE: u8 = 4;
+}
+
+/// CHAP algorithms
+pub mod algorithms {
+    /// MD5 (most common)
+    pub const MD5: u8 = 5;
+}
+
+/// Parsed CHAP packet (zero-copy reference)
+#[derive(Debug)]
+pub struct ChapPacket<'a> {
+    buffer: &'a [u8],
+}
+
+impl<'a> ChapPacket<'a> {
+    /// Parse CHAP packet from buffer
+    pub fn parse(buffer: &'a [u8]) -> Result<Self> {
+        if buffer.len() < CHAP_HEADER_SIZE {
+            return Err(Error::Parse("CHAP packet too short".into()));
+        }
+
+        let packet = Self { buffer };
+
+        let length = packet.length() as usize;
+        if length < CHAP_HEADER_SIZE {
+            return Err(Error::Parse("CHAP length too small".into()));
+        }
+        if buffer.len() < length {
+            return Err(Error::Parse("CHAP packet truncated".into()));
+        }
+
+        Ok(packet)
+    }
+
+    /// Code field
+    pub fn code(&self) -> u8 {
+        self.buffer[0]
+    }
+
+    /// Identifier field
+    pub fn identifier(&self) -> u8 {
+        self.buffer[1]
+    }
+
+    /// Length field
+    pub fn length(&self) -> u16 {
+        u16::from_be_bytes([self.buffer[2], self.buffer[3]])
+    }
+
+    /// Data field
+    pub fn data(&self) -> &[u8] {
+        let len = self.length() as usize;
+        &self.buffer[CHAP_HEADER_SIZE..len]
+    }
+
+    /// Get Challenge/Response value
+    /// Format for Challenge/Response: Value-Size (1 byte) + Value + Name
+    pub fn value(&self) -> Option<&[u8]> {
+        let code = self.code();
+        if code != codes::CHALLENGE && code != codes::RESPONSE {
+            return None;
+        }
+        let data = self.data();
+        if data.is_empty() {
+            return None;
+        }
+        let value_size = data[0] as usize;
+        if data.len() < 1 + value_size {
+            return None;
+        }
+        Some(&data[1..1 + value_size])
+    }
+
+    /// Get Name from Challenge/Response
+    /// Format: Value-Size (1) + Value + Name (rest of data)
+    pub fn name(&self) -> Option<&[u8]> {
+        let code = self.code();
+        if code != codes::CHALLENGE && code != codes::RESPONSE {
+            return None;
+        }
+        let data = self.data();
+        if data.is_empty() {
+            return None;
+        }
+        let value_size = data[0] as usize;
+        if data.len() < 1 + value_size {
+            return None;
+        }
+        Some(&data[1 + value_size..])
+    }
+
+    /// Get message from Success/Failure
+    pub fn message(&self) -> Option<&[u8]> {
+        let code = self.code();
+        if code != codes::SUCCESS && code != codes::FAILURE {
+            return None;
+        }
+        Some(self.data())
+    }
+
+    /// Check if this is a challenge
+    pub fn is_challenge(&self) -> bool {
+        self.code() == codes::CHALLENGE
+    }
+
+    /// Check if this is an authentication success
+    pub fn is_success(&self) -> bool {
+        self.code() == codes::SUCCESS
+    }
+
+    /// Check if this is an authentication failure
+    pub fn is_failure(&self) -> bool {
+        self.code() == codes::FAILURE
+    }
+
+    /// Get the raw buffer
+    pub fn as_bytes(&self) -> &[u8] {
+        let len = self.length() as usize;
+        &self.buffer[..len]
+    }
+}
+
+/// Calculate CHAP-MD5 response
+///
+/// response = MD5(identifier + password + challenge)
+pub fn calculate_chap_md5(identifier: u8, password: &str, challenge: &[u8]) -> [u8; 16] {
+    // MD5 algorithm: MD5(ID || Secret || Challenge)
+    md5_hash(identifier, password.as_bytes(), challenge)
+}
+
+/// Simple MD5 implementation for CHAP
+/// MD5(ID || Secret || Challenge)
+fn md5_hash(id: u8, secret: &[u8], challenge: &[u8]) -> [u8; 16] {
+    // MD5 implementation following RFC 1321
+    let mut input = Vec::with_capacity(1 + secret.len() + challenge.len());
+    input.push(id);
+    input.extend_from_slice(secret);
+    input.extend_from_slice(challenge);
+
+    md5_compute(&input)
+}
+
+/// MD5 hash computation (RFC 1321)
+fn md5_compute(message: &[u8]) -> [u8; 16] {
+    // Initial hash values
+    let mut a0: u32 = 0x67452301;
+    let mut b0: u32 = 0xefcdab89;
+    let mut c0: u32 = 0x98badcfe;
+    let mut d0: u32 = 0x10325476;
+
+    // Pre-computed shift amounts
+    const S: [u32; 64] = [
+        7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 5, 9, 14, 20, 5, 9, 14, 20, 5,
+        9, 14, 20, 5, 9, 14, 20, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 6, 10,
+        15, 21, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21,
+    ];
+
+    // Pre-computed constants (floor(2^32 * abs(sin(i+1))))
+    const K: [u32; 64] = [
+        0xd76aa478, 0xe8c7b756, 0x242070db, 0xc1bdceee, 0xf57c0faf, 0x4787c62a, 0xa8304613,
+        0xfd469501, 0x698098d8, 0x8b44f7af, 0xffff5bb1, 0x895cd7be, 0x6b901122, 0xfd987193,
+        0xa679438e, 0x49b40821, 0xf61e2562, 0xc040b340, 0x265e5a51, 0xe9b6c7aa, 0xd62f105d,
+        0x02441453, 0xd8a1e681, 0xe7d3fbc8, 0x21e1cde6, 0xc33707d6, 0xf4d50d87, 0x455a14ed,
+        0xa9e3e905, 0xfcefa3f8, 0x676f02d9, 0x8d2a4c8a, 0xfffa3942, 0x8771f681, 0x6d9d6122,
+        0xfde5380c, 0xa4beea44, 0x4bdecfa9, 0xf6bb4b60, 0xbebfbc70, 0x289b7ec6, 0xeaa127fa,
+        0xd4ef3085, 0x04881d05, 0xd9d4d039, 0xe6db99e5, 0x1fa27cf8, 0xc4ac5665, 0xf4292244,
+        0x432aff97, 0xab9423a7, 0xfc93a039, 0x655b59c3, 0x8f0ccc92, 0xffeff47d, 0x85845dd1,
+        0x6fa87e4f, 0xfe2ce6e0, 0xa3014314, 0x4e0811a1, 0xf7537e82, 0xbd3af235, 0x2ad7d2bb,
+        0xeb86d391,
+    ];
+
+    // Pad message
+    let original_len_bits = (message.len() as u64) * 8;
+    let mut padded = message.to_vec();
+    padded.push(0x80);
+    while (padded.len() % 64) != 56 {
+        padded.push(0);
+    }
+    padded.extend_from_slice(&original_len_bits.to_le_bytes());
+
+    // Process each 512-bit block
+    for chunk in padded.chunks(64) {
+        let mut m = [0u32; 16];
+        for (i, word) in chunk.chunks(4).enumerate() {
+            m[i] = u32::from_le_bytes([word[0], word[1], word[2], word[3]]);
+        }
+
+        let mut a = a0;
+        let mut b = b0;
+        let mut c = c0;
+        let mut d = d0;
+
+        for i in 0..64 {
+            let (f, g) = match i {
+                0..=15 => ((b & c) | ((!b) & d), i),
+                16..=31 => ((d & b) | ((!d) & c), (5 * i + 1) % 16),
+                32..=47 => (b ^ c ^ d, (3 * i + 5) % 16),
+                _ => (c ^ (b | (!d)), (7 * i) % 16),
+            };
+
+            let f = f.wrapping_add(a).wrapping_add(K[i]).wrapping_add(m[g]);
+            a = d;
+            d = c;
+            c = b;
+            b = b.wrapping_add(f.rotate_left(S[i]));
+        }
+
+        a0 = a0.wrapping_add(a);
+        b0 = b0.wrapping_add(b);
+        c0 = c0.wrapping_add(c);
+        d0 = d0.wrapping_add(d);
+    }
+
+    let mut result = [0u8; 16];
+    result[0..4].copy_from_slice(&a0.to_le_bytes());
+    result[4..8].copy_from_slice(&b0.to_le_bytes());
+    result[8..12].copy_from_slice(&c0.to_le_bytes());
+    result[12..16].copy_from_slice(&d0.to_le_bytes());
+    result
+}
+
+/// Builder for CHAP packets
+#[derive(Debug, Default)]
+pub struct ChapBuilder {
+    code: u8,
+    identifier: u8,
+    data: Vec<u8>,
+}
+
+impl ChapBuilder {
+    /// Create a new CHAP packet builder
+    pub fn new(code: u8, identifier: u8) -> Self {
+        Self {
+            code,
+            identifier,
+            data: Vec::new(),
+        }
+    }
+
+    /// Create Challenge builder (for testing/server side)
+    pub fn challenge(identifier: u8, challenge_value: &[u8], name: &str) -> Self {
+        let mut builder = Self::new(codes::CHALLENGE, identifier);
+        builder.data.push(challenge_value.len() as u8);
+        builder.data.extend_from_slice(challenge_value);
+        builder.data.extend_from_slice(name.as_bytes());
+        builder
+    }
+
+    /// Create Response builder
+    pub fn response(identifier: u8, response_value: &[u8], name: &str) -> Self {
+        let mut builder = Self::new(codes::RESPONSE, identifier);
+        builder.data.push(response_value.len() as u8);
+        builder.data.extend_from_slice(response_value);
+        builder.data.extend_from_slice(name.as_bytes());
+        builder
+    }
+
+    /// Create Success builder (for testing/server side)
+    pub fn success(identifier: u8, message: &str) -> Self {
+        let mut builder = Self::new(codes::SUCCESS, identifier);
+        builder.data.extend_from_slice(message.as_bytes());
+        builder
+    }
+
+    /// Create Failure builder (for testing/server side)
+    pub fn failure(identifier: u8, message: &str) -> Self {
+        let mut builder = Self::new(codes::FAILURE, identifier);
+        builder.data.extend_from_slice(message.as_bytes());
+        builder
+    }
+
+    /// Build the CHAP packet
+    pub fn build(self) -> Vec<u8> {
+        let length = (CHAP_HEADER_SIZE + self.data.len()) as u16;
+        let mut packet = Vec::with_capacity(length as usize);
+
+        packet.push(self.code);
+        packet.push(self.identifier);
+        packet.extend_from_slice(&length.to_be_bytes());
+        packet.extend_from_slice(&self.data);
+
+        packet
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_challenge() {
+        // CHAP Challenge: value=[0x01,0x02,0x03,0x04], name="server"
+        let data = [
+            0x01, // Code: Challenge
+            0x01, // Identifier
+            0x00, 0x0f, // Length=15
+            0x04, // Value size=4
+            0x01, 0x02, 0x03, 0x04, // Challenge value
+            b's', b'e', b'r', b'v', b'e', b'r', // Name
+        ];
+
+        let packet = ChapPacket::parse(&data).unwrap();
+        assert_eq!(packet.code(), codes::CHALLENGE);
+        assert!(packet.is_challenge());
+        assert_eq!(packet.identifier(), 1);
+        assert_eq!(packet.value(), Some([0x01, 0x02, 0x03, 0x04].as_slice()));
+        assert_eq!(packet.name(), Some(b"server".as_slice()));
+    }
+
+    #[test]
+    fn test_parse_response() {
+        // CHAP Response with MD5 hash
+        let data = [
+            0x02, // Code: Response
+            0x01, // Identifier
+            0x00, 0x19, // Length=25
+            0x10, // Value size=16 (MD5)
+            // 16 bytes MD5 hash
+            0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+            0x88, 0x99, b'u', b's', b'e', b'r', // Name
+        ];
+
+        let packet = ChapPacket::parse(&data).unwrap();
+        assert_eq!(packet.code(), codes::RESPONSE);
+        assert_eq!(packet.value().unwrap().len(), 16);
+        assert_eq!(packet.name(), Some(b"user".as_slice()));
+    }
+
+    #[test]
+    fn test_parse_success() {
+        let data = [
+            0x03, // Code: Success
+            0x01, // Identifier
+            0x00, 0x0e, // Length=14
+            b'W', b'e', b'l', b'c', b'o', b'm', b'e', b'!', b'!', b'!',
+        ];
+
+        let packet = ChapPacket::parse(&data).unwrap();
+        assert!(packet.is_success());
+        assert!(!packet.is_failure());
+        assert_eq!(packet.message(), Some(b"Welcome!!!".as_slice()));
+    }
+
+    #[test]
+    fn test_parse_failure() {
+        let data = [
+            0x04, // Code: Failure
+            0x01, // Identifier
+            0x00, 0x08, // Length=8
+            b'F', b'A', b'I', b'L',
+        ];
+
+        let packet = ChapPacket::parse(&data).unwrap();
+        assert!(!packet.is_success());
+        assert!(packet.is_failure());
+        assert_eq!(packet.message(), Some(b"FAIL".as_slice()));
+    }
+
+    #[test]
+    fn test_build_challenge() {
+        let challenge = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+        let packet = ChapBuilder::challenge(1, &challenge, "myserver").build();
+
+        let parsed = ChapPacket::parse(&packet).unwrap();
+        assert!(parsed.is_challenge());
+        assert_eq!(parsed.identifier(), 1);
+        assert_eq!(parsed.value(), Some(challenge.as_slice()));
+        assert_eq!(parsed.name(), Some(b"myserver".as_slice()));
+    }
+
+    #[test]
+    fn test_build_response() {
+        let response_hash = [0xaa; 16]; // Simulated MD5 hash
+        let packet = ChapBuilder::response(1, &response_hash, "myuser").build();
+
+        let parsed = ChapPacket::parse(&packet).unwrap();
+        assert_eq!(parsed.code(), codes::RESPONSE);
+        assert_eq!(parsed.value(), Some(response_hash.as_slice()));
+        assert_eq!(parsed.name(), Some(b"myuser".as_slice()));
+    }
+
+    #[test]
+    fn test_build_success() {
+        let packet = ChapBuilder::success(1, "Auth OK").build();
+
+        let parsed = ChapPacket::parse(&packet).unwrap();
+        assert!(parsed.is_success());
+        assert_eq!(parsed.message(), Some(b"Auth OK".as_slice()));
+    }
+
+    #[test]
+    fn test_build_failure() {
+        let packet = ChapBuilder::failure(1, "Bad password").build();
+
+        let parsed = ChapPacket::parse(&packet).unwrap();
+        assert!(parsed.is_failure());
+        assert_eq!(parsed.message(), Some(b"Bad password".as_slice()));
+    }
+
+    #[test]
+    fn test_calculate_chap_md5() {
+        // Test vector: ID=1, password="password", challenge=[0x01,0x02,0x03,0x04]
+        let challenge = [0x01, 0x02, 0x03, 0x04];
+        let result = calculate_chap_md5(1, "password", &challenge);
+
+        // The result should be deterministic
+        let result2 = calculate_chap_md5(1, "password", &challenge);
+        assert_eq!(result, result2);
+
+        // Different inputs should produce different outputs
+        let result3 = calculate_chap_md5(2, "password", &challenge);
+        assert_ne!(result, result3);
+
+        let result4 = calculate_chap_md5(1, "different", &challenge);
+        assert_ne!(result, result4);
+    }
+
+    #[test]
+    fn test_md5_known_value() {
+        // MD5("") = d41d8cd98f00b204e9800998ecf8427e
+        let result = md5_compute(b"");
+        assert_eq!(
+            result,
+            [
+                0xd4, 0x1d, 0x8c, 0xd9, 0x8f, 0x00, 0xb2, 0x04, 0xe9, 0x80, 0x09, 0x98, 0xec, 0xf8,
+                0x42, 0x7e
+            ]
+        );
+
+        // MD5("a") = 0cc175b9c0f1b6a831c399e269772661
+        let result = md5_compute(b"a");
+        assert_eq!(
+            result,
+            [
+                0x0c, 0xc1, 0x75, 0xb9, 0xc0, 0xf1, 0xb6, 0xa8, 0x31, 0xc3, 0x99, 0xe2, 0x69, 0x77,
+                0x26, 0x61
+            ]
+        );
+
+        // MD5("abc") = 900150983cd24fb0d6963f7d28e17f72
+        let result = md5_compute(b"abc");
+        assert_eq!(
+            result,
+            [
+                0x90, 0x01, 0x50, 0x98, 0x3c, 0xd2, 0x4f, 0xb0, 0xd6, 0x96, 0x3f, 0x7d, 0x28, 0xe1,
+                0x7f, 0x72
+            ]
+        );
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let challenge = [0xde, 0xad, 0xbe, 0xef];
+        let original = ChapBuilder::challenge(42, &challenge, "test-server").build();
+
+        let parsed = ChapPacket::parse(&original).unwrap();
+        assert_eq!(parsed.as_bytes(), original.as_slice());
+    }
+
+    #[test]
+    fn test_parse_too_short() {
+        let data = [0x01, 0x01, 0x00];
+        assert!(ChapPacket::parse(&data).is_err());
+    }
+
+    #[test]
+    fn test_parse_truncated() {
+        let data = [0x01, 0x01, 0x00, 0x10]; // Length=16 but only 4 bytes
+        assert!(ChapPacket::parse(&data).is_err());
+    }
+
+    #[test]
+    fn test_value_wrong_code() {
+        let data = [0x03, 0x01, 0x00, 0x04]; // Success, not Challenge/Response
+        let packet = ChapPacket::parse(&data).unwrap();
+        assert_eq!(packet.value(), None);
+        assert_eq!(packet.name(), None);
+    }
+
+    #[test]
+    fn test_message_wrong_code() {
+        // Challenge packet, message() should return None
+        let data = [0x01, 0x01, 0x00, 0x06, 0x01, 0xaa];
+        let packet = ChapPacket::parse(&data).unwrap();
+        assert_eq!(packet.message(), None);
+    }
+}

--- a/src/protocol/ipcp.rs
+++ b/src/protocol/ipcp.rs
@@ -1,0 +1,443 @@
+//! IPCP protocol - RFC 1332
+//!
+//! Internet Protocol Control Protocol for negotiating IPv4 parameters.
+
+use crate::{Error, Result};
+use std::net::Ipv4Addr;
+
+/// IPCP header size (code + identifier + length)
+pub const IPCP_HEADER_SIZE: usize = 4;
+
+/// IPCP packet codes (same as LCP)
+pub mod codes {
+    /// Configure-Request
+    pub const CONFIGURE_REQUEST: u8 = 1;
+    /// Configure-Ack
+    pub const CONFIGURE_ACK: u8 = 2;
+    /// Configure-Nak
+    pub const CONFIGURE_NAK: u8 = 3;
+    /// Configure-Reject
+    pub const CONFIGURE_REJECT: u8 = 4;
+    /// Terminate-Request
+    pub const TERMINATE_REQUEST: u8 = 5;
+    /// Terminate-Ack
+    pub const TERMINATE_ACK: u8 = 6;
+    /// Code-Reject
+    pub const CODE_REJECT: u8 = 7;
+}
+
+/// IPCP option types
+pub mod options {
+    /// IP-Addresses (deprecated, RFC 1172)
+    pub const IP_ADDRESSES: u8 = 1;
+    /// IP-Compression-Protocol
+    pub const IP_COMPRESSION: u8 = 2;
+    /// IP-Address
+    pub const IP_ADDRESS: u8 = 3;
+    /// Primary DNS Server Address (Microsoft extension)
+    pub const PRIMARY_DNS: u8 = 129;
+    /// Primary NBNS Server Address (Microsoft extension)
+    pub const PRIMARY_NBNS: u8 = 130;
+    /// Secondary DNS Server Address (Microsoft extension)
+    pub const SECONDARY_DNS: u8 = 131;
+    /// Secondary NBNS Server Address (Microsoft extension)
+    pub const SECONDARY_NBNS: u8 = 132;
+}
+
+/// Parsed IPCP packet (zero-copy reference)
+#[derive(Debug)]
+pub struct IpcpPacket<'a> {
+    buffer: &'a [u8],
+}
+
+impl<'a> IpcpPacket<'a> {
+    /// Parse IPCP packet from buffer
+    pub fn parse(buffer: &'a [u8]) -> Result<Self> {
+        if buffer.len() < IPCP_HEADER_SIZE {
+            return Err(Error::Parse("IPCP packet too short".into()));
+        }
+
+        let packet = Self { buffer };
+
+        let length = packet.length() as usize;
+        if length < IPCP_HEADER_SIZE {
+            return Err(Error::Parse("IPCP length too small".into()));
+        }
+        if buffer.len() < length {
+            return Err(Error::Parse("IPCP packet truncated".into()));
+        }
+
+        Ok(packet)
+    }
+
+    /// Code field
+    pub fn code(&self) -> u8 {
+        self.buffer[0]
+    }
+
+    /// Identifier field
+    pub fn identifier(&self) -> u8 {
+        self.buffer[1]
+    }
+
+    /// Length field
+    pub fn length(&self) -> u16 {
+        u16::from_be_bytes([self.buffer[2], self.buffer[3]])
+    }
+
+    /// Data (options)
+    pub fn data(&self) -> &[u8] {
+        let len = self.length() as usize;
+        &self.buffer[IPCP_HEADER_SIZE..len]
+    }
+
+    /// Iterate over options
+    pub fn iter_options(&self) -> IpcpOptionIterator<'_> {
+        IpcpOptionIterator {
+            data: self.data(),
+            offset: 0,
+        }
+    }
+
+    /// Find a specific option by type
+    pub fn find_option(&self, opt_type: u8) -> Option<&[u8]> {
+        for opt in self.iter_options() {
+            if opt.opt_type == opt_type {
+                return Some(opt.data);
+            }
+        }
+        None
+    }
+
+    /// Get IP-Address option as Ipv4Addr
+    pub fn ip_address(&self) -> Option<Ipv4Addr> {
+        self.find_option_ip(options::IP_ADDRESS)
+    }
+
+    /// Get Primary-DNS option as Ipv4Addr
+    pub fn primary_dns(&self) -> Option<Ipv4Addr> {
+        self.find_option_ip(options::PRIMARY_DNS)
+    }
+
+    /// Get Secondary-DNS option as Ipv4Addr
+    pub fn secondary_dns(&self) -> Option<Ipv4Addr> {
+        self.find_option_ip(options::SECONDARY_DNS)
+    }
+
+    /// Helper to extract IPv4 address from option
+    pub fn find_option_ip(&self, opt_type: u8) -> Option<Ipv4Addr> {
+        self.find_option(opt_type).and_then(|data| {
+            if data.len() >= 4 {
+                Some(Ipv4Addr::new(data[0], data[1], data[2], data[3]))
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Get the raw buffer
+    pub fn as_bytes(&self) -> &[u8] {
+        let len = self.length() as usize;
+        &self.buffer[..len]
+    }
+}
+
+/// An IPCP option during iteration
+#[derive(Debug, Clone)]
+pub struct IpcpOption<'a> {
+    /// Option type
+    pub opt_type: u8,
+    /// Option data (excluding type and length bytes)
+    pub data: &'a [u8],
+}
+
+/// Iterator over IPCP options
+pub struct IpcpOptionIterator<'a> {
+    data: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> Iterator for IpcpOptionIterator<'a> {
+    type Item = IpcpOption<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.offset + 2 > self.data.len() {
+            return None;
+        }
+
+        let opt_type = self.data[self.offset];
+        let opt_len = self.data[self.offset + 1] as usize;
+
+        if opt_len < 2 || self.offset + opt_len > self.data.len() {
+            return None;
+        }
+
+        let data_start = self.offset + 2;
+        let data_end = self.offset + opt_len;
+
+        let opt = IpcpOption {
+            opt_type,
+            data: &self.data[data_start..data_end],
+        };
+
+        self.offset = data_end;
+        Some(opt)
+    }
+}
+
+/// Builder for IPCP packets
+#[derive(Debug, Default)]
+pub struct IpcpBuilder {
+    code: u8,
+    identifier: u8,
+    data: Vec<u8>,
+}
+
+impl IpcpBuilder {
+    /// Create a new IPCP packet builder
+    pub fn new(code: u8, identifier: u8) -> Self {
+        Self {
+            code,
+            identifier,
+            data: Vec::new(),
+        }
+    }
+
+    /// Create Configure-Request builder
+    pub fn configure_request(identifier: u8) -> Self {
+        Self::new(codes::CONFIGURE_REQUEST, identifier)
+    }
+
+    /// Create Configure-Ack builder
+    pub fn configure_ack(identifier: u8) -> Self {
+        Self::new(codes::CONFIGURE_ACK, identifier)
+    }
+
+    /// Create Configure-Nak builder
+    pub fn configure_nak(identifier: u8) -> Self {
+        Self::new(codes::CONFIGURE_NAK, identifier)
+    }
+
+    /// Create Configure-Reject builder
+    pub fn configure_reject(identifier: u8) -> Self {
+        Self::new(codes::CONFIGURE_REJECT, identifier)
+    }
+
+    /// Add a raw option
+    pub fn add_option(mut self, opt_type: u8, data: &[u8]) -> Self {
+        let opt_len = (2 + data.len()) as u8;
+        self.data.push(opt_type);
+        self.data.push(opt_len);
+        self.data.extend_from_slice(data);
+        self
+    }
+
+    /// Add IP-Address option
+    pub fn ip_address(self, ip: Ipv4Addr) -> Self {
+        self.add_option(options::IP_ADDRESS, &ip.octets())
+    }
+
+    /// Add Primary-DNS option
+    pub fn primary_dns(self, ip: Ipv4Addr) -> Self {
+        self.add_option(options::PRIMARY_DNS, &ip.octets())
+    }
+
+    /// Add Secondary-DNS option
+    pub fn secondary_dns(self, ip: Ipv4Addr) -> Self {
+        self.add_option(options::SECONDARY_DNS, &ip.octets())
+    }
+
+    /// Set raw data (for copying options in Ack)
+    pub fn raw_data(mut self, data: &[u8]) -> Self {
+        self.data = data.to_vec();
+        self
+    }
+
+    /// Build the IPCP packet
+    pub fn build(self) -> Vec<u8> {
+        let length = (IPCP_HEADER_SIZE + self.data.len()) as u16;
+        let mut packet = Vec::with_capacity(length as usize);
+
+        packet.push(self.code);
+        packet.push(self.identifier);
+        packet.extend_from_slice(&length.to_be_bytes());
+        packet.extend_from_slice(&self.data);
+
+        packet
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_configure_request() {
+        // IPCP Configure-Request with IP=0.0.0.0 (request assignment)
+        let data = [
+            0x01, // Code: Configure-Request
+            0x01, // Identifier
+            0x00, 0x0a, // Length=10
+            // IP-Address option
+            0x03, 0x06, // Type=3, Length=6
+            0x00, 0x00, 0x00, 0x00, // IP=0.0.0.0
+        ];
+
+        let packet = IpcpPacket::parse(&data).unwrap();
+        assert_eq!(packet.code(), codes::CONFIGURE_REQUEST);
+        assert_eq!(packet.identifier(), 1);
+        assert_eq!(packet.ip_address(), Some(Ipv4Addr::new(0, 0, 0, 0)));
+    }
+
+    #[test]
+    fn test_parse_configure_nak_with_ip() {
+        // IPCP Configure-Nak with suggested IP
+        let data = [
+            0x03, // Code: Configure-Nak
+            0x01, // Identifier
+            0x00, 0x0a, // Length=10
+            // IP-Address option
+            0x03, 0x06, // Type=3, Length=6
+            0xc0, 0xa8, 0x01, 0x64, // IP=192.168.1.100
+        ];
+
+        let packet = IpcpPacket::parse(&data).unwrap();
+        assert_eq!(packet.code(), codes::CONFIGURE_NAK);
+        assert_eq!(packet.ip_address(), Some(Ipv4Addr::new(192, 168, 1, 100)));
+    }
+
+    #[test]
+    fn test_parse_with_dns() {
+        // IPCP Configure-Request with IP and DNS options
+        let data = [
+            0x01, // Code: Configure-Request
+            0x01, // Identifier
+            0x00, 0x16, // Length=22
+            // IP-Address option
+            0x03, 0x06, 0x00, 0x00, 0x00, 0x00, // Primary DNS
+            0x81, 0x06, 0x00, 0x00, 0x00, 0x00, // Secondary DNS
+            0x83, 0x06, 0x00, 0x00, 0x00, 0x00,
+        ];
+
+        let packet = IpcpPacket::parse(&data).unwrap();
+        assert_eq!(packet.ip_address(), Some(Ipv4Addr::new(0, 0, 0, 0)));
+        assert_eq!(packet.primary_dns(), Some(Ipv4Addr::new(0, 0, 0, 0)));
+        assert_eq!(packet.secondary_dns(), Some(Ipv4Addr::new(0, 0, 0, 0)));
+    }
+
+    #[test]
+    fn test_parse_nak_with_dns() {
+        // IPCP Configure-Nak with suggested DNS servers
+        let data = [
+            0x03, // Code: Configure-Nak
+            0x01, // Identifier
+            0x00, 0x16, // Length=22
+            // IP-Address option
+            0x03, 0x06, 0xc0, 0xa8, 0x01, 0x64, // 192.168.1.100
+            // Primary DNS
+            0x81, 0x06, 0x08, 0x08, 0x08, 0x08, // 8.8.8.8
+            // Secondary DNS
+            0x83, 0x06, 0x08, 0x08, 0x04, 0x04, // 8.8.4.4
+        ];
+
+        let packet = IpcpPacket::parse(&data).unwrap();
+        assert_eq!(packet.ip_address(), Some(Ipv4Addr::new(192, 168, 1, 100)));
+        assert_eq!(packet.primary_dns(), Some(Ipv4Addr::new(8, 8, 8, 8)));
+        assert_eq!(packet.secondary_dns(), Some(Ipv4Addr::new(8, 8, 4, 4)));
+    }
+
+    #[test]
+    fn test_iterate_options() {
+        let data = [
+            0x01, 0x01, 0x00, 0x16, 0x03, 0x06, 0x00, 0x00, 0x00, 0x00, 0x81, 0x06, 0x00, 0x00,
+            0x00, 0x00, 0x83, 0x06, 0x00, 0x00, 0x00, 0x00,
+        ];
+
+        let packet = IpcpPacket::parse(&data).unwrap();
+        let opts: Vec<_> = packet.iter_options().collect();
+        assert_eq!(opts.len(), 3);
+        assert_eq!(opts[0].opt_type, options::IP_ADDRESS);
+        assert_eq!(opts[1].opt_type, options::PRIMARY_DNS);
+        assert_eq!(opts[2].opt_type, options::SECONDARY_DNS);
+    }
+
+    #[test]
+    fn test_build_configure_request() {
+        let packet = IpcpBuilder::configure_request(1)
+            .ip_address(Ipv4Addr::new(0, 0, 0, 0))
+            .primary_dns(Ipv4Addr::new(0, 0, 0, 0))
+            .secondary_dns(Ipv4Addr::new(0, 0, 0, 0))
+            .build();
+
+        let parsed = IpcpPacket::parse(&packet).unwrap();
+        assert_eq!(parsed.code(), codes::CONFIGURE_REQUEST);
+        assert_eq!(parsed.identifier(), 1);
+        assert_eq!(parsed.ip_address(), Some(Ipv4Addr::new(0, 0, 0, 0)));
+        assert_eq!(parsed.primary_dns(), Some(Ipv4Addr::new(0, 0, 0, 0)));
+        assert_eq!(parsed.secondary_dns(), Some(Ipv4Addr::new(0, 0, 0, 0)));
+    }
+
+    #[test]
+    fn test_build_configure_ack() {
+        let options_data = [0x03, 0x06, 0xc0, 0xa8, 0x01, 0x64]; // IP=192.168.1.100
+        let packet = IpcpBuilder::configure_ack(5)
+            .raw_data(&options_data)
+            .build();
+
+        let parsed = IpcpPacket::parse(&packet).unwrap();
+        assert_eq!(parsed.code(), codes::CONFIGURE_ACK);
+        assert_eq!(parsed.identifier(), 5);
+        assert_eq!(parsed.ip_address(), Some(Ipv4Addr::new(192, 168, 1, 100)));
+    }
+
+    #[test]
+    fn test_build_configure_nak() {
+        let packet = IpcpBuilder::configure_nak(1)
+            .ip_address(Ipv4Addr::new(10, 0, 0, 100))
+            .primary_dns(Ipv4Addr::new(8, 8, 8, 8))
+            .build();
+
+        let parsed = IpcpPacket::parse(&packet).unwrap();
+        assert_eq!(parsed.code(), codes::CONFIGURE_NAK);
+        assert_eq!(parsed.ip_address(), Some(Ipv4Addr::new(10, 0, 0, 100)));
+        assert_eq!(parsed.primary_dns(), Some(Ipv4Addr::new(8, 8, 8, 8)));
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let original = IpcpBuilder::configure_request(42)
+            .ip_address(Ipv4Addr::new(172, 16, 0, 1))
+            .primary_dns(Ipv4Addr::new(1, 1, 1, 1))
+            .secondary_dns(Ipv4Addr::new(1, 0, 0, 1))
+            .build();
+
+        let parsed = IpcpPacket::parse(&original).unwrap();
+        assert_eq!(parsed.as_bytes(), original.as_slice());
+    }
+
+    #[test]
+    fn test_parse_too_short() {
+        let data = [0x01, 0x01, 0x00];
+        assert!(IpcpPacket::parse(&data).is_err());
+    }
+
+    #[test]
+    fn test_parse_invalid_length() {
+        let data = [0x01, 0x01, 0x00, 0x02]; // Length=2, but min is 4
+        assert!(IpcpPacket::parse(&data).is_err());
+    }
+
+    #[test]
+    fn test_parse_truncated() {
+        let data = [0x01, 0x01, 0x00, 0x10]; // Length=16, but only 4 bytes
+        assert!(IpcpPacket::parse(&data).is_err());
+    }
+
+    #[test]
+    fn test_no_options() {
+        let data = [0x01, 0x01, 0x00, 0x04]; // No options
+        let packet = IpcpPacket::parse(&data).unwrap();
+        assert_eq!(packet.ip_address(), None);
+        assert_eq!(packet.primary_dns(), None);
+    }
+}

--- a/src/protocol/lcp.rs
+++ b/src/protocol/lcp.rs
@@ -1,0 +1,510 @@
+//! LCP protocol - RFC 1661
+//!
+//! Link Control Protocol for establishing, configuring, and testing
+//! the data-link connection.
+
+use crate::{Error, Result};
+
+/// LCP header size (code + identifier + length)
+pub const LCP_HEADER_SIZE: usize = 4;
+
+/// LCP packet codes
+pub mod codes {
+    /// Configure-Request
+    pub const CONFIGURE_REQUEST: u8 = 1;
+    /// Configure-Ack
+    pub const CONFIGURE_ACK: u8 = 2;
+    /// Configure-Nak
+    pub const CONFIGURE_NAK: u8 = 3;
+    /// Configure-Reject
+    pub const CONFIGURE_REJECT: u8 = 4;
+    /// Terminate-Request
+    pub const TERMINATE_REQUEST: u8 = 5;
+    /// Terminate-Ack
+    pub const TERMINATE_ACK: u8 = 6;
+    /// Code-Reject
+    pub const CODE_REJECT: u8 = 7;
+    /// Protocol-Reject
+    pub const PROTOCOL_REJECT: u8 = 8;
+    /// Echo-Request
+    pub const ECHO_REQUEST: u8 = 9;
+    /// Echo-Reply
+    pub const ECHO_REPLY: u8 = 10;
+    /// Discard-Request
+    pub const DISCARD_REQUEST: u8 = 11;
+}
+
+/// LCP option types
+pub mod options {
+    /// Maximum-Receive-Unit
+    pub const MRU: u8 = 1;
+    /// Async-Control-Character-Map (not used in PPPoE)
+    pub const ACCM: u8 = 2;
+    /// Authentication-Protocol
+    pub const AUTH_PROTOCOL: u8 = 3;
+    /// Quality-Protocol
+    pub const QUALITY_PROTOCOL: u8 = 4;
+    /// Magic-Number
+    pub const MAGIC_NUMBER: u8 = 5;
+    /// Protocol-Field-Compression
+    pub const PFC: u8 = 7;
+    /// Address-and-Control-Field-Compression
+    pub const ACFC: u8 = 8;
+}
+
+/// Authentication protocol values for LCP option 3
+pub mod auth {
+    /// Password Authentication Protocol
+    pub const PAP: u16 = 0xc023;
+    /// Challenge Handshake Authentication Protocol
+    pub const CHAP: u16 = 0xc223;
+    /// CHAP algorithm: MD5
+    pub const CHAP_MD5: u8 = 5;
+}
+
+/// Parsed LCP packet (zero-copy reference)
+#[derive(Debug)]
+pub struct LcpPacket<'a> {
+    buffer: &'a [u8],
+}
+
+impl<'a> LcpPacket<'a> {
+    /// Parse LCP packet from buffer
+    pub fn parse(buffer: &'a [u8]) -> Result<Self> {
+        if buffer.len() < LCP_HEADER_SIZE {
+            return Err(Error::Parse("LCP packet too short".into()));
+        }
+
+        let packet = Self { buffer };
+
+        // Verify length field
+        let length = packet.length() as usize;
+        if length < LCP_HEADER_SIZE {
+            return Err(Error::Parse("LCP length too small".into()));
+        }
+        if buffer.len() < length {
+            return Err(Error::Parse("LCP packet truncated".into()));
+        }
+
+        Ok(packet)
+    }
+
+    /// Code field
+    pub fn code(&self) -> u8 {
+        self.buffer[0]
+    }
+
+    /// Identifier field (for matching requests and responses)
+    pub fn identifier(&self) -> u8 {
+        self.buffer[1]
+    }
+
+    /// Length field (total packet length including header)
+    pub fn length(&self) -> u16 {
+        u16::from_be_bytes([self.buffer[2], self.buffer[3]])
+    }
+
+    /// Data (options for Configure-*, or payload for Echo-*)
+    pub fn data(&self) -> &[u8] {
+        let len = self.length() as usize;
+        &self.buffer[LCP_HEADER_SIZE..len]
+    }
+
+    /// Iterate over options (for Configure-Request/Ack/Nak/Reject)
+    pub fn iter_options(&self) -> LcpOptionIterator<'_> {
+        LcpOptionIterator {
+            data: self.data(),
+            offset: 0,
+        }
+    }
+
+    /// Find a specific option by type
+    pub fn find_option(&self, opt_type: u8) -> Option<&[u8]> {
+        for opt in self.iter_options() {
+            if opt.opt_type == opt_type {
+                return Some(opt.data);
+            }
+        }
+        None
+    }
+
+    /// Get MRU option value
+    pub fn mru(&self) -> Option<u16> {
+        self.find_option(options::MRU).and_then(|data| {
+            if data.len() >= 2 {
+                Some(u16::from_be_bytes([data[0], data[1]]))
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Get Magic-Number option value
+    pub fn magic_number(&self) -> Option<u32> {
+        self.find_option(options::MAGIC_NUMBER).and_then(|data| {
+            if data.len() >= 4 {
+                Some(u32::from_be_bytes([data[0], data[1], data[2], data[3]]))
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Get Authentication-Protocol option
+    pub fn auth_protocol(&self) -> Option<(u16, Option<u8>)> {
+        self.find_option(options::AUTH_PROTOCOL).and_then(|data| {
+            if data.len() >= 2 {
+                let proto = u16::from_be_bytes([data[0], data[1]]);
+                let algorithm = if data.len() >= 3 { Some(data[2]) } else { None };
+                Some((proto, algorithm))
+            } else {
+                None
+            }
+        })
+    }
+
+    /// For Echo-Request/Reply, get the magic number from data
+    pub fn echo_magic(&self) -> Option<u32> {
+        let data = self.data();
+        if data.len() >= 4 {
+            Some(u32::from_be_bytes([data[0], data[1], data[2], data[3]]))
+        } else {
+            None
+        }
+    }
+
+    /// Get the raw buffer
+    pub fn as_bytes(&self) -> &[u8] {
+        let len = self.length() as usize;
+        &self.buffer[..len]
+    }
+}
+
+/// An LCP option during iteration
+#[derive(Debug, Clone)]
+pub struct LcpOption<'a> {
+    /// Option type
+    pub opt_type: u8,
+    /// Option data (excluding type and length bytes)
+    pub data: &'a [u8],
+}
+
+/// Iterator over LCP options
+pub struct LcpOptionIterator<'a> {
+    data: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> Iterator for LcpOptionIterator<'a> {
+    type Item = LcpOption<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Need at least 2 bytes for option header (type + length)
+        if self.offset + 2 > self.data.len() {
+            return None;
+        }
+
+        let opt_type = self.data[self.offset];
+        let opt_len = self.data[self.offset + 1] as usize;
+
+        // Option length includes type and length bytes
+        if opt_len < 2 || self.offset + opt_len > self.data.len() {
+            return None;
+        }
+
+        let data_start = self.offset + 2;
+        let data_end = self.offset + opt_len;
+
+        let opt = LcpOption {
+            opt_type,
+            data: &self.data[data_start..data_end],
+        };
+
+        self.offset = data_end;
+        Some(opt)
+    }
+}
+
+/// Builder for LCP packets
+#[derive(Debug, Default)]
+pub struct LcpBuilder {
+    code: u8,
+    identifier: u8,
+    data: Vec<u8>,
+}
+
+impl LcpBuilder {
+    /// Create a new LCP packet builder
+    pub fn new(code: u8, identifier: u8) -> Self {
+        Self {
+            code,
+            identifier,
+            data: Vec::new(),
+        }
+    }
+
+    /// Create Configure-Request builder
+    pub fn configure_request(identifier: u8) -> Self {
+        Self::new(codes::CONFIGURE_REQUEST, identifier)
+    }
+
+    /// Create Configure-Ack builder
+    pub fn configure_ack(identifier: u8) -> Self {
+        Self::new(codes::CONFIGURE_ACK, identifier)
+    }
+
+    /// Create Configure-Nak builder
+    pub fn configure_nak(identifier: u8) -> Self {
+        Self::new(codes::CONFIGURE_NAK, identifier)
+    }
+
+    /// Create Configure-Reject builder
+    pub fn configure_reject(identifier: u8) -> Self {
+        Self::new(codes::CONFIGURE_REJECT, identifier)
+    }
+
+    /// Create Terminate-Request builder
+    pub fn terminate_request(identifier: u8) -> Self {
+        Self::new(codes::TERMINATE_REQUEST, identifier)
+    }
+
+    /// Create Terminate-Ack builder
+    pub fn terminate_ack(identifier: u8) -> Self {
+        Self::new(codes::TERMINATE_ACK, identifier)
+    }
+
+    /// Create Echo-Request builder
+    pub fn echo_request(identifier: u8, magic: u32) -> Self {
+        let mut builder = Self::new(codes::ECHO_REQUEST, identifier);
+        builder.data.extend_from_slice(&magic.to_be_bytes());
+        builder
+    }
+
+    /// Create Echo-Reply builder
+    pub fn echo_reply(identifier: u8, magic: u32) -> Self {
+        let mut builder = Self::new(codes::ECHO_REPLY, identifier);
+        builder.data.extend_from_slice(&magic.to_be_bytes());
+        builder
+    }
+
+    /// Add a raw option
+    pub fn add_option(mut self, opt_type: u8, data: &[u8]) -> Self {
+        let opt_len = (2 + data.len()) as u8;
+        self.data.push(opt_type);
+        self.data.push(opt_len);
+        self.data.extend_from_slice(data);
+        self
+    }
+
+    /// Add MRU option
+    pub fn mru(self, mru: u16) -> Self {
+        self.add_option(options::MRU, &mru.to_be_bytes())
+    }
+
+    /// Add Magic-Number option
+    pub fn magic_number(self, magic: u32) -> Self {
+        self.add_option(options::MAGIC_NUMBER, &magic.to_be_bytes())
+    }
+
+    /// Add Authentication-Protocol option (PAP)
+    pub fn auth_pap(self) -> Self {
+        self.add_option(options::AUTH_PROTOCOL, &auth::PAP.to_be_bytes())
+    }
+
+    /// Add Authentication-Protocol option (CHAP MD5)
+    pub fn auth_chap_md5(self) -> Self {
+        let mut data = auth::CHAP.to_be_bytes().to_vec();
+        data.push(auth::CHAP_MD5);
+        self.add_option(options::AUTH_PROTOCOL, &data)
+    }
+
+    /// Set raw data (for Echo packets or copying options)
+    pub fn raw_data(mut self, data: &[u8]) -> Self {
+        self.data = data.to_vec();
+        self
+    }
+
+    /// Build the LCP packet
+    pub fn build(self) -> Vec<u8> {
+        let length = (LCP_HEADER_SIZE + self.data.len()) as u16;
+        let mut packet = Vec::with_capacity(length as usize);
+
+        packet.push(self.code);
+        packet.push(self.identifier);
+        packet.extend_from_slice(&length.to_be_bytes());
+        packet.extend_from_slice(&self.data);
+
+        packet
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_configure_request() {
+        // LCP Configure-Request with MRU=1492 and Magic-Number
+        let data = [
+            0x01, // Code: Configure-Request
+            0x01, // Identifier
+            0x00, 0x0e, // Length=14 (4 header + 4 MRU + 6 Magic)
+            // MRU option
+            0x01, 0x04, // Type=1, Length=4
+            0x05, 0xd4, // MRU=1492
+            // Magic-Number option
+            0x05, 0x06, // Type=5, Length=6
+            0x12, 0x34, 0x56, 0x78, // Magic
+        ];
+
+        let packet = LcpPacket::parse(&data).unwrap();
+        assert_eq!(packet.code(), codes::CONFIGURE_REQUEST);
+        assert_eq!(packet.identifier(), 1);
+        assert_eq!(packet.length(), 14);
+        assert_eq!(packet.mru(), Some(1492));
+        assert_eq!(packet.magic_number(), Some(0x12345678));
+    }
+
+    #[test]
+    fn test_parse_configure_request_with_auth() {
+        // LCP Configure-Request with CHAP MD5
+        let data = [
+            0x01, // Code: Configure-Request
+            0x02, // Identifier
+            0x00, 0x09, // Length=9
+            // Auth-Protocol option (CHAP MD5)
+            0x03, 0x05, // Type=3, Length=5
+            0xc2, 0x23, // CHAP
+            0x05, // MD5
+        ];
+
+        let packet = LcpPacket::parse(&data).unwrap();
+        assert_eq!(
+            packet.auth_protocol(),
+            Some((auth::CHAP, Some(auth::CHAP_MD5)))
+        );
+    }
+
+    #[test]
+    fn test_parse_echo_request() {
+        let data = [
+            0x09, // Code: Echo-Request
+            0x01, // Identifier
+            0x00, 0x08, // Length=8
+            0xab, 0xcd, 0xef, 0x12, // Magic number
+        ];
+
+        let packet = LcpPacket::parse(&data).unwrap();
+        assert_eq!(packet.code(), codes::ECHO_REQUEST);
+        assert_eq!(packet.echo_magic(), Some(0xabcdef12));
+    }
+
+    #[test]
+    fn test_iterate_options() {
+        let data = [
+            0x01, 0x01, 0x00, 0x0e, // Length=14 (4 header + 4 MRU + 6 Magic)
+            // MRU option
+            0x01, 0x04, 0x05, 0xd4, // Magic option
+            0x05, 0x06, 0x00, 0x00, 0x00, 0x01,
+        ];
+
+        let packet = LcpPacket::parse(&data).unwrap();
+        let opts: Vec<_> = packet.iter_options().collect();
+        assert_eq!(opts.len(), 2);
+        assert_eq!(opts[0].opt_type, options::MRU);
+        assert_eq!(opts[1].opt_type, options::MAGIC_NUMBER);
+    }
+
+    #[test]
+    fn test_build_configure_request() {
+        let packet = LcpBuilder::configure_request(1)
+            .mru(1492)
+            .magic_number(0x12345678)
+            .build();
+
+        let parsed = LcpPacket::parse(&packet).unwrap();
+        assert_eq!(parsed.code(), codes::CONFIGURE_REQUEST);
+        assert_eq!(parsed.identifier(), 1);
+        assert_eq!(parsed.mru(), Some(1492));
+        assert_eq!(parsed.magic_number(), Some(0x12345678));
+    }
+
+    #[test]
+    fn test_build_configure_ack() {
+        let options_data = [0x01, 0x04, 0x05, 0xd4]; // MRU=1492
+        let packet = LcpBuilder::configure_ack(5).raw_data(&options_data).build();
+
+        let parsed = LcpPacket::parse(&packet).unwrap();
+        assert_eq!(parsed.code(), codes::CONFIGURE_ACK);
+        assert_eq!(parsed.identifier(), 5);
+        assert_eq!(parsed.mru(), Some(1492));
+    }
+
+    #[test]
+    fn test_build_echo_request() {
+        let packet = LcpBuilder::echo_request(10, 0xdeadbeef).build();
+
+        let parsed = LcpPacket::parse(&packet).unwrap();
+        assert_eq!(parsed.code(), codes::ECHO_REQUEST);
+        assert_eq!(parsed.identifier(), 10);
+        assert_eq!(parsed.echo_magic(), Some(0xdeadbeef));
+    }
+
+    #[test]
+    fn test_build_echo_reply() {
+        let packet = LcpBuilder::echo_reply(10, 0xdeadbeef).build();
+
+        let parsed = LcpPacket::parse(&packet).unwrap();
+        assert_eq!(parsed.code(), codes::ECHO_REPLY);
+        assert_eq!(parsed.identifier(), 10);
+        assert_eq!(parsed.echo_magic(), Some(0xdeadbeef));
+    }
+
+    #[test]
+    fn test_build_with_auth_pap() {
+        let packet = LcpBuilder::configure_request(1).auth_pap().build();
+
+        let parsed = LcpPacket::parse(&packet).unwrap();
+        assert_eq!(parsed.auth_protocol(), Some((auth::PAP, None)));
+    }
+
+    #[test]
+    fn test_build_with_auth_chap() {
+        let packet = LcpBuilder::configure_request(1).auth_chap_md5().build();
+
+        let parsed = LcpPacket::parse(&packet).unwrap();
+        assert_eq!(
+            parsed.auth_protocol(),
+            Some((auth::CHAP, Some(auth::CHAP_MD5)))
+        );
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let original = LcpBuilder::configure_request(42)
+            .mru(1400)
+            .magic_number(0xfeedface)
+            .build();
+
+        let parsed = LcpPacket::parse(&original).unwrap();
+        assert_eq!(parsed.as_bytes(), original.as_slice());
+    }
+
+    #[test]
+    fn test_parse_too_short() {
+        let data = [0x01, 0x01, 0x00];
+        assert!(LcpPacket::parse(&data).is_err());
+    }
+
+    #[test]
+    fn test_parse_invalid_length() {
+        let data = [0x01, 0x01, 0x00, 0x02]; // Length=2, but min is 4
+        assert!(LcpPacket::parse(&data).is_err());
+    }
+
+    #[test]
+    fn test_parse_truncated() {
+        let data = [0x01, 0x01, 0x00, 0x10]; // Length=16, but only 4 bytes
+        assert!(LcpPacket::parse(&data).is_err());
+    }
+}

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -3,14 +3,20 @@
 //! All L2+ protocols are implemented from scratch for learning purposes.
 
 pub mod arp;
+pub mod chap;
 pub mod dhcp;
 pub mod dhcpv6;
 pub mod dns;
 pub mod ethernet;
 pub mod icmp;
 pub mod icmpv6;
+pub mod ipcp;
 pub mod ipv4;
 pub mod ipv6;
+pub mod lcp;
+pub mod pap;
+pub mod ppp;
+pub mod pppoe;
 pub mod tcp;
 pub mod types;
 pub mod udp;

--- a/src/protocol/pap.rs
+++ b/src/protocol/pap.rs
@@ -1,0 +1,343 @@
+//! PAP protocol - RFC 1334
+//!
+//! Password Authentication Protocol for simple clear-text authentication.
+
+use crate::{Error, Result};
+
+/// PAP header size (code + identifier + length)
+pub const PAP_HEADER_SIZE: usize = 4;
+
+/// PAP packet codes
+pub mod codes {
+    /// Authenticate-Request
+    pub const AUTHENTICATE_REQUEST: u8 = 1;
+    /// Authenticate-Ack (success)
+    pub const AUTHENTICATE_ACK: u8 = 2;
+    /// Authenticate-Nak (failure)
+    pub const AUTHENTICATE_NAK: u8 = 3;
+}
+
+/// Parsed PAP packet (zero-copy reference)
+#[derive(Debug)]
+pub struct PapPacket<'a> {
+    buffer: &'a [u8],
+}
+
+impl<'a> PapPacket<'a> {
+    /// Parse PAP packet from buffer
+    pub fn parse(buffer: &'a [u8]) -> Result<Self> {
+        if buffer.len() < PAP_HEADER_SIZE {
+            return Err(Error::Parse("PAP packet too short".into()));
+        }
+
+        let packet = Self { buffer };
+
+        let length = packet.length() as usize;
+        if length < PAP_HEADER_SIZE {
+            return Err(Error::Parse("PAP length too small".into()));
+        }
+        if buffer.len() < length {
+            return Err(Error::Parse("PAP packet truncated".into()));
+        }
+
+        Ok(packet)
+    }
+
+    /// Code field
+    pub fn code(&self) -> u8 {
+        self.buffer[0]
+    }
+
+    /// Identifier field
+    pub fn identifier(&self) -> u8 {
+        self.buffer[1]
+    }
+
+    /// Length field
+    pub fn length(&self) -> u16 {
+        u16::from_be_bytes([self.buffer[2], self.buffer[3]])
+    }
+
+    /// Data field
+    pub fn data(&self) -> &[u8] {
+        let len = self.length() as usize;
+        &self.buffer[PAP_HEADER_SIZE..len]
+    }
+
+    /// Get Peer-ID from Authenticate-Request
+    /// Format: Peer-ID-Length (1 byte) + Peer-ID
+    pub fn peer_id(&self) -> Option<&[u8]> {
+        if self.code() != codes::AUTHENTICATE_REQUEST {
+            return None;
+        }
+        let data = self.data();
+        if data.is_empty() {
+            return None;
+        }
+        let peer_id_len = data[0] as usize;
+        if data.len() < 1 + peer_id_len {
+            return None;
+        }
+        Some(&data[1..1 + peer_id_len])
+    }
+
+    /// Get Password from Authenticate-Request
+    /// Format: Peer-ID-Length (1) + Peer-ID + Passwd-Length (1) + Password
+    pub fn password(&self) -> Option<&[u8]> {
+        if self.code() != codes::AUTHENTICATE_REQUEST {
+            return None;
+        }
+        let data = self.data();
+        if data.is_empty() {
+            return None;
+        }
+        let peer_id_len = data[0] as usize;
+        let passwd_offset = 1 + peer_id_len;
+        if data.len() < passwd_offset + 1 {
+            return None;
+        }
+        let passwd_len = data[passwd_offset] as usize;
+        let passwd_start = passwd_offset + 1;
+        if data.len() < passwd_start + passwd_len {
+            return None;
+        }
+        Some(&data[passwd_start..passwd_start + passwd_len])
+    }
+
+    /// Get message from Authenticate-Ack/Nak
+    /// Format: Msg-Length (1 byte) + Message
+    pub fn message(&self) -> Option<&[u8]> {
+        if self.code() != codes::AUTHENTICATE_ACK && self.code() != codes::AUTHENTICATE_NAK {
+            return None;
+        }
+        let data = self.data();
+        if data.is_empty() {
+            return Some(&[]);
+        }
+        let msg_len = data[0] as usize;
+        if data.len() < 1 + msg_len {
+            return Some(&[]);
+        }
+        Some(&data[1..1 + msg_len])
+    }
+
+    /// Check if this is an authentication success
+    pub fn is_success(&self) -> bool {
+        self.code() == codes::AUTHENTICATE_ACK
+    }
+
+    /// Check if this is an authentication failure
+    pub fn is_failure(&self) -> bool {
+        self.code() == codes::AUTHENTICATE_NAK
+    }
+
+    /// Get the raw buffer
+    pub fn as_bytes(&self) -> &[u8] {
+        let len = self.length() as usize;
+        &self.buffer[..len]
+    }
+}
+
+/// Builder for PAP packets
+#[derive(Debug, Default)]
+pub struct PapBuilder {
+    code: u8,
+    identifier: u8,
+    data: Vec<u8>,
+}
+
+impl PapBuilder {
+    /// Create a new PAP packet builder
+    pub fn new(code: u8, identifier: u8) -> Self {
+        Self {
+            code,
+            identifier,
+            data: Vec::new(),
+        }
+    }
+
+    /// Create Authenticate-Request builder
+    pub fn authenticate_request(identifier: u8, peer_id: &str, password: &str) -> Self {
+        let mut builder = Self::new(codes::AUTHENTICATE_REQUEST, identifier);
+
+        // Peer-ID-Length + Peer-ID
+        builder.data.push(peer_id.len() as u8);
+        builder.data.extend_from_slice(peer_id.as_bytes());
+
+        // Passwd-Length + Password
+        builder.data.push(password.len() as u8);
+        builder.data.extend_from_slice(password.as_bytes());
+
+        builder
+    }
+
+    /// Create Authenticate-Ack builder (for testing/server side)
+    pub fn authenticate_ack(identifier: u8, message: &str) -> Self {
+        let mut builder = Self::new(codes::AUTHENTICATE_ACK, identifier);
+        builder.data.push(message.len() as u8);
+        builder.data.extend_from_slice(message.as_bytes());
+        builder
+    }
+
+    /// Create Authenticate-Nak builder (for testing/server side)
+    pub fn authenticate_nak(identifier: u8, message: &str) -> Self {
+        let mut builder = Self::new(codes::AUTHENTICATE_NAK, identifier);
+        builder.data.push(message.len() as u8);
+        builder.data.extend_from_slice(message.as_bytes());
+        builder
+    }
+
+    /// Build the PAP packet
+    pub fn build(self) -> Vec<u8> {
+        let length = (PAP_HEADER_SIZE + self.data.len()) as u16;
+        let mut packet = Vec::with_capacity(length as usize);
+
+        packet.push(self.code);
+        packet.push(self.identifier);
+        packet.extend_from_slice(&length.to_be_bytes());
+        packet.extend_from_slice(&self.data);
+
+        packet
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_authenticate_request() {
+        // PAP Authenticate-Request: user="test", password="pass"
+        let data = [
+            0x01, // Code: Authenticate-Request
+            0x01, // Identifier
+            0x00, 0x0e, // Length=14
+            0x04, // Peer-ID length=4
+            b't', b'e', b's', b't', // Peer-ID
+            0x04, // Password length=4
+            b'p', b'a', b's', b's', // Password
+        ];
+
+        let packet = PapPacket::parse(&data).unwrap();
+        assert_eq!(packet.code(), codes::AUTHENTICATE_REQUEST);
+        assert_eq!(packet.identifier(), 1);
+        assert_eq!(packet.peer_id(), Some(b"test".as_slice()));
+        assert_eq!(packet.password(), Some(b"pass".as_slice()));
+    }
+
+    #[test]
+    fn test_parse_authenticate_ack() {
+        // PAP Authenticate-Ack with message "OK"
+        let data = [
+            0x02, // Code: Authenticate-Ack
+            0x01, // Identifier
+            0x00, 0x07, // Length=7
+            0x02, // Message length=2
+            b'O', b'K', // Message
+        ];
+
+        let packet = PapPacket::parse(&data).unwrap();
+        assert_eq!(packet.code(), codes::AUTHENTICATE_ACK);
+        assert!(packet.is_success());
+        assert!(!packet.is_failure());
+        assert_eq!(packet.message(), Some(b"OK".as_slice()));
+    }
+
+    #[test]
+    fn test_parse_authenticate_nak() {
+        // PAP Authenticate-Nak with message "FAIL"
+        let data = [
+            0x03, // Code: Authenticate-Nak
+            0x01, // Identifier
+            0x00, 0x09, // Length=9
+            0x04, // Message length=4
+            b'F', b'A', b'I', b'L', // Message
+        ];
+
+        let packet = PapPacket::parse(&data).unwrap();
+        assert_eq!(packet.code(), codes::AUTHENTICATE_NAK);
+        assert!(!packet.is_success());
+        assert!(packet.is_failure());
+        assert_eq!(packet.message(), Some(b"FAIL".as_slice()));
+    }
+
+    #[test]
+    fn test_parse_ack_empty_message() {
+        let data = [
+            0x02, // Code: Authenticate-Ack
+            0x01, // Identifier
+            0x00, 0x05, // Length=5
+            0x00, // Message length=0
+        ];
+
+        let packet = PapPacket::parse(&data).unwrap();
+        assert!(packet.is_success());
+        assert_eq!(packet.message(), Some(b"".as_slice()));
+    }
+
+    #[test]
+    fn test_build_authenticate_request() {
+        let packet = PapBuilder::authenticate_request(1, "myuser", "mypass").build();
+
+        let parsed = PapPacket::parse(&packet).unwrap();
+        assert_eq!(parsed.code(), codes::AUTHENTICATE_REQUEST);
+        assert_eq!(parsed.identifier(), 1);
+        assert_eq!(parsed.peer_id(), Some(b"myuser".as_slice()));
+        assert_eq!(parsed.password(), Some(b"mypass".as_slice()));
+    }
+
+    #[test]
+    fn test_build_authenticate_ack() {
+        let packet = PapBuilder::authenticate_ack(1, "Welcome").build();
+
+        let parsed = PapPacket::parse(&packet).unwrap();
+        assert!(parsed.is_success());
+        assert_eq!(parsed.identifier(), 1);
+        assert_eq!(parsed.message(), Some(b"Welcome".as_slice()));
+    }
+
+    #[test]
+    fn test_build_authenticate_nak() {
+        let packet = PapBuilder::authenticate_nak(1, "Bad credentials").build();
+
+        let parsed = PapPacket::parse(&packet).unwrap();
+        assert!(parsed.is_failure());
+        assert_eq!(parsed.message(), Some(b"Bad credentials".as_slice()));
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let original = PapBuilder::authenticate_request(42, "user123", "secret456").build();
+
+        let parsed = PapPacket::parse(&original).unwrap();
+        assert_eq!(parsed.as_bytes(), original.as_slice());
+    }
+
+    #[test]
+    fn test_parse_too_short() {
+        let data = [0x01, 0x01, 0x00];
+        assert!(PapPacket::parse(&data).is_err());
+    }
+
+    #[test]
+    fn test_parse_truncated() {
+        let data = [0x01, 0x01, 0x00, 0x10]; // Length=16, but only 4 bytes
+        assert!(PapPacket::parse(&data).is_err());
+    }
+
+    #[test]
+    fn test_peer_id_wrong_code() {
+        let data = [0x02, 0x01, 0x00, 0x05, 0x00]; // Ack, not Request
+        let packet = PapPacket::parse(&data).unwrap();
+        assert_eq!(packet.peer_id(), None);
+        assert_eq!(packet.password(), None);
+    }
+
+    #[test]
+    fn test_message_wrong_code() {
+        // Request packet, message() should return None
+        let data = [0x01, 0x01, 0x00, 0x08, 0x02, b'a', b'b', 0x00];
+        let packet = PapPacket::parse(&data).unwrap();
+        assert_eq!(packet.message(), None);
+    }
+}

--- a/src/protocol/ppp.rs
+++ b/src/protocol/ppp.rs
@@ -1,0 +1,254 @@
+//! PPP protocol - RFC 1661
+//!
+//! Point-to-Point Protocol frame parsing and building.
+//! PPP frames are encapsulated within PPPoE Session frames.
+
+use crate::{Error, Result};
+
+/// PPP header size (protocol field only, no HDLC framing in PPPoE)
+pub const PPP_HEADER_SIZE: usize = 2;
+
+/// PPP protocol numbers
+pub mod protocols {
+    /// Internet Protocol version 4
+    pub const IP: u16 = 0x0021;
+    /// Internet Protocol version 6
+    pub const IPV6: u16 = 0x0057;
+    /// Internet Protocol Control Protocol
+    pub const IPCP: u16 = 0x8021;
+    /// IPv6 Control Protocol
+    pub const IPV6CP: u16 = 0x8057;
+    /// Link Control Protocol
+    pub const LCP: u16 = 0xc021;
+    /// Password Authentication Protocol
+    pub const PAP: u16 = 0xc023;
+    /// Challenge Handshake Authentication Protocol
+    pub const CHAP: u16 = 0xc223;
+}
+
+/// Parsed PPP frame (zero-copy reference)
+#[derive(Debug)]
+pub struct PppFrame<'a> {
+    buffer: &'a [u8],
+}
+
+impl<'a> PppFrame<'a> {
+    /// Parse PPP frame from buffer
+    pub fn parse(buffer: &'a [u8]) -> Result<Self> {
+        if buffer.len() < PPP_HEADER_SIZE {
+            return Err(Error::Parse("PPP frame too short".into()));
+        }
+        Ok(Self { buffer })
+    }
+
+    /// Protocol field
+    pub fn protocol(&self) -> u16 {
+        u16::from_be_bytes([self.buffer[0], self.buffer[1]])
+    }
+
+    /// Payload (protocol-specific data)
+    pub fn payload(&self) -> &[u8] {
+        &self.buffer[PPP_HEADER_SIZE..]
+    }
+
+    /// Check if this is a control protocol (LCP, PAP, CHAP, IPCP, etc.)
+    pub fn is_control(&self) -> bool {
+        let proto = self.protocol();
+        // Control protocols have values >= 0x8000 or authentication protocols
+        proto >= 0x8000 || proto == protocols::PAP || proto == protocols::CHAP
+    }
+
+    /// Check if this is a network protocol (IP, IPv6)
+    pub fn is_network(&self) -> bool {
+        matches!(self.protocol(), protocols::IP | protocols::IPV6)
+    }
+
+    /// Get the raw buffer
+    pub fn as_bytes(&self) -> &[u8] {
+        self.buffer
+    }
+}
+
+/// Builder for PPP frames
+#[derive(Debug, Default)]
+pub struct PppBuilder {
+    protocol: u16,
+    payload: Vec<u8>,
+}
+
+impl PppBuilder {
+    /// Create a new PPP frame builder
+    pub fn new(protocol: u16) -> Self {
+        Self {
+            protocol,
+            payload: Vec::new(),
+        }
+    }
+
+    /// Create builder for LCP
+    pub fn lcp() -> Self {
+        Self::new(protocols::LCP)
+    }
+
+    /// Create builder for PAP
+    pub fn pap() -> Self {
+        Self::new(protocols::PAP)
+    }
+
+    /// Create builder for CHAP
+    pub fn chap() -> Self {
+        Self::new(protocols::CHAP)
+    }
+
+    /// Create builder for IPCP
+    pub fn ipcp() -> Self {
+        Self::new(protocols::IPCP)
+    }
+
+    /// Create builder for IPv6CP
+    pub fn ipv6cp() -> Self {
+        Self::new(protocols::IPV6CP)
+    }
+
+    /// Create builder for IPv4 data
+    pub fn ip() -> Self {
+        Self::new(protocols::IP)
+    }
+
+    /// Create builder for IPv6 data
+    pub fn ipv6() -> Self {
+        Self::new(protocols::IPV6)
+    }
+
+    /// Set the payload
+    pub fn payload(mut self, data: &[u8]) -> Self {
+        self.payload = data.to_vec();
+        self
+    }
+
+    /// Build the PPP frame
+    pub fn build(self) -> Vec<u8> {
+        let mut frame = Vec::with_capacity(PPP_HEADER_SIZE + self.payload.len());
+        frame.extend_from_slice(&self.protocol.to_be_bytes());
+        frame.extend_from_slice(&self.payload);
+        frame
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_lcp() {
+        let data = [
+            0xc0, 0x21, // Protocol: LCP
+            0x01, 0x01, 0x00, 0x04, // LCP payload
+        ];
+
+        let frame = PppFrame::parse(&data).unwrap();
+        assert_eq!(frame.protocol(), protocols::LCP);
+        assert!(frame.is_control());
+        assert!(!frame.is_network());
+        assert_eq!(frame.payload(), &[0x01, 0x01, 0x00, 0x04]);
+    }
+
+    #[test]
+    fn test_parse_ipcp() {
+        let data = [
+            0x80, 0x21, // Protocol: IPCP
+            0x01, 0x02, 0x00, 0x0a, // IPCP payload
+        ];
+
+        let frame = PppFrame::parse(&data).unwrap();
+        assert_eq!(frame.protocol(), protocols::IPCP);
+        assert!(frame.is_control());
+    }
+
+    #[test]
+    fn test_parse_ip() {
+        let data = [
+            0x00, 0x21, // Protocol: IP
+            0x45, 0x00, // IP header start
+        ];
+
+        let frame = PppFrame::parse(&data).unwrap();
+        assert_eq!(frame.protocol(), protocols::IP);
+        assert!(!frame.is_control());
+        assert!(frame.is_network());
+    }
+
+    #[test]
+    fn test_parse_pap() {
+        let data = [
+            0xc0, 0x23, // Protocol: PAP
+            0x01, 0x01, // PAP payload
+        ];
+
+        let frame = PppFrame::parse(&data).unwrap();
+        assert_eq!(frame.protocol(), protocols::PAP);
+        assert!(frame.is_control());
+    }
+
+    #[test]
+    fn test_parse_chap() {
+        let data = [
+            0xc2, 0x23, // Protocol: CHAP
+            0x01, 0x01, // CHAP payload
+        ];
+
+        let frame = PppFrame::parse(&data).unwrap();
+        assert_eq!(frame.protocol(), protocols::CHAP);
+        assert!(frame.is_control());
+    }
+
+    #[test]
+    fn test_build_lcp() {
+        let payload = [0x01, 0x01, 0x00, 0x04];
+        let frame = PppBuilder::lcp().payload(&payload).build();
+
+        assert_eq!(frame[0..2], [0xc0, 0x21]);
+        assert_eq!(&frame[2..], &payload);
+    }
+
+    #[test]
+    fn test_build_ipcp() {
+        let payload = [0x01, 0x02, 0x00, 0x0a];
+        let frame = PppBuilder::ipcp().payload(&payload).build();
+
+        assert_eq!(frame[0..2], [0x80, 0x21]);
+    }
+
+    #[test]
+    fn test_build_ip() {
+        let ip_packet = [0x45, 0x00, 0x00, 0x14];
+        let frame = PppBuilder::ip().payload(&ip_packet).build();
+
+        assert_eq!(frame[0..2], [0x00, 0x21]);
+        assert_eq!(&frame[2..], &ip_packet);
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let payload = [0x01, 0x02, 0x03, 0x04];
+        let frame = PppBuilder::lcp().payload(&payload).build();
+
+        let parsed = PppFrame::parse(&frame).unwrap();
+        assert_eq!(parsed.protocol(), protocols::LCP);
+        assert_eq!(parsed.payload(), &payload);
+    }
+
+    #[test]
+    fn test_parse_too_short() {
+        let data = [0xc0];
+        assert!(PppFrame::parse(&data).is_err());
+    }
+
+    #[test]
+    fn test_parse_empty_payload() {
+        let data = [0xc0, 0x21]; // Just protocol, no payload
+        let frame = PppFrame::parse(&data).unwrap();
+        assert_eq!(frame.protocol(), protocols::LCP);
+        assert!(frame.payload().is_empty());
+    }
+}

--- a/src/protocol/pppoe.rs
+++ b/src/protocol/pppoe.rs
@@ -1,0 +1,476 @@
+//! PPPoE protocol - RFC 2516
+//!
+//! Point-to-Point Protocol over Ethernet for establishing PPP sessions
+//! over Ethernet networks.
+
+use crate::{Error, Result};
+
+/// PPPoE Discovery EtherType
+pub const PPPOE_DISCOVERY_ETHERTYPE: u16 = 0x8863;
+
+/// PPPoE Session EtherType
+pub const PPPOE_SESSION_ETHERTYPE: u16 = 0x8864;
+
+/// PPPoE header size (ver/type + code + session_id + length)
+pub const PPPOE_HEADER_SIZE: usize = 6;
+
+/// PPPoE version (must be 1)
+pub const PPPOE_VERSION: u8 = 1;
+
+/// PPPoE type (must be 1)
+pub const PPPOE_TYPE: u8 = 1;
+
+/// PPPoE Discovery codes
+pub mod codes {
+    /// Active Discovery Initiation (broadcast from client)
+    pub const PADI: u8 = 0x09;
+    /// Active Discovery Offer (unicast from server)
+    pub const PADO: u8 = 0x07;
+    /// Active Discovery Request (unicast to server)
+    pub const PADR: u8 = 0x19;
+    /// Active Discovery Session-confirmation (assigns session_id)
+    pub const PADS: u8 = 0x65;
+    /// Active Discovery Terminate
+    pub const PADT: u8 = 0xa7;
+    /// Session data (code=0 in session stage)
+    pub const SESSION: u8 = 0x00;
+}
+
+/// PPPoE tag types used in Discovery packets
+pub mod tags {
+    /// End of list
+    pub const END_OF_LIST: u16 = 0x0000;
+    /// Service name (empty = any service)
+    pub const SERVICE_NAME: u16 = 0x0101;
+    /// Access Concentrator name
+    pub const AC_NAME: u16 = 0x0102;
+    /// Host unique identifier (used to match responses)
+    pub const HOST_UNIQ: u16 = 0x0103;
+    /// AC cookie (must be echoed back)
+    pub const AC_COOKIE: u16 = 0x0104;
+    /// Vendor specific
+    pub const VENDOR_SPECIFIC: u16 = 0x0105;
+    /// Relay session ID
+    pub const RELAY_SESSION_ID: u16 = 0x0110;
+    /// Service name error
+    pub const SERVICE_NAME_ERROR: u16 = 0x0201;
+    /// AC system error
+    pub const AC_SYSTEM_ERROR: u16 = 0x0202;
+    /// Generic error
+    pub const GENERIC_ERROR: u16 = 0x0203;
+}
+
+/// Parsed PPPoE frame (zero-copy reference)
+#[derive(Debug)]
+pub struct PppoeFrame<'a> {
+    buffer: &'a [u8],
+}
+
+impl<'a> PppoeFrame<'a> {
+    /// Parse PPPoE frame from buffer
+    pub fn parse(buffer: &'a [u8]) -> Result<Self> {
+        if buffer.len() < PPPOE_HEADER_SIZE {
+            return Err(Error::Parse("PPPoE frame too short".into()));
+        }
+
+        let frame = Self { buffer };
+
+        // Verify version and type
+        if frame.version() != PPPOE_VERSION || frame.frame_type() != PPPOE_TYPE {
+            return Err(Error::Parse(format!(
+                "Invalid PPPoE version/type: {}/{}",
+                frame.version(),
+                frame.frame_type()
+            )));
+        }
+
+        // Verify payload length matches
+        let payload_len = frame.length() as usize;
+        if buffer.len() < PPPOE_HEADER_SIZE + payload_len {
+            return Err(Error::Parse("PPPoE payload truncated".into()));
+        }
+
+        Ok(frame)
+    }
+
+    /// Version (4 bits, should be 1)
+    pub fn version(&self) -> u8 {
+        (self.buffer[0] >> 4) & 0x0f
+    }
+
+    /// Type (4 bits, should be 1)
+    pub fn frame_type(&self) -> u8 {
+        self.buffer[0] & 0x0f
+    }
+
+    /// Code (PADI, PADO, PADR, PADS, PADT, or 0 for session)
+    pub fn code(&self) -> u8 {
+        self.buffer[1]
+    }
+
+    /// Session ID (0 for discovery, assigned by server for session)
+    pub fn session_id(&self) -> u16 {
+        u16::from_be_bytes([self.buffer[2], self.buffer[3]])
+    }
+
+    /// Payload length
+    pub fn length(&self) -> u16 {
+        u16::from_be_bytes([self.buffer[4], self.buffer[5]])
+    }
+
+    /// Payload (tags for discovery, PPP frame for session)
+    pub fn payload(&self) -> &[u8] {
+        let len = self.length() as usize;
+        &self.buffer[PPPOE_HEADER_SIZE..PPPOE_HEADER_SIZE + len]
+    }
+
+    /// Iterate over tags in discovery payload
+    pub fn iter_tags(&self) -> PppoeTagIterator<'_> {
+        PppoeTagIterator {
+            data: self.payload(),
+            offset: 0,
+        }
+    }
+
+    /// Find a specific tag by type
+    pub fn find_tag(&self, tag_type: u16) -> Option<&[u8]> {
+        for tag in self.iter_tags() {
+            if tag.tag_type == tag_type {
+                return Some(tag.data);
+            }
+        }
+        None
+    }
+
+    /// Get the raw buffer
+    pub fn as_bytes(&self) -> &[u8] {
+        let len = PPPOE_HEADER_SIZE + self.length() as usize;
+        &self.buffer[..len]
+    }
+}
+
+/// A PPPoE tag during iteration
+#[derive(Debug, Clone)]
+pub struct PppoeTag<'a> {
+    /// Tag type
+    pub tag_type: u16,
+    /// Tag data
+    pub data: &'a [u8],
+}
+
+/// Iterator over PPPoE tags
+pub struct PppoeTagIterator<'a> {
+    data: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> Iterator for PppoeTagIterator<'a> {
+    type Item = PppoeTag<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Need at least 4 bytes for tag header (type + length)
+        if self.offset + 4 > self.data.len() {
+            return None;
+        }
+
+        let tag_type = u16::from_be_bytes([self.data[self.offset], self.data[self.offset + 1]]);
+        let tag_len =
+            u16::from_be_bytes([self.data[self.offset + 2], self.data[self.offset + 3]]) as usize;
+
+        // End of list
+        if tag_type == tags::END_OF_LIST && tag_len == 0 {
+            return None;
+        }
+
+        let data_start = self.offset + 4;
+        let data_end = data_start + tag_len;
+
+        if data_end > self.data.len() {
+            return None;
+        }
+
+        let tag = PppoeTag {
+            tag_type,
+            data: &self.data[data_start..data_end],
+        };
+
+        self.offset = data_end;
+        Some(tag)
+    }
+}
+
+/// Builder for PPPoE frames
+#[derive(Debug, Default)]
+pub struct PppoeBuilder {
+    code: u8,
+    session_id: u16,
+    payload: Vec<u8>,
+}
+
+impl PppoeBuilder {
+    /// Create a new builder for discovery packets
+    pub fn discovery() -> Self {
+        Self {
+            code: codes::PADI,
+            session_id: 0,
+            payload: Vec::new(),
+        }
+    }
+
+    /// Create a new builder for session packets
+    pub fn session(session_id: u16) -> Self {
+        Self {
+            code: codes::SESSION,
+            session_id,
+            payload: Vec::new(),
+        }
+    }
+
+    /// Set the code
+    pub fn code(mut self, code: u8) -> Self {
+        self.code = code;
+        self
+    }
+
+    /// Set the session ID
+    pub fn session_id(mut self, session_id: u16) -> Self {
+        self.session_id = session_id;
+        self
+    }
+
+    /// Add a raw tag (for discovery packets)
+    pub fn add_tag(mut self, tag_type: u16, data: &[u8]) -> Self {
+        self.payload.extend_from_slice(&tag_type.to_be_bytes());
+        self.payload
+            .extend_from_slice(&(data.len() as u16).to_be_bytes());
+        self.payload.extend_from_slice(data);
+        self
+    }
+
+    /// Add service name tag
+    pub fn service_name(self, name: &str) -> Self {
+        self.add_tag(tags::SERVICE_NAME, name.as_bytes())
+    }
+
+    /// Add empty service name tag (accept any service)
+    pub fn service_name_any(self) -> Self {
+        self.add_tag(tags::SERVICE_NAME, &[])
+    }
+
+    /// Add host unique tag
+    pub fn host_uniq(self, uniq: &[u8]) -> Self {
+        self.add_tag(tags::HOST_UNIQ, uniq)
+    }
+
+    /// Add AC cookie tag
+    pub fn ac_cookie(self, cookie: &[u8]) -> Self {
+        self.add_tag(tags::AC_COOKIE, cookie)
+    }
+
+    /// Set payload directly (for session packets containing PPP)
+    pub fn payload(mut self, data: &[u8]) -> Self {
+        self.payload = data.to_vec();
+        self
+    }
+
+    /// Build the PPPoE frame
+    pub fn build(self) -> Vec<u8> {
+        let mut frame = Vec::with_capacity(PPPOE_HEADER_SIZE + self.payload.len());
+
+        // Version (4 bits) + Type (4 bits) = 0x11
+        frame.push((PPPOE_VERSION << 4) | PPPOE_TYPE);
+        // Code
+        frame.push(self.code);
+        // Session ID
+        frame.extend_from_slice(&self.session_id.to_be_bytes());
+        // Length
+        frame.extend_from_slice(&(self.payload.len() as u16).to_be_bytes());
+        // Payload
+        frame.extend_from_slice(&self.payload);
+
+        frame
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_padi() {
+        // PPPoE PADI with Service-Name tag (empty)
+        let data = [
+            0x11, // Version=1, Type=1
+            0x09, // Code=PADI
+            0x00, 0x00, // Session ID=0
+            0x00, 0x04, // Length=4
+            0x01, 0x01, // Tag: Service-Name
+            0x00, 0x00, // Tag Length=0
+        ];
+
+        let frame = PppoeFrame::parse(&data).unwrap();
+        assert_eq!(frame.version(), 1);
+        assert_eq!(frame.frame_type(), 1);
+        assert_eq!(frame.code(), codes::PADI);
+        assert_eq!(frame.session_id(), 0);
+        assert_eq!(frame.length(), 4);
+
+        let tags: Vec<_> = frame.iter_tags().collect();
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].tag_type, tags::SERVICE_NAME);
+        assert_eq!(tags[0].data.len(), 0);
+    }
+
+    #[test]
+    fn test_parse_pado() {
+        // PPPoE PADO with Service-Name and AC-Name tags
+        let data = [
+            0x11, // Version=1, Type=1
+            0x07, // Code=PADO
+            0x00, 0x00, // Session ID=0
+            0x00, 0x10, // Length=16
+            0x01, 0x01, // Tag: Service-Name
+            0x00, 0x00, // Tag Length=0
+            0x01, 0x02, // Tag: AC-Name
+            0x00, 0x04, // Tag Length=4
+            b't', b'e', b's', b't', // AC Name
+            0x01, 0x04, // Tag: AC-Cookie
+            0x00, 0x00, // Tag Length=0
+        ];
+
+        let frame = PppoeFrame::parse(&data).unwrap();
+        assert_eq!(frame.code(), codes::PADO);
+
+        let ac_name = frame.find_tag(tags::AC_NAME).unwrap();
+        assert_eq!(ac_name, b"test");
+    }
+
+    #[test]
+    fn test_parse_pads() {
+        // PPPoE PADS with session ID
+        let data = [
+            0x11, // Version=1, Type=1
+            0x65, // Code=PADS
+            0x00, 0x01, // Session ID=1
+            0x00, 0x04, // Length=4
+            0x01, 0x01, // Tag: Service-Name
+            0x00, 0x00, // Tag Length=0
+        ];
+
+        let frame = PppoeFrame::parse(&data).unwrap();
+        assert_eq!(frame.code(), codes::PADS);
+        assert_eq!(frame.session_id(), 1);
+    }
+
+    #[test]
+    fn test_parse_session() {
+        // PPPoE Session with PPP payload
+        let data = [
+            0x11, // Version=1, Type=1
+            0x00, // Code=0 (Session)
+            0x00, 0x01, // Session ID=1
+            0x00, 0x04, // Length=4
+            0xc0, 0x21, // PPP Protocol: LCP
+            0x01, 0x02, // Some LCP data
+        ];
+
+        let frame = PppoeFrame::parse(&data).unwrap();
+        assert_eq!(frame.code(), codes::SESSION);
+        assert_eq!(frame.session_id(), 1);
+        assert_eq!(frame.payload(), &[0xc0, 0x21, 0x01, 0x02]);
+    }
+
+    #[test]
+    fn test_build_padi() {
+        let frame = PppoeBuilder::discovery()
+            .code(codes::PADI)
+            .service_name_any()
+            .host_uniq(&[0x12, 0x34, 0x56, 0x78])
+            .build();
+
+        let parsed = PppoeFrame::parse(&frame).unwrap();
+        assert_eq!(parsed.code(), codes::PADI);
+        assert_eq!(parsed.session_id(), 0);
+
+        let host_uniq = parsed.find_tag(tags::HOST_UNIQ).unwrap();
+        assert_eq!(host_uniq, &[0x12, 0x34, 0x56, 0x78]);
+    }
+
+    #[test]
+    fn test_build_padr() {
+        let frame = PppoeBuilder::discovery()
+            .code(codes::PADR)
+            .service_name("ISP")
+            .ac_cookie(&[0xaa, 0xbb])
+            .build();
+
+        let parsed = PppoeFrame::parse(&frame).unwrap();
+        assert_eq!(parsed.code(), codes::PADR);
+
+        let service_name = parsed.find_tag(tags::SERVICE_NAME).unwrap();
+        assert_eq!(service_name, b"ISP");
+
+        let cookie = parsed.find_tag(tags::AC_COOKIE).unwrap();
+        assert_eq!(cookie, &[0xaa, 0xbb]);
+    }
+
+    #[test]
+    fn test_build_padt() {
+        let frame = PppoeBuilder::discovery()
+            .code(codes::PADT)
+            .session_id(0x1234)
+            .build();
+
+        let parsed = PppoeFrame::parse(&frame).unwrap();
+        assert_eq!(parsed.code(), codes::PADT);
+        assert_eq!(parsed.session_id(), 0x1234);
+    }
+
+    #[test]
+    fn test_build_session() {
+        let ppp_data = [0xc0, 0x21, 0x01, 0x01, 0x00, 0x04]; // LCP Configure-Request
+
+        let frame = PppoeBuilder::session(0x0001).payload(&ppp_data).build();
+
+        let parsed = PppoeFrame::parse(&frame).unwrap();
+        assert_eq!(parsed.code(), codes::SESSION);
+        assert_eq!(parsed.session_id(), 0x0001);
+        assert_eq!(parsed.payload(), &ppp_data);
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let original = PppoeBuilder::discovery()
+            .code(codes::PADI)
+            .service_name("test-service")
+            .host_uniq(&[1, 2, 3, 4])
+            .build();
+
+        let parsed = PppoeFrame::parse(&original).unwrap();
+        assert_eq!(parsed.as_bytes(), original.as_slice());
+    }
+
+    #[test]
+    fn test_parse_invalid_version() {
+        let data = [
+            0x21, // Version=2 (invalid), Type=1
+            0x09, 0x00, 0x00, 0x00, 0x00,
+        ];
+        assert!(PppoeFrame::parse(&data).is_err());
+    }
+
+    #[test]
+    fn test_parse_too_short() {
+        let data = [0x11, 0x09, 0x00];
+        assert!(PppoeFrame::parse(&data).is_err());
+    }
+
+    #[test]
+    fn test_parse_truncated_payload() {
+        let data = [
+            0x11, 0x09, 0x00, 0x00, 0x00, 0x10, // Length=16 but only 2 bytes follow
+            0x01, 0x01,
+        ];
+        assert!(PppoeFrame::parse(&data).is_err());
+    }
+}

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -127,6 +127,8 @@ pub enum EtherType {
     Arp = 0x0806,
     Vlan = 0x8100,
     Ipv6 = 0x86DD,
+    PppoeDiscovery = 0x8863,
+    PppoeSession = 0x8864,
 }
 
 impl EtherType {
@@ -136,6 +138,8 @@ impl EtherType {
             0x0806 => Some(EtherType::Arp),
             0x8100 => Some(EtherType::Vlan),
             0x86DD => Some(EtherType::Ipv6),
+            0x8863 => Some(EtherType::PppoeDiscovery),
+            0x8864 => Some(EtherType::PppoeSession),
             _ => None,
         }
     }


### PR DESCRIPTION
## Summary

- Implement RFC 2516 PPPoE client with full session establishment
- Discovery Stage: PADI/PADO/PADR/PADS packet exchange
- LCP negotiation: MRU, Magic-Number, Auth-Protocol options
- Authentication: PAP and CHAP (MD5) support
- IPCP: IPv4 address and DNS server negotiation
- Session maintenance: LCP Echo keepalive

### New protocol modules

- `src/protocol/pppoe.rs`: PPPoE frame parsing/building
- `src/protocol/ppp.rs`: PPP encapsulation
- `src/protocol/lcp.rs`: Link Control Protocol
- `src/protocol/pap.rs`: PAP authentication
- `src/protocol/chap.rs`: CHAP authentication with MD5
- `src/protocol/ipcp.rs`: IPCP for IPv4 configuration

### New dataplane module

- `src/dataplane/pppoe_client.rs`: State machine implementation

Closes #23

## Test plan

- [x] All unit tests pass (466 tests)
- [x] Code formatted with `cargo fmt`
- [x] No clippy warnings
- [ ] E2E test with PPPoE server (to be addressed in separate issue)