### PR TITLE
fix(ci): Make E2E workflow fail properly on test failures

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,8 +14,6 @@ jobs:
   e2e:
     name: Containerlab E2E
     runs-on: ubuntu-latest
-    # E2E tests are currently expected to fail until ruster main loop is implemented
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -32,14 +30,8 @@ jobs:
 
       - name: Pull container images
         run: |
-          docker pull debian:bookworm-slim
+          docker pull alpine:3.19
 
       - name: Run E2E tests
         run: |
-          cargo test --test e2e --features e2e -- --test-threads=1 2>&1 || echo "E2E tests failed (expected until main loop is implemented)"
-
-      - name: Show test results
-        if: always()
-        run: |
-          echo "Note: E2E tests require ruster main loop to be implemented."
-          echo "Current status: Infrastructure ready, waiting for packet processing loop."
+          cargo test --test e2e --features e2e -- --test-threads=1


### PR DESCRIPTION
## Summary
- Remove `continue-on-error: true` that masked job failures
- Remove `|| echo` fallback that masked step failures  
- Update container image to `alpine:3.19` (matching topology.yml)
- Remove outdated comments

## Note
Depends on #70 being merged first (topology.yml fix).

## Test plan
- [ ] CI E2E tests should now fail red when tests actually fail