### PR TITLE
feat(dataplane): DPDK startup abstraction with mock backend

### DIFF
--- a/crates/dataplane/Cargo.toml
+++ b/crates/dataplane/Cargo.toml
@@ -6,3 +6,4 @@ license.workspace = true
 publish.workspace = true
 
 [dependencies]
+thiserror.workspace = true

--- a/crates/dataplane/src/dpdk/backend.rs
+++ b/crates/dataplane/src/dpdk/backend.rs
@@ -1,0 +1,22 @@
+use super::config::{DpdkConfig, PortConfig};
+use super::context::{MempoolHandle, PortHandle};
+use super::error::DpdkError;
+
+/// Abstraction over real DPDK FFI so the init flow can be tested with mocks.
+pub trait DpdkBackend: Send + Sync {
+    /// Initialise the DPDK EAL.
+    fn eal_init(&self, config: &DpdkConfig) -> Result<(), DpdkError>;
+
+    /// Create the packet mempool.
+    fn create_mempool(&self, config: &DpdkConfig) -> Result<MempoolHandle, DpdkError>;
+
+    /// Configure and set up queues for a single port.
+    fn init_port(
+        &self,
+        port: &PortConfig,
+        mempool: &MempoolHandle,
+    ) -> Result<PortHandle, DpdkError>;
+
+    /// Start an already-configured port.
+    fn start_port(&self, handle: &PortHandle) -> Result<(), DpdkError>;
+}

--- a/crates/dataplane/src/dpdk/config.rs
+++ b/crates/dataplane/src/dpdk/config.rs
@@ -1,0 +1,51 @@
+use super::error::DpdkError;
+
+/// DPDK startup configuration.
+#[derive(Debug, Clone)]
+pub struct DpdkConfig {
+    /// EAL lcore list, e.g. "0-3".
+    pub lcore_list: String,
+    /// Hugepage memory in MiB.
+    pub memory_mb: u32,
+    /// Per-port RX descriptor ring size.
+    pub rx_queue_size: u16,
+    /// Per-port TX descriptor ring size.
+    pub tx_queue_size: u16,
+    /// Port configurations (only `admin_up = true` ports are initialised).
+    pub ports: Vec<PortConfig>,
+}
+
+/// Per-port configuration.
+#[derive(Debug, Clone)]
+pub struct PortConfig {
+    pub name: String,
+    pub port_id: u16,
+    pub mtu: u16,
+    pub mac: [u8; 6],
+    pub admin_up: bool,
+    /// Number of RX queues (v0.1: always 1).
+    pub rx_queues: u16,
+    /// Number of TX queues (v0.1: always 1).
+    pub tx_queues: u16,
+}
+
+impl DpdkConfig {
+    /// Validate configuration before EAL init.
+    pub fn validate(&self) -> Result<(), DpdkError> {
+        if self.lcore_list.is_empty() {
+            return Err(DpdkError::Config(
+                "lcore_list must not be empty".to_string(),
+            ));
+        }
+        if self.memory_mb == 0 {
+            return Err(DpdkError::Config("memory_mb must be > 0".to_string()));
+        }
+        if self.rx_queue_size == 0 {
+            return Err(DpdkError::Config("rx_queue_size must be > 0".to_string()));
+        }
+        if self.tx_queue_size == 0 {
+            return Err(DpdkError::Config("tx_queue_size must be > 0".to_string()));
+        }
+        Ok(())
+    }
+}

--- a/crates/dataplane/src/dpdk/context.rs
+++ b/crates/dataplane/src/dpdk/context.rs
@@ -1,0 +1,20 @@
+/// Opaque handle to a DPDK mempool.
+#[derive(Debug)]
+pub struct MempoolHandle {
+    pub name: String,
+    pub capacity: u32,
+}
+
+/// Opaque handle to an initialised DPDK port.
+#[derive(Debug)]
+pub struct PortHandle {
+    pub port_id: u16,
+    pub name: String,
+}
+
+/// State retained after successful DPDK initialisation.
+#[derive(Debug)]
+pub struct DpdkContext {
+    pub mempool: MempoolHandle,
+    pub ports: Vec<PortHandle>,
+}

