### PR TITLE
fix(e2e): Enable IP forwarding and use alpine for main.rs E2E tests

### DIFF
--- a/tests/clab/topology.yml
+++ b/tests/clab/topology.yml
@@ -5,18 +5,19 @@ topology:
     # Device Under Test - ruster router
     ruster:
       kind: linux
-      image: debian:bookworm-slim
+      image: alpine:3.19
       binds:
         - ../../target/release/ruster:/usr/local/bin/ruster:ro
         - ./config.toml:/etc/ruster/config.toml:ro
       exec:
+        - sysctl -w net.ipv4.ip_forward=1
         - ip addr add 10.0.1.1/24 dev eth1
         - ip addr add 10.0.2.1/24 dev eth2
 
     # Client host
     client:
       kind: linux
-      image: debian:bookworm-slim
+      image: alpine:3.19
       exec:
         - ip addr add 10.0.1.2/24 dev eth1
         - ip route add 10.0.2.0/24 via 10.0.1.1
@@ -24,7 +25,7 @@ topology:
     # Server host
     server:
       kind: linux
-      image: debian:bookworm-slim
+      image: alpine:3.19
       exec:
         - ip addr add 10.0.2.2/24 dev eth1
         - ip route add 10.0.1.0/24 via 10.0.2.1


### PR DESCRIPTION
## Summary
- Add `sysctl -w net.ipv4.ip_forward=1` to ruster node in `tests/clab/topology.yml`
- Change container image from `debian:bookworm-slim` to `alpine:3.19` (debian-slim lacks `ip`/`sysctl` commands)

## Test plan
- [x] All 11 E2E tests pass locally (`cargo test --test e2e --features e2e -- --test-threads=1`)

Closes #67