### PR TITLE
fix(main): wire up full bootstrap pipeline (#116)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,11 +58,9 @@ dependencies = [
 name = "ruster"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "ruster-config",
  "ruster-control",
  "ruster-dataplane",
- "ruster-observe",
 ]
 
 [[package]]

--- a/crates/dataplane/src/firewall/mod.rs
+++ b/crates/dataplane/src/firewall/mod.rs
@@ -109,6 +109,7 @@ impl FwContext {
 ///
 /// Holds the firewall configuration and provides the [`FirewallEngine::evaluate`] method
 /// for per-packet verdict computation.
+#[derive(Debug)]
 pub struct FirewallEngine {
     enabled: bool,
     default_input: DefaultPolicy,

--- a/crates/dataplane/src/lib.rs
+++ b/crates/dataplane/src/lib.rs
@@ -7,15 +7,95 @@ pub mod nat;
 pub mod packet;
 pub mod routing;
 
-#[derive(Debug, Default)]
-pub struct Dataplane;
+use ruster_config::model::RouterConfig;
+
+/// Initialization error for the dataplane.
+#[derive(Debug, thiserror::Error)]
+pub enum DataplaneError {
+    /// DPDK subsystem initialization failed.
+    #[error("DPDK init: {0}")]
+    Dpdk(#[from] dpdk::error::DpdkError),
+}
+
+/// The dataplane runtime holding initialized engines.
+///
+/// Created via [`Dataplane::init`] from a validated [`RouterConfig`].
+/// In v0.1 the DPDK backend is mocked, so no real NIC init happens;
+/// however all forwarding engines (L2, ARP, L3, NAT, firewall, conntrack)
+/// are fully constructed from configuration.
+#[derive(Debug)]
+pub struct Dataplane {
+    /// L2 bridging engine (MAC learning, FDB, bridge domains).
+    pub l2: l2::L2Engine,
+    /// ARP resolution engine (per-interface ARP caches).
+    pub arp: arp::ArpEngine,
+    /// L3 IPv4 forwarding engine (static routing, LPM).
+    pub l3: routing::L3Engine,
+    /// NAT44 engine (NAPT, port forwarding, hairpin).
+    pub nat: nat::NatEngine,
+    /// Stateful firewall engine.
+    pub firewall: firewall::FirewallEngine,
+    /// Connection tracking engine (session table).
+    pub conntrack: conntrack::ConntrackEngine,
+}
 
 impl Dataplane {
-    pub fn new() -> Self {
-        Self
+    /// Initialize the dataplane from a validated configuration.
+    ///
+    /// Creates all sub-engines (L2, ARP, L3, NAT, FW, conntrack) from config.
+    /// In v0.1 the DPDK backend is mocked, so no real NIC init happens.
+    pub fn init(config: &RouterConfig) -> Result<Self, DataplaneError> {
+        let l2 = l2::L2Engine::from_config(&config.l2);
+        let arp = arp::ArpEngine::from_config(&config.l2, &config.interfaces);
+        let l3 = routing::L3Engine::from_config(&config.routing, &config.interfaces);
+        let nat = nat::NatEngine::from_config(&config.nat, &config.interfaces);
+        let firewall = firewall::FirewallEngine::from_config(&config.firewall);
+        let conntrack = conntrack::ConntrackEngine::from_nat_config(&config.nat);
+
+        Ok(Self {
+            l2,
+            arp,
+            l3,
+            nat,
+            firewall,
+            conntrack,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn example_toml() -> String {
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.pop(); // crates
+        path.pop(); // project root
+        path.push("router.toml.example");
+        std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()))
     }
 
-    pub fn start(&self) {
-        // Placeholder: DPDK/EAL startup will be implemented in v0.1 issues.
+    fn load_example() -> RouterConfig {
+        ruster_config::load_from_str(&example_toml()).expect("valid config")
+    }
+
+    #[test]
+    fn dataplane_init_succeeds_with_valid_config() {
+        let config = load_example();
+        let dp = Dataplane::init(&config).expect("init should succeed");
+
+        // Verify all engines were created from the example config.
+        // The example has 2 bridge domains, 1 static route, NAT enabled.
+        assert!(dp.nat.is_enabled());
+    }
+
+    #[test]
+    fn dataplane_init_returns_result() {
+        // Verify the return type is Result (compile-time check, essentially).
+        let config = load_example();
+        let result: Result<Dataplane, DataplaneError> = Dataplane::init(&config);
+        assert!(result.is_ok());
     }
 }

--- a/crates/main/Cargo.toml
+++ b/crates/main/Cargo.toml
@@ -6,8 +6,6 @@ license.workspace = true
 publish.workspace = true
 
 [dependencies]
-anyhow.workspace = true
 ruster-config = { path = "../config" }
 ruster-control = { path = "../control" }
 ruster-dataplane = { path = "../dataplane" }
-ruster-observe = { path = "../observe" }

--- a/crates/main/src/main.rs
+++ b/crates/main/src/main.rs
@@ -1,17 +1,66 @@
-use anyhow::Result;
-use ruster_dataplane::Dataplane;
-use ruster_observe::Counters;
+use std::env;
+use std::process;
 
-fn main() -> Result<()> {
-    let config = ruster_config::load_from_file("router.toml.example")?;
-    ruster_control::validate(&config)?;
+fn main() {
+    // Parse CLI args: --config <path> / -c <path>, or default to "router.toml"
+    let config_path = parse_config_path();
 
-    let dataplane = Dataplane::new();
-    dataplane.start();
+    // Load and validate config
+    let config = match ruster_config::load_from_file(&config_path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Error: failed to load config '{}': {}", config_path, e);
+            process::exit(1);
+        }
+    };
 
-    let mut counters = Counters::default();
-    counters.inc_drop();
+    println!("ruster v0.1 — {}", config.meta.hostname);
+    println!("Config loaded from: {}", config_path);
 
-    println!("ruster bootstrap ok: hostname={}", config.meta.hostname);
-    Ok(())
+    // Initialize control plane (validate -> plan -> apply)
+    let mut store = ruster_control::ConfigStore::new();
+    if let Err(e) = store.apply(config.clone()) {
+        eprintln!("Error: config apply failed: {}", e);
+        process::exit(1);
+    }
+    store.commit().expect("commit after successful apply");
+
+    // Initialize dataplane
+    let _dataplane = match ruster_dataplane::Dataplane::init(&config) {
+        Ok(dp) => dp,
+        Err(e) => {
+            eprintln!("Error: dataplane init failed: {}", e);
+            process::exit(1);
+        }
+    };
+
+    println!("Dataplane initialized successfully");
+    println!("  L2 bridge domains: {}", config.l2.bridge_domains.len());
+    println!(
+        "  Static routes: {}",
+        config.routing.ipv4_static_routes.len()
+    );
+    println!("  NAT enabled: {}", config.nat.enabled);
+    println!("  Firewall enabled: {}", config.firewall.enabled);
+
+    // In v0.1, we just print status and exit.
+    // Real packet processing loop will be added when DPDK backend is integrated.
+    println!("\nruster ready. (v0.1: init-only mode, no packet loop yet)");
+}
+
+fn parse_config_path() -> String {
+    let args: Vec<String> = env::args().collect();
+    let mut i = 1;
+    while i < args.len() {
+        if args[i] == "--config" || args[i] == "-c" {
+            if i + 1 < args.len() {
+                return args[i + 1].clone();
+            } else {
+                eprintln!("Error: --config requires a path argument");
+                process::exit(1);
+            }
+        }
+        i += 1;
+    }
+    "router.toml".to_string()
 }

--- a/crates/main/tests/startup.rs
+++ b/crates/main/tests/startup.rs
@@ -1,0 +1,135 @@
+//! E2E startup tests for ruster.
+//!
+//! These tests verify the full init pipeline:
+//! config load -> control validate/apply -> dataplane init.
+
+use std::path::PathBuf;
+
+/// Path to the example config at the project root.
+fn example_config_path() -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop(); // crates
+    path.pop(); // project root
+    path.push("router.toml.example");
+    path
+}
+
+/// Helper: read the example toml as a string.
+fn example_toml_str() -> String {
+    std::fs::read_to_string(example_config_path())
+        .unwrap_or_else(|e| panic!("failed to read example config: {e}"))
+}
+
+// ── Config loading tests ──────────────────────────────────────────────
+
+#[test]
+fn load_valid_config_succeeds() {
+    let path = example_config_path();
+    let config = ruster_config::load_from_file(path.to_str().unwrap());
+    assert!(config.is_ok(), "loading example config should succeed");
+}
+
+#[test]
+fn load_nonexistent_config_fails() {
+    let result = ruster_config::load_from_file("/tmp/ruster-nonexistent-config-42.toml");
+    assert!(result.is_err(), "loading nonexistent config should fail");
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("read config file") || err.contains("No such file"),
+        "error should mention file read failure: {err}"
+    );
+}
+
+#[test]
+fn load_invalid_toml_content_fails() {
+    let tmp_path = "/tmp/ruster-test-invalid.toml";
+    std::fs::write(tmp_path, "this is not valid toml {{{{").unwrap();
+    let result = ruster_config::load_from_file(tmp_path);
+    assert!(result.is_err(), "loading invalid toml should fail");
+    let _ = std::fs::remove_file(tmp_path);
+}
+
+// ── Control plane tests ───────────────────────────────────────────────
+
+#[test]
+fn control_validate_and_apply_succeeds() {
+    let config =
+        ruster_config::load_from_str(&example_toml_str()).expect("example config should be valid");
+
+    // Validate
+    ruster_control::validate(&config).expect("validation should succeed");
+
+    // Apply via store
+    let mut store = ruster_control::ConfigStore::new();
+    let plan = store
+        .apply(config.clone())
+        .expect("apply should succeed for valid config");
+    assert!(plan.has_changes, "initial apply should have changes");
+
+    store.commit().expect("commit should succeed");
+    assert!(
+        !store.has_pending_changes(),
+        "no pending changes after commit"
+    );
+}
+
+// ── Dataplane init tests ──────────────────────────────────────────────
+
+#[test]
+fn dataplane_init_creates_all_engines() {
+    let config =
+        ruster_config::load_from_str(&example_toml_str()).expect("example config should be valid");
+
+    let dp = ruster_dataplane::Dataplane::init(&config).expect("dataplane init should succeed");
+
+    // Verify engines are created from config values.
+    // The example config has NAT enabled.
+    assert!(dp.nat.is_enabled(), "NAT should be enabled per config");
+
+    // L3 engine should have the static routes loaded.
+    assert_eq!(
+        dp.l3.route_table().len(),
+        config.routing.ipv4_static_routes.len(),
+        "route table should have all static routes"
+    );
+
+    // Conntrack should start with zero sessions.
+    assert_eq!(
+        dp.conntrack.session_count(),
+        0,
+        "conntrack should start empty"
+    );
+}
+
+#[test]
+fn dataplane_init_returns_result_type() {
+    // This test primarily verifies the API contract: init returns Result.
+    let config =
+        ruster_config::load_from_str(&example_toml_str()).expect("example config should be valid");
+
+    let result: Result<ruster_dataplane::Dataplane, ruster_dataplane::DataplaneError> =
+        ruster_dataplane::Dataplane::init(&config);
+    assert!(result.is_ok());
+}
+
+// ── Full pipeline E2E ─────────────────────────────────────────────────
+
+#[test]
+fn full_startup_pipeline_succeeds() {
+    // Simulate the full main() flow without process::exit.
+    let config_path = example_config_path();
+    let config = ruster_config::load_from_file(config_path.to_str().unwrap())
+        .expect("config load should succeed");
+
+    ruster_control::validate(&config).expect("validation should succeed");
+
+    let mut store = ruster_control::ConfigStore::new();
+    store.apply(config.clone()).expect("apply should succeed");
+    store.commit().expect("commit should succeed");
+
+    let dp = ruster_dataplane::Dataplane::init(&config).expect("dataplane init should succeed");
+
+    // Verify the dataplane is properly initialized.
+    assert!(dp.nat.is_enabled());
+    assert_eq!(dp.conntrack.session_count(), 0);
+}


### PR DESCRIPTION
## Summary
- `--config`/`-c` CLI引数追加（デフォルト: `router.toml`）
- `Dataplane::start()` no-op を `Dataplane::init()` に置換、全サブエンジン（L2, ARP, L3, conntrack, NAT, firewall）を設定から初期化
- `DataplaneError` enum による構造化エラーレポート
- `FirewallEngine` に `#[derive(Debug)]` 追加
- main から未使用の `anyhow`, `ruster-observe` 依存削除
- 9テスト追加（integration 7 + unit 2）

## Test plan
- [x] `cargo test --workspace` — 287テスト全パス
- [x] `cargo clippy --workspace -- -D warnings` — クリーン
- [x] `cargo fmt --all -- --check` — クリーン
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — クリーン

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)