--- a/crates/dataplane/src/dpdk/error.rs
+++ b/crates/dataplane/src/dpdk/error.rs
@@ -1,0 +1,26 @@
+/// DPDK subsystem errors.
+#[derive(Debug, thiserror::Error)]
+pub enum DpdkError {
+    #[error("EAL initialization failed: {reason}")]
+    EalInit { reason: String },
+
+    #[error("mempool creation failed: {reason}")]
+    MempoolCreate { reason: String },
+
+    #[error("port {port_id} ({name}) initialization failed: {reason}")]
+    PortInit {
+        port_id: u16,
+        name: String,
+        reason: String,
+    },
+
+    #[error("port {port_id} ({name}) start failed: {reason}")]
+    PortStart {
+        port_id: u16,
+        name: String,
+        reason: String,
+    },
+
+    #[error("configuration error: {0}")]
+    Config(String),
+}

--- a/crates/dataplane/src/dpdk/mock.rs
+++ b/crates/dataplane/src/dpdk/mock.rs
@@ -1,0 +1,78 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+
+use super::backend::DpdkBackend;
+use super::config::{DpdkConfig, PortConfig};
+use super::context::{MempoolHandle, PortHandle};
+use super::error::DpdkError;
+
+/// Test-only DPDK backend that never touches real hardware.
+#[derive(Debug, Default)]
+pub struct MockDpdkBackend {
+    pub fail_eal_init: AtomicBool,
+    pub fail_mempool: AtomicBool,
+    /// If `Some(port_id)`, `init_port` will fail for that port.
+    pub fail_port_init: Mutex<Option<u16>>,
+    /// If `Some(port_id)`, `start_port` will fail for that port.
+    pub fail_port_start: Mutex<Option<u16>>,
+}
+
+impl MockDpdkBackend {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl DpdkBackend for MockDpdkBackend {
+    fn eal_init(&self, _config: &DpdkConfig) -> Result<(), DpdkError> {
+        if self.fail_eal_init.load(Ordering::Relaxed) {
+            return Err(DpdkError::EalInit {
+                reason: "mock EAL init failure".to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    fn create_mempool(&self, config: &DpdkConfig) -> Result<MempoolHandle, DpdkError> {
+        if self.fail_mempool.load(Ordering::Relaxed) {
+            return Err(DpdkError::MempoolCreate {
+                reason: "mock mempool creation failure".to_string(),
+            });
+        }
+        Ok(MempoolHandle {
+            name: "mock_mempool".to_string(),
+            capacity: config.memory_mb,
+        })
+    }
+
+    fn init_port(
+        &self,
+        port: &PortConfig,
+        _mempool: &MempoolHandle,
+    ) -> Result<PortHandle, DpdkError> {
+        let fail_id = self.fail_port_init.lock().unwrap();
+        if *fail_id == Some(port.port_id) {
+            return Err(DpdkError::PortInit {
+                port_id: port.port_id,
+                name: port.name.clone(),
+                reason: "mock port init failure".to_string(),
+            });
+        }
+        Ok(PortHandle {
+            port_id: port.port_id,
+            name: port.name.clone(),
+        })
+    }
+
+    fn start_port(&self, handle: &PortHandle) -> Result<(), DpdkError> {
+        let fail_id = self.fail_port_start.lock().unwrap();
+        if *fail_id == Some(handle.port_id) {
+            return Err(DpdkError::PortStart {
+                port_id: handle.port_id,
+                name: handle.name.clone(),
+                reason: "mock port start failure".to_string(),
+            });
+        }
+        Ok(())
+    }
+}

--- a/crates/dataplane/src/dpdk/mod.rs
+++ b/crates/dataplane/src/dpdk/mod.rs
@@ -1,0 +1,206 @@
+pub mod backend;
+pub mod config;
+pub mod context;
+pub mod error;
+pub mod mock;
+
+use self::backend::DpdkBackend;
+use self::config::DpdkConfig;
+use self::context::DpdkContext;
+use self::error::DpdkError;
+
+/// Run the full DPDK initialisation sequence:
+/// 1. Validate config
+/// 2. EAL init
+/// 3. Create mempool
+/// 4. For each port with `admin_up = true`: init + start
+pub fn init_dpdk(backend: &dyn DpdkBackend, config: &DpdkConfig) -> Result<DpdkContext, DpdkError> {
+    config.validate()?;
+
+    backend.eal_init(config)?;
+    let mempool = backend.create_mempool(config)?;
+
+    let mut ports = Vec::new();
+    for port_cfg in &config.ports {
+        if !port_cfg.admin_up {
+            continue;
+        }
+        let handle = backend.init_port(port_cfg, &mempool)?;
+        backend.start_port(&handle)?;
+        ports.push(handle);
+    }
+
+    Ok(DpdkContext { mempool, ports })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::Ordering;
+
+    use super::config::{DpdkConfig, PortConfig};
+    use super::error::DpdkError;
+    use super::init_dpdk;
+    use super::mock::MockDpdkBackend;
+
+    fn default_config() -> DpdkConfig {
+        DpdkConfig {
+            lcore_list: "0-3".to_string(),
+            memory_mb: 2048,
+            rx_queue_size: 1024,
+            tx_queue_size: 1024,
+            ports: vec![],
+        }
+    }
+
+    fn wan_port() -> PortConfig {
+        PortConfig {
+            name: "wan0".to_string(),
+            port_id: 0,
+            mtu: 1500,
+            mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
+            admin_up: true,
+            rx_queues: 1,
+            tx_queues: 1,
+        }
+    }
+
+    fn lan_port() -> PortConfig {
+        PortConfig {
+            name: "lan0".to_string(),
+            port_id: 1,
+            mtu: 1500,
+            mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x02],
+            admin_up: true,
+            rx_queues: 1,
+            tx_queues: 1,
+        }
+    }
+
+    #[test]
+    fn two_port_init_succeeds() {
+        let backend = MockDpdkBackend::new();
+        let mut cfg = default_config();
+        cfg.ports = vec![wan_port(), lan_port()];
+
+        let ctx = init_dpdk(&backend, &cfg).expect("init should succeed");
+        assert_eq!(ctx.ports.len(), 2);
+        assert_eq!(ctx.ports[0].name, "wan0");
+        assert_eq!(ctx.ports[1].name, "lan0");
+    }
+
+    #[test]
+    fn admin_down_port_skipped() {
+        let backend = MockDpdkBackend::new();
+        let mut cfg = default_config();
+        let mut down = lan_port();
+        down.admin_up = false;
+        cfg.ports = vec![wan_port(), down];
+
+        let ctx = init_dpdk(&backend, &cfg).expect("init should succeed");
+        assert_eq!(ctx.ports.len(), 1);
+        assert_eq!(ctx.ports[0].name, "wan0");
+    }
+
+    #[test]
+    fn eal_init_failure() {
+        let backend = MockDpdkBackend::new();
+        backend.fail_eal_init.store(true, Ordering::Relaxed);
+        let cfg = default_config();
+
+        let err = init_dpdk(&backend, &cfg).unwrap_err();
+        assert!(matches!(err, DpdkError::EalInit { .. }));
+    }
+
+    #[test]
+    fn mempool_create_failure() {
+        let backend = MockDpdkBackend::new();
+        backend.fail_mempool.store(true, Ordering::Relaxed);
+        let cfg = default_config();
+
+        let err = init_dpdk(&backend, &cfg).unwrap_err();
+        assert!(matches!(err, DpdkError::MempoolCreate { .. }));
+    }
+
+    #[test]
+    fn port_init_failure() {
+        let backend = MockDpdkBackend::new();
+        *backend.fail_port_init.lock().unwrap() = Some(1);
+        let mut cfg = default_config();
+        cfg.ports = vec![wan_port(), lan_port()];
+
+        let err = init_dpdk(&backend, &cfg).unwrap_err();
+        match &err {
+            DpdkError::PortInit { port_id, name, .. } => {
+                assert_eq!(*port_id, 1);
+                assert_eq!(name, "lan0");
+            }
+            other => panic!("expected PortInit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn port_start_failure() {
+        let backend = MockDpdkBackend::new();
+        *backend.fail_port_start.lock().unwrap() = Some(0);
+        let mut cfg = default_config();
+        cfg.ports = vec![wan_port()];
+
+        let err = init_dpdk(&backend, &cfg).unwrap_err();
+        match &err {
+            DpdkError::PortStart { port_id, name, .. } => {
+                assert_eq!(*port_id, 0);
+                assert_eq!(name, "wan0");
+            }
+            other => panic!("expected PortStart, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_ports_succeeds() {
+        let backend = MockDpdkBackend::new();
+        let cfg = default_config();
+
+        let ctx = init_dpdk(&backend, &cfg).expect("init with no ports should succeed");
+        assert!(ctx.ports.is_empty());
+    }
+
+    #[test]
+    fn validate_memory_mb_zero() {
+        let backend = MockDpdkBackend::new();
+        let mut cfg = default_config();
+        cfg.memory_mb = 0;
+
+        let err = init_dpdk(&backend, &cfg).unwrap_err();
+        assert!(matches!(err, DpdkError::Config(_)));
+    }
+
+    #[test]
+    fn validate_lcore_list_empty() {
+        let backend = MockDpdkBackend::new();
+        let mut cfg = default_config();
+        cfg.lcore_list = String::new();
+
+        let err = init_dpdk(&backend, &cfg).unwrap_err();
+        assert!(matches!(err, DpdkError::Config(_)));
+    }
+
+    #[test]
+    fn validate_rx_queue_size_zero() {
+        let backend = MockDpdkBackend::new();
+        let mut cfg = default_config();
+        cfg.rx_queue_size = 0;
+
+        let err = init_dpdk(&backend, &cfg).unwrap_err();
+        assert!(matches!(err, DpdkError::Config(_)));
+    }
+
+    #[test]
+    fn validate_tx_queue_size_zero() {
+        let backend = MockDpdkBackend::new();
+        let mut cfg = default_config();
+        cfg.tx_queue_size = 0;
+
+        let err = init_dpdk(&backend, &cfg).unwrap_err();
+        assert!(matches!(err, DpdkError::Config(_)));
+    }
+}

--- a/crates/dataplane/src/lib.rs
+++ b/crates/dataplane/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod dpdk;
+
 #[derive(Debug, Default)]
 pub struct Dataplane;
 


### PR DESCRIPTION
## Summary
- Add `DpdkBackend` trait abstracting EAL/mempool/port/queue initialization for testability
- Implement `MockDpdkBackend` with failure injection for unit testing
- Add `init_dpdk()` flow: config validate → EAL init → mempool create → port init/start
- Skip `admin_down` ports, fail-fast on config errors (no panics)
- Add `DpdkError` with descriptive messages for all failure modes

## Test plan
- [x] 2-port mock init succeeds
- [x] `admin_up=false` port is skipped
- [x] EAL init failure returns `DpdkError::EalInit`
- [x] Mempool creation failure returns `DpdkError::MempoolCreate`
- [x] Port init/start failures return correct error with port_id and name
- [x] Empty port config succeeds
- [x] Config validation rejects `memory_mb=0`, empty `lcore_list`, zero queue sizes
- [x] `cargo test --workspace` passes (11 new tests)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)