### PR TITLE
fix(config): validate IP/CIDR format in routes and interface addresses

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -157,4 +157,101 @@ mod tests {
         assert!(msg.contains("state"), "error should mention field: {msg}");
         assert!(msg.contains("empty"), "error should mention reason: {msg}");
     }
+
+    // ── IP/CIDR validation tests ─────────────────────────────────────
+
+    #[test]
+    fn reject_invalid_route_prefix_not_cidr() {
+        let toml = make_valid_toml().replace(r#"prefix = "0.0.0.0/0""#, r#"prefix = "not-a-cidr""#);
+        let err = load_from_str(&toml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("ipv4_static_routes"),
+            "error should mention field: {msg}"
+        );
+        assert!(
+            msg.contains("invalid CIDR prefix"),
+            "error should mention reason: {msg}"
+        );
+    }
+
+    #[test]
+    fn reject_invalid_route_prefix_len_too_large() {
+        let toml =
+            make_valid_toml().replace(r#"prefix = "0.0.0.0/0""#, r#"prefix = "192.168.1.0/33""#);
+        let err = load_from_str(&toml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("ipv4_static_routes"),
+            "error should mention field: {msg}"
+        );
+        assert!(
+            msg.contains("invalid CIDR prefix"),
+            "error should mention reason: {msg}"
+        );
+    }
+
+    #[test]
+    fn reject_invalid_route_next_hop() {
+        let toml =
+            make_valid_toml().replace(r#"next_hop = "203.0.113.1""#, r#"next_hop = "not-an-ip""#);
+        let err = load_from_str(&toml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("next_hop"),
+            "error should mention field: {msg}"
+        );
+        assert!(
+            msg.contains("invalid IPv4 address"),
+            "error should mention reason: {msg}"
+        );
+    }
+
+    #[test]
+    fn reject_invalid_interface_ipv4_addr_no_prefix() {
+        // ipv4_addrs without CIDR prefix notation should be rejected
+        let toml = make_valid_toml().replace(
+            r#"ipv4_addrs = ["203.0.113.2/24"]"#,
+            r#"ipv4_addrs = ["192.168.1.1"]"#,
+        );
+        let err = load_from_str(&toml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("ipv4_addrs"),
+            "error should mention field: {msg}"
+        );
+        assert!(
+            msg.contains("invalid CIDR"),
+            "error should mention reason: {msg}"
+        );
+    }
+
+    #[test]
+    fn reject_invalid_interface_ipv4_addr_bad_ip() {
+        let toml = make_valid_toml().replace(
+            r#"ipv4_addrs = ["203.0.113.2/24"]"#,
+            r#"ipv4_addrs = ["bad-addr/24"]"#,
+        );
+        let err = load_from_str(&toml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("ipv4_addrs"),
+            "error should mention field: {msg}"
+        );
+        assert!(
+            msg.contains("invalid CIDR"),
+            "error should mention reason: {msg}"
+        );
+    }
+
+    #[test]
+    fn accept_valid_ip_and_cidr_values() {
+        // The example toml has valid IPs and CIDRs, so it should pass
+        let result = load_from_str(&make_valid_toml());
+        assert!(
+            result.is_ok(),
+            "valid config should pass: {:?}",
+            result.err()
+        );
+    }
 }

--- a/crates/config/src/validate.rs
+++ b/crates/config/src/validate.rs
@@ -23,6 +23,8 @@ pub fn validate(config: &RouterConfig) -> Result<(), Vec<ValidationError>> {
     check_nat_external_if(config, &mut errors);
     check_nat_requires_firewall(config, &mut errors);
     check_firewall_rule_states(config, &mut errors);
+    check_ipv4_addrs(config, &mut errors);
+    check_route_addresses(config, &mut errors);
 
     if errors.is_empty() {
         Ok(())
@@ -128,4 +130,64 @@ fn check_firewall_rule_states(config: &RouterConfig, errors: &mut Vec<Validation
             });
         }
     }
+}
+
+/// Validate that every `ipv4_addrs` entry on each interface is a valid CIDR
+/// string (e.g. "192.168.1.1/24").
+fn check_ipv4_addrs(config: &RouterConfig, errors: &mut Vec<ValidationError>) {
+    for iface in &config.interfaces {
+        for (i, addr) in iface.ipv4_addrs.iter().enumerate() {
+            if !is_valid_cidr(addr) {
+                errors.push(ValidationError {
+                    field: format!("interfaces[name={}].ipv4_addrs[{}]", iface.name, i),
+                    reason: format!("invalid CIDR address '{}'", addr),
+                });
+            }
+        }
+    }
+}
+
+/// Validate that every static route has a valid CIDR prefix and a valid IPv4
+/// next-hop address.
+fn check_route_addresses(config: &RouterConfig, errors: &mut Vec<ValidationError>) {
+    for route in &config.routing.ipv4_static_routes {
+        if !is_valid_cidr(&route.prefix) {
+            errors.push(ValidationError {
+                field: format!("routing.ipv4_static_routes[prefix={}].prefix", route.prefix),
+                reason: format!("invalid CIDR prefix '{}'", route.prefix),
+            });
+        }
+        if !is_valid_ipv4(&route.next_hop) {
+            errors.push(ValidationError {
+                field: format!(
+                    "routing.ipv4_static_routes[prefix={}].next_hop",
+                    route.prefix
+                ),
+                reason: format!("invalid IPv4 address '{}'", route.next_hop),
+            });
+        }
+    }
+}
+
+/// Check whether a string is a valid IPv4 address (e.g. "192.168.1.1").
+fn is_valid_ipv4(s: &str) -> bool {
+    let parts: Vec<&str> = s.split('.').collect();
+    if parts.len() != 4 {
+        return false;
+    }
+    parts.iter().all(|p| p.parse::<u8>().is_ok())
+}
+
+/// Check whether a string is a valid IPv4 CIDR notation (e.g. "192.168.1.0/24").
+fn is_valid_cidr(s: &str) -> bool {
+    let Some((ip_str, len_str)) = s.split_once('/') else {
+        return false;
+    };
+    if !is_valid_ipv4(ip_str) {
+        return false;
+    }
+    let Ok(prefix_len) = len_str.parse::<u8>() else {
+        return false;
+    };
+    prefix_len <= 32
 }

