### PR TITLE
fix(dataplane): return errors from routing from_config (#122)

### DIFF
--- a/crates/dataplane/examples/bench_pipeline.rs
+++ b/crates/dataplane/examples/bench_pipeline.rs
@@ -297,7 +297,7 @@ fn bench_l2_fdb_hit() -> BenchResult {
 fn bench_l3_lpm_lookup() -> BenchResult {
     let routing_config = make_routing_config();
     let interfaces = make_interfaces();
-    let engine = L3Engine::from_config(&routing_config, &interfaces);
+    let engine = L3Engine::from_config(&routing_config, &interfaces).unwrap();
 
     // Packet destined to an external IP -> LPM hit on default route.
     let meta = make_ipv4_tcp_meta("lan0", [192, 168, 1, 100], [8, 8, 8, 8], 49152, 80);
@@ -541,7 +541,7 @@ fn bench_arp_cache_hit() -> BenchResult {
 fn bench_full_pipeline() -> BenchResult {
     // Set up all engines.
     let interfaces = make_interfaces();
-    let l3_engine = L3Engine::from_config(&make_routing_config(), &interfaces);
+    let l3_engine = L3Engine::from_config(&make_routing_config(), &interfaces).unwrap();
     let fw_engine = FirewallEngine::from_config(&make_fw_config());
     let nat_config = make_nat_config();
     let mut nat_engine = NatEngine::from_config(&nat_config, &interfaces);
@@ -802,7 +802,7 @@ fn verify_correctness() {
 
     // L3 LPM
     let interfaces = make_interfaces();
-    let l3_engine = L3Engine::from_config(&make_routing_config(), &interfaces);
+    let l3_engine = L3Engine::from_config(&make_routing_config(), &interfaces).unwrap();
     let meta = make_ipv4_tcp_meta("lan0", [192, 168, 1, 100], [8, 8, 8, 8], 49152, 80);
     let decision = l3_engine.process(&meta);
     assert!(

--- a/crates/dataplane/src/lib.rs
+++ b/crates/dataplane/src/lib.rs
@@ -15,6 +15,10 @@ pub enum DataplaneError {
     /// DPDK subsystem initialization failed.
     #[error("DPDK init: {0}")]
     Dpdk(#[from] dpdk::error::DpdkError),
+
+    /// L3 routing engine configuration failed (invalid routes or local IPs).
+    #[error("L3 routing config: {0}")]
+    Routing(#[from] routing::L3ConfigError),
 }
 
 /// The dataplane runtime holding initialized engines.
@@ -47,7 +51,7 @@ impl Dataplane {
     pub fn init(config: &RouterConfig) -> Result<Self, DataplaneError> {
         let l2 = l2::L2Engine::from_config(&config.l2);
         let arp = arp::ArpEngine::from_config(&config.l2, &config.interfaces);
-        let l3 = routing::L3Engine::from_config(&config.routing, &config.interfaces);
+        let l3 = routing::L3Engine::from_config(&config.routing, &config.interfaces)?;
         let nat = nat::NatEngine::from_config(&config.nat, &config.interfaces);
         let firewall = firewall::FirewallEngine::from_config(&config.firewall);
         let conntrack = conntrack::ConntrackEngine::from_nat_config(&config.nat);

--- a/crates/dataplane/src/routing/mod.rs
+++ b/crates/dataplane/src/routing/mod.rs
@@ -7,6 +7,13 @@
 //! 4. Perform longest-prefix-match route lookup.
 //! 5. Return a forwarding decision with the decremented TTL.
 //!
+//! # Validated-input contract
+//!
+//! [`L3Engine::from_config`] assumes its inputs have been validated by the
+//! config layer.  It returns a [`Result`] so that any parse failures
+//! (indicating a bug or unvalidated usage) surface immediately rather than
+//! being silently dropped.
+//!
 //! RFC-REF: RFC 791 Section 3.2
 //! "The internet module determines the destination address [...] and makes
 //! a routing decision to forward the datagram to the next gateway or
@@ -15,10 +22,52 @@
 pub mod table;
 
 use std::collections::HashSet;
+use std::fmt;
 
 use crate::packet::{L3Info, PacketMeta};
 use ruster_config::model::{InterfaceConfig, RoutingConfig};
-use table::RouteTable;
+use table::{RouteError, RouteTable};
+
+/// Error returned when [`L3Engine::from_config`] encounters invalid
+/// configuration entries (route table entries or local IP address strings).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum L3ConfigError {
+    /// One or more static route entries could not be parsed.
+    InvalidRoutes(Vec<RouteError>),
+    /// One or more interface IPv4 address strings could not be parsed.
+    ///
+    /// Each element is `(interface_name, raw_addr_string)`.
+    InvalidLocalAddrs(Vec<(String, String)>),
+}
+
+impl fmt::Display for L3ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidRoutes(errs) => {
+                write!(f, "invalid route entries: ")?;
+                for (i, e) in errs.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, "; ")?;
+                    }
+                    write!(f, "{e}")?;
+                }
+                Ok(())
+            }
+            Self::InvalidLocalAddrs(addrs) => {
+                write!(f, "invalid local addresses: ")?;
+                for (i, (iface, addr)) in addrs.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, "; ")?;
+                    }
+                    write!(f, "{iface}: \"{addr}\"")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl std::error::Error for L3ConfigError {}
 
 /// Reason an L3 packet was dropped.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -79,27 +128,50 @@ impl L3Engine {
     ///
     /// Loads the static route table from `routing_config` and collects
     /// all IPv4 addresses from `interfaces` for local delivery checks.
-    pub fn from_config(routing_config: &RoutingConfig, interfaces: &[InterfaceConfig]) -> Self {
-        let route_table = RouteTable::from_config(routing_config);
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`L3ConfigError`] if any route entry or local IP
+    /// address string cannot be parsed.  Route errors are reported via
+    /// [`L3ConfigError::InvalidRoutes`]; local address errors via
+    /// [`L3ConfigError::InvalidLocalAddrs`].
+    ///
+    /// # Validated-input contract
+    ///
+    /// Callers that run config validation via `ruster-config` before
+    /// reaching this point can expect `from_config` to always succeed.
+    pub fn from_config(
+        routing_config: &RoutingConfig,
+        interfaces: &[InterfaceConfig],
+    ) -> Result<Self, L3ConfigError> {
+        let route_table =
+            RouteTable::from_config(routing_config).map_err(L3ConfigError::InvalidRoutes)?;
 
-        // NOTE: Config validation (ruster-config validate) ensures all
-        // ipv4_addrs entries are well-formed CIDR strings before they reach
-        // here. filter_map is retained as a defence-in-depth measure; any
-        // parse failure at this stage indicates a logic bug.
-        let local_ips: HashSet<[u8; 4]> = interfaces
-            .iter()
-            .flat_map(|iface| {
-                iface
-                    .ipv4_addrs
-                    .iter()
-                    .filter_map(|addr_str| parse_ipv4_addr(addr_str))
-            })
-            .collect();
+        // Collect local IPs, tracking any parse failures.
+        let mut local_ips: HashSet<[u8; 4]> = HashSet::new();
+        let mut addr_errors: Vec<(String, String)> = Vec::new();
 
-        Self {
+        for iface in interfaces {
+            for addr_str in &iface.ipv4_addrs {
+                match parse_ipv4_addr(addr_str) {
+                    Some(ip) => {
+                        local_ips.insert(ip);
+                    }
+                    None => {
+                        addr_errors.push((iface.name.clone(), addr_str.clone()));
+                    }
+                }
+            }
+        }
+
+        if !addr_errors.is_empty() {
+            return Err(L3ConfigError::InvalidLocalAddrs(addr_errors));
+        }
+
+        Ok(Self {
             route_table,
             local_ips,
-        }
+        })
     }
 
     /// Make a forwarding decision for the given packet.
@@ -236,7 +308,7 @@ mod tests {
     }
 
     fn make_engine() -> L3Engine {
-        L3Engine::from_config(&make_routing_config(), &make_interfaces())
+        L3Engine::from_config(&make_routing_config(), &make_interfaces()).unwrap()
     }
 
     fn make_ipv4_meta(
@@ -412,7 +484,7 @@ mod tests {
                 metric: 10,
             }],
         };
-        let engine = L3Engine::from_config(&config, &make_interfaces());
+        let engine = L3Engine::from_config(&config, &make_interfaces()).unwrap();
 
         // Packet to 8.8.8.8 has no matching route.
         let meta = make_ipv4_meta("lan0", [192, 168, 1, 100], [8, 8, 8, 8], 64);

--- a/crates/dataplane/src/routing/table.rs
+++ b/crates/dataplane/src/routing/table.rs
@@ -4,12 +4,59 @@
 //! configuration and performs longest-prefix-match lookups for L3
 //! forwarding decisions.
 //!
+//! # Validated-input contract
+//!
+//! [`RouteTable::from_config`] expects that all route entries have already
+//! been validated by the config layer (`ruster-config` validate).  If any
+//! entry cannot be parsed, `from_config` returns an error listing every
+//! invalid entry instead of silently dropping them.  Callers that want to
+//! guarantee success should run config validation first.
+//!
 //! RFC-REF: RFC 791 Section 3.2
 //! "The internet modules use the addresses carried in the internet header
 //! to select the next gateway (or destination host) to which the datagram
 //! should be forwarded."
 
+use std::fmt;
+
 use ruster_config::model::RoutingConfig;
+
+/// Error describing a single invalid route entry encountered during
+/// [`RouteTable::from_config`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteError {
+    /// Zero-based index of the entry in the config list.
+    pub index: usize,
+    /// The kind of parse failure.
+    pub kind: RouteErrorKind,
+    /// The raw string value that failed to parse.
+    pub raw_value: String,
+}
+
+/// What went wrong when parsing a route entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RouteErrorKind {
+    /// The prefix string (e.g. "192.168.1.0/24") could not be parsed.
+    InvalidPrefix,
+    /// The next-hop address string could not be parsed as an IPv4 address.
+    InvalidNextHop,
+}
+
+impl fmt::Display for RouteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let field = match &self.kind {
+            RouteErrorKind::InvalidPrefix => "prefix",
+            RouteErrorKind::InvalidNextHop => "next_hop",
+        };
+        write!(
+            f,
+            "route[{}]: invalid {} \"{}\"",
+            self.index, field, self.raw_value
+        )
+    }
+}
+
+impl std::error::Error for RouteError {}
 
 /// A single route entry in the routing table.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -41,26 +88,57 @@ impl RouteTable {
     ///
     /// Parses each static route's prefix string (e.g. "192.168.1.0/24")
     /// and next-hop address, then sorts entries for LPM lookup.
-    pub fn from_config(routing_config: &RoutingConfig) -> Self {
-        // NOTE: Config validation (ruster-config validate) ensures all prefix
-        // and next_hop strings are well-formed before they reach here.
-        // filter_map is retained as a defence-in-depth measure; any parse
-        // failure at this stage indicates a logic bug.
-        let mut entries: Vec<RouteEntry> = routing_config
-            .ipv4_static_routes
-            .iter()
-            .filter_map(|sr| {
-                let (prefix, prefix_len) = parse_prefix(&sr.prefix)?;
-                let next_hop = parse_ipv4_addr(&sr.next_hop)?;
-                Some(RouteEntry {
+    ///
+    /// # Errors
+    ///
+    /// Returns **all** [`RouteError`]s found across every entry.  If any
+    /// entry is invalid the entire call fails so that callers are never
+    /// left with a silently incomplete routing table.
+    ///
+    /// # Validated-input contract
+    ///
+    /// Callers that run config validation via `ruster-config` before
+    /// reaching this point can expect `from_config` to always succeed.
+    /// The `Result` return type exists to surface bugs or direct
+    /// (unvalidated) usage clearly.
+    pub fn from_config(routing_config: &RoutingConfig) -> Result<Self, Vec<RouteError>> {
+        let mut entries: Vec<RouteEntry> =
+            Vec::with_capacity(routing_config.ipv4_static_routes.len());
+        let mut errors: Vec<RouteError> = Vec::new();
+
+        for (index, sr) in routing_config.ipv4_static_routes.iter().enumerate() {
+            let prefix_result = parse_prefix(&sr.prefix);
+            let next_hop_result = parse_ipv4_addr(&sr.next_hop);
+
+            if prefix_result.is_none() {
+                errors.push(RouteError {
+                    index,
+                    kind: RouteErrorKind::InvalidPrefix,
+                    raw_value: sr.prefix.clone(),
+                });
+            }
+            if next_hop_result.is_none() {
+                errors.push(RouteError {
+                    index,
+                    kind: RouteErrorKind::InvalidNextHop,
+                    raw_value: sr.next_hop.clone(),
+                });
+            }
+
+            if let (Some((prefix, prefix_len)), Some(next_hop)) = (prefix_result, next_hop_result) {
+                entries.push(RouteEntry {
                     prefix,
                     prefix_len,
                     next_hop,
                     out_ifname: sr.out_if.clone(),
                     metric: sr.metric,
-                })
-            })
-            .collect();
+                });
+            }
+        }
+
+        if !errors.is_empty() {
+            return Err(errors);
+        }
 
         // Sort by prefix_len descending (longest first), then metric ascending.
         entries.sort_by(|a, b| {
@@ -69,7 +147,7 @@ impl RouteTable {
                 .then(a.metric.cmp(&b.metric))
         });
 
-        Self { entries }
+        Ok(Self { entries })
     }
 
     /// Create an empty route table.
@@ -260,13 +338,13 @@ mod tests {
 
     #[test]
     fn from_config_parses_routes() {
-        let table = RouteTable::from_config(&make_routing_config());
+        let table = RouteTable::from_config(&make_routing_config()).unwrap();
         assert_eq!(table.len(), 3);
     }
 
     #[test]
     fn from_config_sorted_by_prefix_len_desc() {
-        let table = RouteTable::from_config(&make_routing_config());
+        let table = RouteTable::from_config(&make_routing_config()).unwrap();
         // /25, /24, /0
         assert_eq!(table.entries[0].prefix_len, 25);
         assert_eq!(table.entries[1].prefix_len, 24);
@@ -274,7 +352,7 @@ mod tests {
     }
 
     #[test]
-    fn from_config_skips_invalid() {
+    fn from_config_rejects_invalid_entries() {
         let config = RoutingConfig {
             ipv4_static_routes: vec![
                 StaticRoute {
@@ -291,15 +369,42 @@ mod tests {
                 },
             ],
         };
-        let table = RouteTable::from_config(&config);
-        assert_eq!(table.len(), 1);
+        let err = RouteTable::from_config(&config).unwrap_err();
+        assert_eq!(err.len(), 1);
+        assert_eq!(err[0].index, 0);
+        assert_eq!(err[0].kind, RouteErrorKind::InvalidPrefix);
+        assert_eq!(err[0].raw_value, "invalid/24");
+    }
+
+    #[test]
+    fn from_config_collects_all_errors() {
+        let config = RoutingConfig {
+            ipv4_static_routes: vec![
+                StaticRoute {
+                    prefix: "bad/99".to_string(),
+                    next_hop: "also_bad".to_string(),
+                    out_if: "wan0".to_string(),
+                    metric: 100,
+                },
+                StaticRoute {
+                    prefix: "10.0.0.0/8".to_string(),
+                    next_hop: "not_an_ip".to_string(),
+                    out_if: "wan0".to_string(),
+                    metric: 50,
+                },
+            ],
+        };
+        let err = RouteTable::from_config(&config).unwrap_err();
+        // Entry 0: invalid prefix AND invalid next_hop (2 errors).
+        // Entry 1: valid prefix, invalid next_hop (1 error).
+        assert_eq!(err.len(), 3);
     }
 
     // ── LPM lookup tests ──────────────────────────────────────────────
 
     #[test]
     fn lookup_longest_match_wins() {
-        let table = RouteTable::from_config(&make_routing_config());
+        let table = RouteTable::from_config(&make_routing_config()).unwrap();
 
         // 192.168.1.200 matches both /25 and /24; /25 should win.
         let result = table.lookup(&[192, 168, 1, 200]);
@@ -311,7 +416,7 @@ mod tests {
 
     #[test]
     fn lookup_shorter_prefix_when_longer_does_not_match() {
-        let table = RouteTable::from_config(&make_routing_config());
+        let table = RouteTable::from_config(&make_routing_config()).unwrap();
 
         // 192.168.1.10 matches /24 but not /25 (128..255 range).
         let result = table.lookup(&[192, 168, 1, 10]);
@@ -323,7 +428,7 @@ mod tests {
 
     #[test]
     fn lookup_default_route() {
-        let table = RouteTable::from_config(&make_routing_config());
+        let table = RouteTable::from_config(&make_routing_config()).unwrap();
 
         // 8.8.8.8 matches only the default route.
         let result = table.lookup(&[8, 8, 8, 8]);
@@ -350,7 +455,7 @@ mod tests {
                 metric: 10,
             }],
         };
-        let table = RouteTable::from_config(&config);
+        let table = RouteTable::from_config(&config).unwrap();
 
         // 10.0.0.1 does not match 192.168.1.0/24.
         assert!(table.lookup(&[10, 0, 0, 1]).is_none());
@@ -376,7 +481,7 @@ mod tests {
                 },
             ],
         };
-        let table = RouteTable::from_config(&config);
+        let table = RouteTable::from_config(&config).unwrap();
         let result = table.lookup(&[10, 1, 2, 3]).unwrap();
         assert_eq!(result.metric, 100);
         assert_eq!(result.next_hop, [10, 0, 0, 1]);

--- a/crates/dataplane/tests/e2e_scenarios.rs
+++ b/crates/dataplane/tests/e2e_scenarios.rs
@@ -343,7 +343,7 @@ fn e2e_l2_bridge_flood_then_unicast() {
 #[test]
 fn e2e_l3_static_routing_lan_to_wan() {
     let (_, routing_config, _, _, interfaces) = make_home_router_config();
-    let l3 = L3Engine::from_config(&routing_config, &interfaces);
+    let l3 = L3Engine::from_config(&routing_config, &interfaces).unwrap();
 
     // LAN host 192.168.1.100 sends to 8.8.8.8
     let meta = PacketMeta {
@@ -373,7 +373,7 @@ fn e2e_l3_static_routing_lan_to_wan() {
 #[test]
 fn e2e_l3_ttl_expired_vs_local_delivery() {
     let (_, routing_config, _, _, interfaces) = make_home_router_config();
-    let l3 = L3Engine::from_config(&routing_config, &interfaces);
+    let l3 = L3Engine::from_config(&routing_config, &interfaces).unwrap();
 
     // ── Case A: TTL=1 destined for external IP → Drop(TtlExpired) ────
     let meta_ttl1 = PacketMeta {
@@ -713,7 +713,7 @@ fn e2e_firewall_established_return_traffic() {
 fn e2e_full_pipeline_outbound_and_reply() {
     let (_, routing_config, nat_config, fw_config, interfaces) = make_home_router_config();
 
-    let l3 = L3Engine::from_config(&routing_config, &interfaces);
+    let l3 = L3Engine::from_config(&routing_config, &interfaces).unwrap();
     let mut nat = NatEngine::from_config(&nat_config, &interfaces);
     let fw = FirewallEngine::from_config(&fw_config);
     let mut conntrack = make_conntrack_from_nat(&nat_config);
@@ -849,7 +849,7 @@ fn e2e_full_pipeline_outbound_and_reply() {
 fn e2e_observer_counter_tracking() {
     let (_, routing_config, nat_config, _, interfaces) = make_home_router_config();
 
-    let l3 = L3Engine::from_config(&routing_config, &interfaces);
+    let l3 = L3Engine::from_config(&routing_config, &interfaces).unwrap();
 
     // Use a restrictive firewall config that only allows LAN->WAN
     // (no WAN->LAN rule), so our uninvited WAN packet will be dropped.


### PR DESCRIPTION
## Summary
- `RouteTable::from_config` を `Result<Self, Vec<RouteError>>` に変更、不正エントリの黙殺を解消
- `L3Engine::from_config` を `Result<Self, L3ConfigError>` に変更
- `RouteError`/`RouteErrorKind`/`L3ConfigError` 型を追加して構造化エラーレポート
- `DataplaneError::Routing` variant でエラー伝播
- validated-input contract をドキュメントに明記

## Test plan
- [x] `cargo test --workspace` — 288テスト全パス
- [x] `cargo clippy --workspace -- -D warnings` — クリーン
- [x] `cargo fmt --all -- --check` — クリーン
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — クリーン

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)