### PR TITLE
feat(config): strict router.toml loader with schema validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,9 @@ dependencies = [
 [[package]]
 name = "ruster-dataplane"
 version = "0.1.0"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "ruster-observe"

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,28 +1,160 @@
-use serde::{Deserialize, Serialize};
-use thiserror::Error;
+pub mod model;
+pub mod validate;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RouterConfig {
-    pub hostname: String,
-}
+pub use model::RouterConfig;
+pub use validate::ValidationError;
+
+use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ConfigError {
     #[error("failed to parse config: {0}")]
     Parse(#[from] toml::de::Error),
+
+    #[error("failed to read config file: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("validation failed:\n{}", .0.iter().map(|e| format!("  - {e}")).collect::<Vec<_>>().join("\n"))]
+    Validation(Vec<ValidationError>),
 }
 
 pub fn load_from_str(input: &str) -> Result<RouterConfig, ConfigError> {
-    toml::from_str(input).map_err(ConfigError::from)
+    let config: RouterConfig = toml::from_str(input)?;
+    validate::validate(&config).map_err(ConfigError::Validation)?;
+    Ok(config)
+}
+
+pub fn load_from_file(path: &str) -> Result<RouterConfig, ConfigError> {
+    let content = std::fs::read_to_string(path)?;
+    load_from_str(&content)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
+
+    fn example_toml() -> String {
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.pop(); // crates
+        path.pop(); // project root
+        path.push("router.toml.example");
+        std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()))
+    }
+
+    fn make_valid_toml() -> String {
+        example_toml()
+    }
 
     #[test]
-    fn parse_minimal_config() {
-        let cfg = load_from_str("hostname = \"ruster-lab\"").expect("valid config");
-        assert_eq!(cfg.hostname, "ruster-lab");
+    fn load_example_toml_succeeds() {
+        let cfg = load_from_str(&example_toml()).expect("example config should be valid");
+        assert_eq!(cfg.meta.hostname, "ruster-lab");
+        assert_eq!(cfg.interfaces.len(), 3);
+        assert_eq!(cfg.l2.bridge_domains.len(), 2);
+    }
+
+    #[test]
+    fn reject_unknown_field() {
+        let toml = format!("{}\n[extra]\nfoo = 1\n", make_valid_toml());
+        let err = load_from_str(&toml).unwrap_err();
+        assert!(matches!(err, ConfigError::Parse(_)));
+    }
+
+    #[test]
+    fn reject_duplicate_interface_name() {
+        let toml = make_valid_toml().replace("name = \"lan1\"", "name = \"lan0\"");
+        let err = load_from_str(&toml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("interfaces.name"),
+            "error should mention field: {msg}"
+        );
+        assert!(
+            msg.contains("duplicate"),
+            "error should mention reason: {msg}"
+        );
+    }
+
+    #[test]
+    fn reject_duplicate_port_id() {
+        let toml = make_valid_toml().replace("port_id = 2", "port_id = 1");
+        let err = load_from_str(&toml).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("port_id"), "error should mention field: {msg}");
+        assert!(
+            msg.contains("duplicate"),
+            "error should mention reason: {msg}"
+        );
+    }
+
+    #[test]
+    fn reject_bridge_domain_unknown_member() {
+        let toml = make_valid_toml().replace(
+            r#"members = ["lan0", "lan1"]"#,
+            r#"members = ["lan0", "nonexistent"]"#,
+        );
+        let err = load_from_str(&toml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("bridge_domains"),
+            "error should mention field: {msg}"
+        );
+        assert!(
+            msg.contains("nonexistent"),
+            "error should mention reason: {msg}"
+        );
+    }
+
+    #[test]
+    fn reject_static_route_unknown_out_if() {
+        let toml = make_valid_toml().replace(r#"out_if = "wan0""#, r#"out_if = "noexist""#);
+        let err = load_from_str(&toml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("static_routes"),
+            "error should mention field: {msg}"
+        );
+        assert!(
+            msg.contains("noexist"),
+            "error should mention reason: {msg}"
+        );
+    }
+
+    #[test]
+    fn reject_nat_external_if_not_wan() {
+        let toml = make_valid_toml().replace(r#"external_if = "wan0""#, r#"external_if = "lan0""#);
+        let err = load_from_str(&toml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("nat.external_if"),
+            "error should mention field: {msg}"
+        );
+    }
+
+    #[test]
+    fn reject_nat_enabled_without_firewall() {
+        let toml =
+            make_valid_toml().replace("[firewall]\nenabled = true", "[firewall]\nenabled = false");
+        let err = load_from_str(&toml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("nat.enabled"),
+            "error should mention field: {msg}"
+        );
+        assert!(
+            msg.contains("firewall"),
+            "error should mention reason: {msg}"
+        );
+    }
+
+    #[test]
+    fn reject_firewall_rule_empty_state() {
+        let toml = make_valid_toml().replace(r#"state = ["new"]"#, r#"state = []"#);
+        let err = load_from_str(&toml).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("state"), "error should mention field: {msg}");
+        assert!(msg.contains("empty"), "error should mention reason: {msg}");
     }
 }

--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -1,0 +1,202 @@
+use serde::{Deserialize, Serialize};
+
+// ── Enums ──
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum InterfaceRole {
+    Wan,
+    Lan,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum InterfaceZone {
+    Wan,
+    Lan,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NatMode {
+    Napt44,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PortForwardProto {
+    Tcp,
+    Udp,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DefaultPolicy {
+    Accept,
+    Drop,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Chain {
+    Input,
+    Forward,
+    Output,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RuleAction {
+    Accept,
+    Drop,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RuleProto {
+    Any,
+    Tcp,
+    Udp,
+    Icmp,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FirewallZone {
+    Wan,
+    Lan,
+    Any,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ConnState {
+    New,
+    Established,
+    Related,
+}
+
+// ── Structs ──
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetaConfig {
+    pub schema: String,
+    pub hostname: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DataplaneConfig {
+    pub backend: String,
+    pub lcore_list: String,
+    pub memory_mb: u32,
+    pub rx_queue_size: u32,
+    pub tx_queue_size: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct InterfaceConfig {
+    pub name: String,
+    pub port_id: u16,
+    pub role: InterfaceRole,
+    pub admin_up: bool,
+    pub mtu: u16,
+    pub mac: String,
+    pub ipv4_addrs: Vec<String>,
+    pub zone: InterfaceZone,
+    pub l2_domain: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BridgeDomain {
+    pub name: String,
+    pub members: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct L2Config {
+    pub mac_table_max_entries: u32,
+    pub mac_aging_sec: u32,
+    pub arp_table_max_entries: u32,
+    pub arp_timeout_sec: u32,
+    pub bridge_domains: Vec<BridgeDomain>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StaticRoute {
+    pub prefix: String,
+    pub next_hop: String,
+    pub out_if: String,
+    pub metric: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RoutingConfig {
+    pub ipv4_static_routes: Vec<StaticRoute>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PortForward {
+    pub name: String,
+    pub proto: PortForwardProto,
+    pub external_port: u16,
+    pub internal_addr: String,
+    pub internal_port: u16,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NatConfig {
+    pub enabled: bool,
+    pub mode: NatMode,
+    pub external_if: String,
+    pub hairpin: bool,
+    pub session_table_max_entries: u32,
+    pub tcp_established_timeout_sec: u32,
+    pub tcp_transitory_timeout_sec: u32,
+    pub udp_timeout_sec: u32,
+    pub icmp_timeout_sec: u32,
+    pub port_forwards: Vec<PortForward>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FirewallRule {
+    pub name: String,
+    pub chain: Chain,
+    pub action: RuleAction,
+    pub proto: RuleProto,
+    pub src_zone: FirewallZone,
+    pub dst_zone: FirewallZone,
+    pub state: Vec<ConnState>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FirewallConfig {
+    pub enabled: bool,
+    pub default_input: DefaultPolicy,
+    pub default_forward: DefaultPolicy,
+    pub default_output: DefaultPolicy,
+    pub allow_established_related: bool,
+    pub rules: Vec<FirewallRule>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RouterConfig {
+    pub meta: MetaConfig,
+    pub dataplane: DataplaneConfig,
+    pub interfaces: Vec<InterfaceConfig>,
+    pub l2: L2Config,
+    pub routing: RoutingConfig,
+    pub nat: NatConfig,
+    pub firewall: FirewallConfig,
+}

--- a/crates/config/src/validate.rs
+++ b/crates/config/src/validate.rs
@@ -1,0 +1,131 @@
+use crate::model::{InterfaceRole, RouterConfig};
+use std::collections::HashSet;
+
+#[derive(Debug)]
+pub struct ValidationError {
+    pub field: String,
+    pub reason: String,
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.field, self.reason)
+    }
+}
+
+pub fn validate(config: &RouterConfig) -> Result<(), Vec<ValidationError>> {
+    let mut errors = Vec::new();
+
+    check_unique_interface_names(config, &mut errors);
+    check_unique_port_ids(config, &mut errors);
+    check_bridge_domain_members(config, &mut errors);
+    check_static_route_out_ifs(config, &mut errors);
+    check_nat_external_if(config, &mut errors);
+    check_nat_requires_firewall(config, &mut errors);
+    check_firewall_rule_states(config, &mut errors);
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}
+
+fn interface_names(config: &RouterConfig) -> HashSet<&str> {
+    config.interfaces.iter().map(|i| i.name.as_str()).collect()
+}
+
+fn check_unique_interface_names(config: &RouterConfig, errors: &mut Vec<ValidationError>) {
+    let mut seen = HashSet::new();
+    for iface in &config.interfaces {
+        if !seen.insert(&iface.name) {
+            errors.push(ValidationError {
+                field: format!("interfaces.name={}", iface.name),
+                reason: "duplicate interface name".to_string(),
+            });
+        }
+    }
+}
+
+fn check_unique_port_ids(config: &RouterConfig, errors: &mut Vec<ValidationError>) {
+    let mut seen = HashSet::new();
+    for iface in &config.interfaces {
+        if !seen.insert(iface.port_id) {
+            errors.push(ValidationError {
+                field: format!("interfaces.port_id={}", iface.port_id),
+                reason: "duplicate port_id".to_string(),
+            });
+        }
+    }
+}
+
+fn check_bridge_domain_members(config: &RouterConfig, errors: &mut Vec<ValidationError>) {
+    let names = interface_names(config);
+    for bd in &config.l2.bridge_domains {
+        for member in &bd.members {
+            if !names.contains(member.as_str()) {
+                errors.push(ValidationError {
+                    field: format!("l2.bridge_domains[name={}].members", bd.name),
+                    reason: format!("member '{}' not found in interfaces", member),
+                });
+            }
+        }
+    }
+}
+
+fn check_static_route_out_ifs(config: &RouterConfig, errors: &mut Vec<ValidationError>) {
+    let names = interface_names(config);
+    for route in &config.routing.ipv4_static_routes {
+        if !names.contains(route.out_if.as_str()) {
+            errors.push(ValidationError {
+                field: format!("routing.ipv4_static_routes[prefix={}].out_if", route.prefix),
+                reason: format!("out_if '{}' not found in interfaces", route.out_if),
+            });
+        }
+    }
+}
+
+fn check_nat_external_if(config: &RouterConfig, errors: &mut Vec<ValidationError>) {
+    let wan_if = config
+        .interfaces
+        .iter()
+        .find(|i| i.name == config.nat.external_if);
+    match wan_if {
+        None => {
+            errors.push(ValidationError {
+                field: "nat.external_if".to_string(),
+                reason: format!("'{}' not found in interfaces", config.nat.external_if),
+            });
+        }
+        Some(iface) if iface.role != InterfaceRole::Wan => {
+            errors.push(ValidationError {
+                field: "nat.external_if".to_string(),
+                reason: format!(
+                    "'{}' has role {:?}, expected wan",
+                    config.nat.external_if, iface.role
+                ),
+            });
+        }
+        _ => {}
+    }
+}
+
+fn check_nat_requires_firewall(config: &RouterConfig, errors: &mut Vec<ValidationError>) {
+    if config.nat.enabled && !config.firewall.enabled {
+        errors.push(ValidationError {
+            field: "nat.enabled".to_string(),
+            reason: "nat.enabled=true requires firewall.enabled=true".to_string(),
+        });
+    }
+}
+
+fn check_firewall_rule_states(config: &RouterConfig, errors: &mut Vec<ValidationError>) {
+    for rule in &config.firewall.rules {
+        if rule.state.is_empty() {
+            errors.push(ValidationError {
+                field: format!("firewall.rules[name={}].state", rule.name),
+                reason: "state must not be empty".to_string(),
+            });
+        }
+    }
+}

--- a/crates/control/src/lib.rs
+++ b/crates/control/src/lib.rs
@@ -7,7 +7,7 @@ pub struct PlanResult {
 }
 
 pub fn validate(config: &RouterConfig) -> Result<()> {
-    if config.hostname.trim().is_empty() {
+    if config.meta.hostname.trim().is_empty() {
         bail!("hostname must not be empty");
     }
     Ok(())

--- a/crates/main/src/main.rs
+++ b/crates/main/src/main.rs
@@ -1,12 +1,9 @@
 use anyhow::Result;
-use ruster_config::RouterConfig;
 use ruster_dataplane::Dataplane;
 use ruster_observe::Counters;
 
 fn main() -> Result<()> {
-    let config = RouterConfig {
-        hostname: "ruster-lab".to_string(),
-    };
+    let config = ruster_config::load_from_file("router.toml.example")?;
     ruster_control::validate(&config)?;
 
     let dataplane = Dataplane::new();
@@ -15,6 +12,6 @@ fn main() -> Result<()> {
     let mut counters = Counters::default();
     counters.inc_drop();
 
-    println!("ruster bootstrap ok: hostname={}", config.hostname);
+    println!("ruster bootstrap ok: hostname={}", config.meta.hostname);
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Implement complete serde model matching `docs/router-toml-schema-v0.1.md` with `deny_unknown_fields` on all structs (strict mode)
- Implement all 7 validation rules: unique IF names/port_ids, bridge domain member refs, route out_if refs, NAT external_if wan check, NAT→FW dependency, FW rule state non-empty
- Add `load_from_file()` for file-based config loading
- Update main/control crates for new `RouterConfig` structure

## Test plan
- [x] `router.toml.example` parses and validates successfully
- [x] Unknown fields rejected (strict deserialization)
- [x] All 7 validation rules have dedicated test cases
- [x] `cargo test --workspace` passes (9 new tests)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)