--- a/crates/dataplane/src/routing/mod.rs
+++ b/crates/dataplane/src/routing/mod.rs
@@ -82,6 +82,10 @@ impl L3Engine {
     pub fn from_config(routing_config: &RoutingConfig, interfaces: &[InterfaceConfig]) -> Self {
         let route_table = RouteTable::from_config(routing_config);
 
+        // NOTE: Config validation (ruster-config validate) ensures all
+        // ipv4_addrs entries are well-formed CIDR strings before they reach
+        // here. filter_map is retained as a defence-in-depth measure; any
+        // parse failure at this stage indicates a logic bug.
         let local_ips: HashSet<[u8; 4]> = interfaces
             .iter()
             .flat_map(|iface| {

--- a/crates/dataplane/src/routing/table.rs
+++ b/crates/dataplane/src/routing/table.rs
@@ -42,6 +42,10 @@ impl RouteTable {
     /// Parses each static route's prefix string (e.g. "192.168.1.0/24")
     /// and next-hop address, then sorts entries for LPM lookup.
     pub fn from_config(routing_config: &RoutingConfig) -> Self {
+        // NOTE: Config validation (ruster-config validate) ensures all prefix
+        // and next_hop strings are well-formed before they reach here.
+        // filter_map is retained as a defence-in-depth measure; any parse
+        // failure at this stage indicates a logic bug.
         let mut entries: Vec<RouteEntry> = routing_config
             .ipv4_static_routes
             .iter()


### PR DESCRIPTION
## Summary

- **check_ipv4_addrs()**: Validates all `interfaces[*].ipv4_addrs` entries are valid CIDR format
- **check_route_addresses()**: Validates `routing.ipv4_static_routes[*].prefix` (CIDR) and `next_hop` (IPv4)
- **Helpers**: `is_valid_ipv4()`, `is_valid_cidr()` for reusable format checking
- **Defence-in-depth comments** on dataplane `filter_map` call sites noting validation is assumed

6 new config tests. Previously invalid values silently passed through to runtime.

Closes #114

## Test plan

- [x] All 278 workspace tests pass
- [x] clippy/fmt/doc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)