### PR TITLE
feat(control): validate → plan → apply config flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ruster-config",
+ "thiserror",
+ "toml",
 ]
 
 [[package]]

--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -78,14 +78,14 @@ pub enum ConnState {
 
 // ── Structs ──
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct MetaConfig {
     pub schema: String,
     pub hostname: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct DataplaneConfig {
     pub backend: String,
@@ -95,7 +95,7 @@ pub struct DataplaneConfig {
     pub tx_queue_size: u32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct InterfaceConfig {
     pub name: String,
@@ -109,14 +109,14 @@ pub struct InterfaceConfig {
     pub l2_domain: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct BridgeDomain {
     pub name: String,
     pub members: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct L2Config {
     pub mac_table_max_entries: u32,
@@ -126,7 +126,7 @@ pub struct L2Config {
     pub bridge_domains: Vec<BridgeDomain>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct StaticRoute {
     pub prefix: String,
@@ -135,13 +135,13 @@ pub struct StaticRoute {
     pub metric: u32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RoutingConfig {
     pub ipv4_static_routes: Vec<StaticRoute>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PortForward {
     pub name: String,
@@ -151,7 +151,7 @@ pub struct PortForward {
     pub internal_port: u16,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct NatConfig {
     pub enabled: bool,
@@ -166,7 +166,7 @@ pub struct NatConfig {
     pub port_forwards: Vec<PortForward>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct FirewallRule {
     pub name: String,
@@ -178,7 +178,7 @@ pub struct FirewallRule {
     pub state: Vec<ConnState>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct FirewallConfig {
     pub enabled: bool,
@@ -189,7 +189,7 @@ pub struct FirewallConfig {
     pub rules: Vec<FirewallRule>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RouterConfig {
     pub meta: MetaConfig,

--- a/crates/control/Cargo.toml
+++ b/crates/control/Cargo.toml
@@ -7,4 +7,6 @@ publish.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+thiserror.workspace = true
+toml.workspace = true
 ruster-config = { path = "../config" }

--- a/crates/control/src/diff.rs
+++ b/crates/control/src/diff.rs
@@ -1,0 +1,195 @@
+use toml::Value;
+
+/// A single change detected between running and candidate configs.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConfigChange {
+    /// Dotted path to the changed key, e.g. `meta.hostname` or `interfaces[0].mtu`.
+    pub path: String,
+    pub kind: ChangeKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ChangeKind {
+    Added { new: String },
+    Removed { old: String },
+    Modified { old: String, new: String },
+}
+
+impl std::fmt::Display for ConfigChange {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.kind {
+            ChangeKind::Added { new } => write!(f, "+ {}: {new}", self.path),
+            ChangeKind::Removed { old } => write!(f, "- {}: {old}", self.path),
+            ChangeKind::Modified { old, new } => {
+                write!(f, "~ {}: {old} -> {new}", self.path)
+            }
+        }
+    }
+}
+
+/// Compare two `RouterConfig`s via their TOML `Value` representations.
+///
+/// Returns a list of changes (added / removed / modified leaf values).
+pub fn diff_configs(
+    running: &ruster_config::RouterConfig,
+    candidate: &ruster_config::RouterConfig,
+) -> Vec<ConfigChange> {
+    let old = toml::Value::try_from(running).expect("running config should serialise");
+    let new = toml::Value::try_from(candidate).expect("candidate config should serialise");
+    let mut changes = Vec::new();
+    diff_value("", &old, &new, &mut changes);
+    changes
+}
+
+fn diff_value(prefix: &str, old: &Value, new: &Value, out: &mut Vec<ConfigChange>) {
+    match (old, new) {
+        (Value::Table(a), Value::Table(b)) => {
+            for (k, v_old) in a {
+                let path = join_path(prefix, k);
+                match b.get(k) {
+                    Some(v_new) => diff_value(&path, v_old, v_new, out),
+                    None => collect_removed(&path, v_old, out),
+                }
+            }
+            for (k, v_new) in b {
+                if !a.contains_key(k) {
+                    let path = join_path(prefix, k);
+                    collect_added(&path, v_new, out);
+                }
+            }
+        }
+        (Value::Array(a), Value::Array(b)) => {
+            let max_len = a.len().max(b.len());
+            for i in 0..max_len {
+                let path = format!("{prefix}[{i}]");
+                match (a.get(i), b.get(i)) {
+                    (Some(v_old), Some(v_new)) => diff_value(&path, v_old, v_new, out),
+                    (Some(v_old), None) => collect_removed(&path, v_old, out),
+                    (None, Some(v_new)) => collect_added(&path, v_new, out),
+                    (None, None) => unreachable!(),
+                }
+            }
+        }
+        _ => {
+            if old != new {
+                out.push(ConfigChange {
+                    path: prefix.to_string(),
+                    kind: ChangeKind::Modified {
+                        old: value_display(old),
+                        new: value_display(new),
+                    },
+                });
+            }
+        }
+    }
+}
+
+fn collect_added(prefix: &str, val: &Value, out: &mut Vec<ConfigChange>) {
+    match val {
+        Value::Table(t) => {
+            for (k, v) in t {
+                collect_added(&join_path(prefix, k), v, out);
+            }
+        }
+        Value::Array(arr) => {
+            for (i, v) in arr.iter().enumerate() {
+                collect_added(&format!("{prefix}[{i}]"), v, out);
+            }
+        }
+        _ => {
+            out.push(ConfigChange {
+                path: prefix.to_string(),
+                kind: ChangeKind::Added {
+                    new: value_display(val),
+                },
+            });
+        }
+    }
+}
+
+fn collect_removed(prefix: &str, val: &Value, out: &mut Vec<ConfigChange>) {
+    match val {
+        Value::Table(t) => {
+            for (k, v) in t {
+                collect_removed(&join_path(prefix, k), v, out);
+            }
+        }
+        Value::Array(arr) => {
+            for (i, v) in arr.iter().enumerate() {
+                collect_removed(&format!("{prefix}[{i}]"), v, out);
+            }
+        }
+        _ => {
+            out.push(ConfigChange {
+                path: prefix.to_string(),
+                kind: ChangeKind::Removed {
+                    old: value_display(val),
+                },
+            });
+        }
+    }
+}
+
+fn join_path(prefix: &str, key: &str) -> String {
+    if prefix.is_empty() {
+        key.to_string()
+    } else {
+        format!("{prefix}.{key}")
+    }
+}
+
+fn value_display(v: &Value) -> String {
+    match v {
+        Value::String(s) => format!("\"{s}\""),
+        Value::Integer(i) => i.to_string(),
+        Value::Float(f) => f.to_string(),
+        Value::Boolean(b) => b.to_string(),
+        Value::Datetime(d) => d.to_string(),
+        Value::Array(a) => format!("[{} items]", a.len()),
+        Value::Table(_) => "{...}".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn load(s: &str) -> ruster_config::RouterConfig {
+        toml::from_str(s).expect("test config should parse")
+    }
+
+    fn example_toml() -> String {
+        let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.pop();
+        path.pop();
+        path.push("router.toml.example");
+        std::fs::read_to_string(&path).expect("example toml")
+    }
+
+    #[test]
+    fn identical_configs_produce_no_changes() {
+        let cfg = load(&example_toml());
+        let changes = diff_configs(&cfg, &cfg);
+        assert!(changes.is_empty());
+    }
+
+    #[test]
+    fn hostname_change_detected() {
+        let cfg1 = load(&example_toml());
+        let mut cfg2 = cfg1.clone();
+        cfg2.meta.hostname = "new-host".to_string();
+        let changes = diff_configs(&cfg1, &cfg2);
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].path, "meta.hostname");
+        assert!(matches!(&changes[0].kind, ChangeKind::Modified { .. }));
+    }
+
+    #[test]
+    fn mtu_change_detected() {
+        let cfg1 = load(&example_toml());
+        let mut cfg2 = cfg1.clone();
+        cfg2.interfaces[0].mtu = 9000;
+        let changes = diff_configs(&cfg1, &cfg2);
+        assert!(changes.iter().any(|c| c.path.contains("mtu")));
+    }
+}

--- a/crates/control/src/error.rs
+++ b/crates/control/src/error.rs
@@ -1,0 +1,8 @@
+#[derive(Debug, thiserror::Error)]
+pub enum ControlError {
+    #[error("validation failed: {0}")]
+    Validation(String),
+
+    #[error("nothing to commit: no running configuration")]
+    NothingToCommit,
+}

--- a/crates/control/src/lib.rs
+++ b/crates/control/src/lib.rs
@@ -1,23 +1,210 @@
-use anyhow::{bail, Result};
+pub mod diff;
+pub mod error;
+pub mod store;
+
+pub use diff::{ChangeKind, ConfigChange};
+pub use error::ControlError;
+pub use store::{ConfigStore, PlanResult};
+
 use ruster_config::RouterConfig;
 
-#[derive(Debug, Clone, Copy)]
-pub struct PlanResult {
-    pub has_changes: bool,
+/// Convenience: validate a config without a store (backwards-compatible).
+pub fn validate(config: &RouterConfig) -> Result<(), ControlError> {
+    let store = ConfigStore::new();
+    store.validate(config)
 }
 
-pub fn validate(config: &RouterConfig) -> Result<()> {
-    if config.meta.hostname.trim().is_empty() {
-        bail!("hostname must not be empty");
+/// Convenience: plan changes from `running` to `candidate`.
+pub fn plan(
+    running: Option<&RouterConfig>,
+    candidate: &RouterConfig,
+) -> Result<PlanResult, ControlError> {
+    match running {
+        Some(r) => {
+            let store = ConfigStore::with_running(r.clone());
+            store.plan(candidate)
+        }
+        None => {
+            let store = ConfigStore::new();
+            store.plan(candidate)
+        }
     }
-    Ok(())
 }
 
-pub fn plan(_running: Option<&RouterConfig>, _candidate: &RouterConfig) -> PlanResult {
-    PlanResult { has_changes: true }
+/// Convenience: validate then apply (returns the plan).
+pub fn apply(
+    running: Option<&RouterConfig>,
+    candidate: RouterConfig,
+) -> Result<(RouterConfig, PlanResult), ControlError> {
+    let mut store = match running {
+        Some(r) => ConfigStore::with_running(r.clone()),
+        None => ConfigStore::new(),
+    };
+    let plan = store.apply(candidate)?;
+    let new_running = store.running().expect("apply succeeded").clone();
+    Ok((new_running, plan))
 }
 
-pub fn apply(candidate: RouterConfig) -> Result<RouterConfig> {
-    validate(&candidate)?;
-    Ok(candidate)
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn example_toml() -> String {
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.pop();
+        path.pop();
+        path.push("router.toml.example");
+        std::fs::read_to_string(&path).expect("example toml")
+    }
+
+    fn load_example() -> RouterConfig {
+        ruster_config::load_from_str(&example_toml()).expect("valid config")
+    }
+
+    // ── validate ──
+
+    #[test]
+    fn validate_valid_config_succeeds() {
+        let cfg = load_example();
+        assert!(validate(&cfg).is_ok());
+    }
+
+    #[test]
+    fn validate_empty_hostname_fails() {
+        let mut cfg = load_example();
+        cfg.meta.hostname = "  ".to_string();
+        let err = validate(&cfg).unwrap_err();
+        assert!(err.to_string().contains("hostname"));
+    }
+
+    // ── plan ──
+
+    #[test]
+    fn plan_no_op_returns_no_changes() {
+        let cfg = load_example();
+        let result = plan(Some(&cfg), &cfg).unwrap();
+        assert!(!result.has_changes);
+        assert!(result.changes.is_empty());
+    }
+
+    #[test]
+    fn plan_initial_load_has_changes() {
+        let cfg = load_example();
+        let result = plan(None, &cfg).unwrap();
+        assert!(result.has_changes);
+    }
+
+    #[test]
+    fn plan_detects_hostname_change() {
+        let cfg1 = load_example();
+        let mut cfg2 = cfg1.clone();
+        cfg2.meta.hostname = "new-host".to_string();
+        let result = plan(Some(&cfg1), &cfg2).unwrap();
+        assert!(result.has_changes);
+        assert!(result.changes.iter().any(|c| c.path == "meta.hostname"));
+    }
+
+    #[test]
+    fn plan_detects_mtu_change() {
+        let cfg1 = load_example();
+        let mut cfg2 = cfg1.clone();
+        cfg2.interfaces[0].mtu = 9000;
+        let result = plan(Some(&cfg1), &cfg2).unwrap();
+        assert!(result.has_changes);
+        assert!(result.changes.iter().any(|c| c.path.contains("mtu")));
+    }
+
+    #[test]
+    fn plan_detects_nat_toggle() {
+        let cfg1 = load_example();
+        let mut cfg2 = cfg1.clone();
+        cfg2.nat.enabled = false;
+        cfg2.firewall.enabled = false;
+        let result = plan(Some(&cfg1), &cfg2).unwrap();
+        assert!(result.has_changes);
+        assert!(result
+            .changes
+            .iter()
+            .any(|c| c.path.contains("nat") && c.path.contains("enabled")));
+    }
+
+    #[test]
+    fn plan_display_format() {
+        let cfg1 = load_example();
+        let mut cfg2 = cfg1.clone();
+        cfg2.meta.hostname = "changed".to_string();
+        let result = plan(Some(&cfg1), &cfg2).unwrap();
+        let display = result.to_string();
+        assert!(display.contains("change(s)"));
+        assert!(display.contains("meta.hostname"));
+    }
+
+    // ── apply ──
+
+    #[test]
+    fn apply_sets_new_running() {
+        let cfg = load_example();
+        let (new_running, plan_result) = apply(None, cfg.clone()).unwrap();
+        assert!(plan_result.has_changes);
+        assert_eq!(new_running.meta.hostname, cfg.meta.hostname);
+    }
+
+    #[test]
+    fn apply_rejects_invalid_config() {
+        let mut cfg = load_example();
+        cfg.meta.hostname = "".to_string();
+        let err = apply(None, cfg).unwrap_err();
+        assert!(err.to_string().contains("hostname"));
+    }
+
+    // ── ConfigStore full flow ──
+
+    #[test]
+    fn store_full_validate_plan_apply_commit_flow() {
+        let cfg1 = load_example();
+        let mut store = ConfigStore::new();
+
+        // Initial apply (no committed baseline yet → pending)
+        store.validate(&cfg1).unwrap();
+        let p = store.apply(cfg1.clone()).unwrap();
+        assert!(p.has_changes);
+        assert!(store.has_pending_changes());
+
+        // Commit
+        store.commit().unwrap();
+        assert!(!store.has_pending_changes());
+
+        // No-op apply
+        let p2 = store.plan(&cfg1).unwrap();
+        assert!(!p2.has_changes);
+
+        // Modify and apply
+        let mut cfg2 = cfg1.clone();
+        cfg2.meta.hostname = "updated".to_string();
+        let p3 = store.apply(cfg2).unwrap();
+        assert!(p3.has_changes);
+        assert!(store.has_pending_changes());
+        assert_eq!(store.running().unwrap().meta.hostname, "updated");
+        assert_eq!(store.committed().unwrap().meta.hostname, "ruster-lab");
+
+        // Commit again
+        store.commit().unwrap();
+        assert!(!store.has_pending_changes());
+        assert_eq!(store.committed().unwrap().meta.hostname, "updated");
+    }
+
+    #[test]
+    fn store_commit_without_running_fails() {
+        let mut store = ConfigStore::new();
+        let err = store.commit().unwrap_err();
+        assert!(matches!(err, ControlError::NothingToCommit));
+    }
+
+    #[test]
+    fn store_with_running_has_no_pending() {
+        let cfg = load_example();
+        let store = ConfigStore::with_running(cfg);
+        assert!(!store.has_pending_changes());
+    }
 }

--- a/crates/control/src/store.rs
+++ b/crates/control/src/store.rs
@@ -1,0 +1,146 @@
+use ruster_config::RouterConfig;
+
+use crate::diff;
+use crate::diff::ConfigChange;
+use crate::error::ControlError;
+
+/// Result of a `plan` operation.
+#[derive(Debug)]
+pub struct PlanResult {
+    pub has_changes: bool,
+    pub changes: Vec<ConfigChange>,
+}
+
+impl std::fmt::Display for PlanResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if !self.has_changes {
+            return write!(f, "No changes.");
+        }
+        writeln!(f, "{} change(s):", self.changes.len())?;
+        for c in &self.changes {
+            writeln!(f, "  {c}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Holds running / candidate configuration state.
+///
+/// Workflow: `validate` → `plan` → `apply` → (optional) `commit`.
+#[derive(Debug)]
+pub struct ConfigStore {
+    /// The currently active configuration (after `apply`).
+    running: Option<RouterConfig>,
+    /// The last committed (saved) configuration.
+    committed: Option<RouterConfig>,
+}
+
+impl ConfigStore {
+    /// Create a new store with no running config.
+    pub fn new() -> Self {
+        Self {
+            running: None,
+            committed: None,
+        }
+    }
+
+    /// Create a store with an initial running config (e.g. loaded at startup).
+    pub fn with_running(config: RouterConfig) -> Self {
+        Self {
+            running: Some(config.clone()),
+            committed: Some(config),
+        }
+    }
+
+    /// Reference to the current running config, if any.
+    pub fn running(&self) -> Option<&RouterConfig> {
+        self.running.as_ref()
+    }
+
+    /// Reference to the last committed config, if any.
+    pub fn committed(&self) -> Option<&RouterConfig> {
+        self.committed.as_ref()
+    }
+
+    /// Returns true if there are uncommitted changes (running differs from committed).
+    pub fn has_pending_changes(&self) -> bool {
+        match (&self.running, &self.committed) {
+            (Some(r), Some(c)) => r != c,
+            (Some(_), None) | (None, Some(_)) => true,
+            (None, None) => false,
+        }
+    }
+
+    /// Validate a candidate configuration (parse + semantic checks).
+    ///
+    /// This does NOT modify store state.
+    pub fn validate(&self, candidate: &RouterConfig) -> Result<(), ControlError> {
+        if candidate.meta.hostname.trim().is_empty() {
+            return Err(ControlError::Validation(
+                "meta.hostname must not be empty".to_string(),
+            ));
+        }
+        // Config-crate level validation is assumed to have passed at load time.
+        Ok(())
+    }
+
+    /// Plan: compare current running config against candidate.
+    ///
+    /// Returns the list of changes. If there is no running config, every field
+    /// in the candidate is treated as an addition.
+    pub fn plan(&self, candidate: &RouterConfig) -> Result<PlanResult, ControlError> {
+        self.validate(candidate)?;
+
+        match &self.running {
+            Some(running) => {
+                let changes = diff::diff_configs(running, candidate);
+                Ok(PlanResult {
+                    has_changes: !changes.is_empty(),
+                    changes,
+                })
+            }
+            None => {
+                // First-time apply: treat the whole config as new.
+                // We use a synthetic empty-like diff by reporting "initial load".
+                Ok(PlanResult {
+                    has_changes: true,
+                    changes: vec![ConfigChange {
+                        path: "<root>".to_string(),
+                        kind: crate::diff::ChangeKind::Added {
+                            new: "initial configuration".to_string(),
+                        },
+                    }],
+                })
+            }
+        }
+    }
+
+    /// Apply a candidate config as the new running config.
+    ///
+    /// Validates and plans first; rejects if validation fails.
+    /// The change becomes "pending" until `commit()` is called.
+    pub fn apply(&mut self, candidate: RouterConfig) -> Result<PlanResult, ControlError> {
+        let plan = self.plan(&candidate)?;
+        self.running = Some(candidate);
+        Ok(plan)
+    }
+
+    /// Commit the current running config as the new baseline.
+    ///
+    /// After commit, `has_pending_changes()` returns false.
+    pub fn commit(&mut self) -> Result<(), ControlError> {
+        match &self.running {
+            Some(r) => {
+                self.committed = Some(r.clone());
+                Ok(())
+            }
+            None => Err(ControlError::NothingToCommit),
+        }
+    }
+}
+
+impl Default for ConfigStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ConfigStore` holding running/candidate/pending configuration state
- Implement `validate` → `plan` → `apply` → `commit` workflow
- Config diff via `toml::Value` tree comparison: detects additions, removals, modifications at any depth
- `PlanResult` with `Display` for human-readable change summaries
- Add `PartialEq` to all config model structs for no-op detection
- Backwards-compatible convenience functions for simple usage

## Test plan
- [x] Valid config passes validation
- [x] Empty hostname rejected by validation
- [x] No-op plan returns `has_changes = false`
- [x] Initial load (no running) returns `has_changes = true`
- [x] Hostname/MTU/NAT changes detected by plan
- [x] Plan display format includes change count and paths
- [x] Apply sets new running config
- [x] Apply rejects invalid config before updating state
- [x] Full flow: validate → plan → apply → commit → re-plan (no-op) → modify → apply → commit
- [x] Commit without running config fails with `NothingToCommit`
- [x] `with_running()` starts with no pending changes
- [x] `cargo test --workspace` passes (16 new tests, 36 total)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)