### PR TITLE
feat(e2e): Use feature flag instead of #[ignore] for E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run E2E tests
         run: |
-          cargo test --test e2e -- --ignored --test-threads=1 2>&1 || echo "E2E tests failed (expected until main loop is implemented)"
+          cargo test --test e2e --features e2e -- --test-threads=1 2>&1 || echo "E2E tests failed (expected until main loop is implemented)"
 
       - name: Show test results
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ cargo fmt
 cargo clippy
 
 # E2Eテスト（Docker/Containerlab必要）
-cargo test --test e2e -- --ignored --test-threads=1
+cargo test --test e2e --features e2e -- --test-threads=1
 ```
 
 ## プロジェクト構造

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ sha2 = "0.10"
 
 [dev-dependencies]
 tempfile = "3"
+
+[features]
+e2e = []

--- a/tests/e2e/home_router.rs
+++ b/tests/e2e/home_router.rs
@@ -81,7 +81,7 @@ fn wait_for_dhcp(topo: &Topology, node: &str, interface: &str, timeout_secs: u64
 
 /// Test: ruster WAN interface obtains IP via DHCP from ISP
 #[test]
-#[ignore]
+#[cfg_attr(not(feature = "e2e"), ignore)]
 fn test_wan_dhcp_acquisition() {
     let topo = Topology::deploy(home_router_topology()).expect("Failed to deploy topology");
 
@@ -109,7 +109,7 @@ fn test_wan_dhcp_acquisition() {
 
 /// Test: ruster can reach ISP gateway after DHCP
 #[test]
-#[ignore]
+#[cfg_attr(not(feature = "e2e"), ignore)]
 fn test_wan_dhcp_gateway_reachable() {
     let topo = Topology::deploy(home_router_topology()).expect("Failed to deploy topology");
 
@@ -135,7 +135,7 @@ fn test_wan_dhcp_gateway_reachable() {
 
 /// Test: LAN client obtains IP from ruster DHCP server
 #[test]
-#[ignore]
+#[cfg_attr(not(feature = "e2e"), ignore)]
 fn test_dhcp_server_lan_client() {
     let topo = Topology::deploy(home_router_topology()).expect("Failed to deploy topology");
 
@@ -162,7 +162,7 @@ fn test_dhcp_server_lan_client() {
 
 /// Test: Client receives correct gateway and DNS from DHCP
 #[test]
-#[ignore]
+#[cfg_attr(not(feature = "e2e"), ignore)]
 fn test_dhcp_server_options() {
     let topo = Topology::deploy(home_router_topology()).expect("Failed to deploy topology");
 
@@ -195,7 +195,7 @@ fn test_dhcp_server_options() {
 
 /// Test: LAN client can reach internet server through NAT
 #[test]
-#[ignore]
+#[cfg_attr(not(feature = "e2e"), ignore)]
 fn test_nat_outbound_connectivity() {
     let topo = Topology::deploy(home_router_topology()).expect("Failed to deploy topology");
 
@@ -238,7 +238,7 @@ fn test_nat_outbound_connectivity() {
 
 /// Test: DNS forwarder responds to client queries
 #[test]
-#[ignore]
+#[cfg_attr(not(feature = "e2e"), ignore)]
 fn test_dns_forwarder_responds() {
     let topo = Topology::deploy(home_router_topology()).expect("Failed to deploy topology");
 
@@ -275,7 +275,7 @@ fn test_dns_forwarder_responds() {
 
 /// Test: Complete home router scenario with DHCP WAN
 #[test]
-#[ignore]
+#[cfg_attr(not(feature = "e2e"), ignore)]
 fn test_home_router_full_scenario() {
     let topo = Topology::deploy(home_router_topology()).expect("Failed to deploy topology");
 

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -1,6 +1,6 @@
 //! E2E tests using containerlab
 //!
-//! Run with: cargo test --test e2e -- --ignored
+//! Run with: cargo test --test e2e --features e2e -- --test-threads=1
 //!
 //! Prerequisites:
 //! - containerlab installed
@@ -31,7 +31,7 @@ fn topology_path() -> PathBuf {
 /// This test verifies that hosts can reach ruster's directly connected interfaces.
 /// Does NOT require ruster's packet processing - uses Linux kernel networking.
 #[test]
-#[ignore] // Requires containerlab and sudo
+#[cfg_attr(not(feature = "e2e"), ignore)]
 fn test_ping_connectivity() {
     let topo = Topology::deploy(topology_path()).expect("Failed to deploy topology");
 
@@ -77,7 +77,7 @@ fn test_ping_connectivity() {
 /// 2. Disable kernel IP forwarding
 /// 3. Verify traffic flows through ruster
 #[test]
-#[ignore] // Requires containerlab, sudo, and ruster implementation
+#[cfg_attr(not(feature = "e2e"), ignore)]
 fn test_routing_through_ruster() {
     let topo = Topology::deploy(topology_path()).expect("Failed to deploy topology");
 
@@ -104,7 +104,7 @@ fn test_routing_through_ruster() {
 
 /// Test ARP resolution works correctly
 #[test]
-#[ignore] // Requires containerlab and sudo
+#[cfg_attr(not(feature = "e2e"), ignore)]
 fn test_arp_resolution() {
     let topo = Topology::deploy(topology_path()).expect("Failed to deploy topology");
 
@@ -124,7 +124,7 @@ fn test_arp_resolution() {
 
 /// Test ICMP echo reply (ping response)
 #[test]
-#[ignore] // Requires containerlab and sudo
+#[cfg_attr(not(feature = "e2e"), ignore)]
 fn test_icmp_echo_reply() {
     let topo = Topology::deploy(topology_path()).expect("Failed to deploy topology");
 


### PR DESCRIPTION
## Summary

- Add `e2e` feature flag to Cargo.toml
- Replace `#[ignore]` with `#[cfg_attr(not(feature = "e2e"), ignore)]` for 11 E2E tests
- Update GitHub Actions workflow to use `--features e2e` instead of `--ignored`
- Update documentation in CLAUDE.md

## New Usage

```bash
# E2E tests (requires Docker/Containerlab)
cargo test --test e2e --features e2e -- --test-threads=1
```

Closes #64