### PR TITLE
feat(runtime): add run loop with graceful shutdown (#121)

### DIFF
--- a/crates/dataplane/src/lib.rs
+++ b/crates/dataplane/src/lib.rs
@@ -7,6 +7,10 @@ pub mod nat;
 pub mod packet;
 pub mod routing;
 
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
 use ruster_config::model::RouterConfig;
 
 /// Initialization error for the dataplane.
@@ -65,6 +69,25 @@ impl Dataplane {
             conntrack,
         })
     }
+
+    /// Run the dataplane event loop until the shutdown flag is set.
+    ///
+    /// In v0.1 there is no real packet I/O (DPDK backend is mocked), so the
+    /// loop simply polls the `shutdown` flag at a fixed interval. When actual
+    /// DPDK integration is added, this loop will drive the poll-mode driver.
+    ///
+    /// Returns `Ok(())` on clean shutdown.
+    pub fn run(&self, shutdown: Arc<AtomicBool>) -> Result<(), DataplaneError> {
+        const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+        while !shutdown.load(Ordering::Relaxed) {
+            // v0.1: no real packet I/O — sleep until shutdown signal.
+            // Future: call DPDK rx_burst / tx_burst here.
+            std::thread::sleep(POLL_INTERVAL);
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -101,5 +124,46 @@ mod tests {
         let config = load_example();
         let result: Result<Dataplane, DataplaneError> = Dataplane::init(&config);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn dataplane_run_returns_on_shutdown() {
+        let config = load_example();
+        let dp = Dataplane::init(&config).expect("init should succeed");
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_trigger = Arc::clone(&shutdown);
+
+        // Signal shutdown after a short delay from another thread.
+        let handle = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(200));
+            shutdown_trigger.store(true, Ordering::Relaxed);
+        });
+
+        // run() should block until the shutdown flag is set, then return Ok.
+        let result = dp.run(shutdown);
+        assert!(result.is_ok(), "run should return Ok on clean shutdown");
+
+        handle.join().expect("trigger thread should join cleanly");
+    }
+
+    #[test]
+    fn dataplane_run_returns_immediately_if_already_shutdown() {
+        let config = load_example();
+        let dp = Dataplane::init(&config).expect("init should succeed");
+
+        // Pre-set the shutdown flag before calling run.
+        let shutdown = Arc::new(AtomicBool::new(true));
+
+        let start = std::time::Instant::now();
+        let result = dp.run(shutdown);
+        let elapsed = start.elapsed();
+
+        assert!(result.is_ok(), "run should return Ok");
+        assert!(
+            elapsed < Duration::from_millis(50),
+            "run should return immediately when shutdown is pre-set, took {:?}",
+            elapsed
+        );
     }
 }

--- a/crates/main/src/main.rs
+++ b/crates/main/src/main.rs
@@ -1,5 +1,46 @@
 use std::env;
 use std::process;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+/// Global shutdown flag, set by the signal handler.
+static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+/// Signal handler for SIGINT and SIGTERM.
+///
+/// SAFETY: This function only performs async-signal-safe operations
+/// (an atomic store). It is registered via `libc::signal`-style
+/// mechanism on POSIX platforms.
+extern "C" fn signal_handler(_sig: i32) {
+    SHUTDOWN_REQUESTED.store(true, Ordering::Relaxed);
+}
+
+/// Register signal handlers for SIGINT (2) and SIGTERM (15).
+///
+/// Uses raw POSIX `signal()` via FFI to avoid external crate dependencies.
+fn register_signal_handlers() {
+    // SAFETY: `signal_handler` performs only an atomic store, which is
+    // async-signal-safe. We pass a valid function pointer.
+    unsafe {
+        // SIGINT = 2, SIGTERM = 15 (POSIX standard values)
+        libc_signal(2, signal_handler as *const () as usize);
+        libc_signal(15, signal_handler as *const () as usize);
+    }
+}
+
+/// Minimal FFI binding to POSIX `signal()`.
+///
+/// We avoid depending on the `libc` crate by declaring just this one symbol.
+unsafe fn libc_signal(signum: i32, handler: usize) {
+    extern "C" {
+        fn signal(signum: i32, handler: usize) -> usize;
+    }
+    // SAFETY: caller guarantees `handler` is a valid function pointer
+    // and `signum` is a valid signal number.
+    unsafe {
+        signal(signum, handler);
+    }
+}
 
 fn main() {
     // Parse CLI args: --config <path> / -c <path>, or default to "router.toml"
@@ -26,7 +67,7 @@ fn main() {
     store.commit().expect("commit after successful apply");
 
     // Initialize dataplane
-    let _dataplane = match ruster_dataplane::Dataplane::init(&config) {
+    let dataplane = match ruster_dataplane::Dataplane::init(&config) {
         Ok(dp) => dp,
         Err(e) => {
             eprintln!("Error: dataplane init failed: {}", e);
@@ -43,9 +84,38 @@ fn main() {
     println!("  NAT enabled: {}", config.nat.enabled);
     println!("  Firewall enabled: {}", config.firewall.enabled);
 
-    // In v0.1, we just print status and exit.
-    // Real packet processing loop will be added when DPDK backend is integrated.
-    println!("\nruster ready. (v0.1: init-only mode, no packet loop yet)");
+    // Register signal handlers for graceful shutdown
+    register_signal_handlers();
+
+    // Bridge the global static flag into an Arc for the dataplane run loop
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown_poll = Arc::clone(&shutdown);
+
+    // Spawn a monitor thread that propagates the global signal flag
+    // into the Arc-based shutdown flag used by the dataplane.
+    let monitor = std::thread::Builder::new()
+        .name("signal-monitor".to_string())
+        .spawn(move || {
+            while !SHUTDOWN_REQUESTED.load(Ordering::Relaxed) {
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            shutdown_poll.store(true, Ordering::Relaxed);
+        })
+        .expect("failed to spawn signal-monitor thread");
+
+    println!("\nruster: running (press Ctrl+C to stop)");
+
+    // Enter the dataplane run loop (blocks until shutdown)
+    if let Err(e) = dataplane.run(shutdown) {
+        eprintln!("Error: dataplane run failed: {}", e);
+        process::exit(1);
+    }
+
+    // Wait for the monitor thread to finish
+    let _ = monitor.join();
+
+    println!("ruster: shutting down...");
+    println!("ruster: shutdown complete");
 }
 
 fn parse_config_path() -> String {

--- a/crates/main/tests/startup.rs
+++ b/crates/main/tests/startup.rs
@@ -133,3 +133,93 @@ fn full_startup_pipeline_succeeds() {
     assert!(dp.nat.is_enabled());
     assert_eq!(dp.conntrack.session_count(), 0);
 }
+
+// ── Run loop tests ──────────────────────────────────────────────────
+
+#[test]
+fn dataplane_run_exits_on_shutdown_signal() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    let config =
+        ruster_config::load_from_str(&example_toml_str()).expect("example config should be valid");
+    let dp = ruster_dataplane::Dataplane::init(&config).expect("dataplane init should succeed");
+
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown_trigger = Arc::clone(&shutdown);
+
+    // Signal shutdown after a short delay.
+    let handle = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(200));
+        shutdown_trigger.store(true, Ordering::Relaxed);
+    });
+
+    let result = dp.run(shutdown);
+    assert!(result.is_ok(), "run should return Ok on clean shutdown");
+
+    handle.join().expect("trigger thread should join cleanly");
+}
+
+#[test]
+fn dataplane_run_immediate_shutdown() {
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    let config =
+        ruster_config::load_from_str(&example_toml_str()).expect("example config should be valid");
+    let dp = ruster_dataplane::Dataplane::init(&config).expect("dataplane init should succeed");
+
+    // Pre-set shutdown before calling run.
+    let shutdown = Arc::new(AtomicBool::new(true));
+
+    let start = std::time::Instant::now();
+    let result = dp.run(shutdown);
+    let elapsed = start.elapsed();
+
+    assert!(result.is_ok(), "run should return Ok");
+    assert!(
+        elapsed < Duration::from_millis(50),
+        "run should return immediately when shutdown is pre-set, took {:?}",
+        elapsed
+    );
+}
+
+#[test]
+fn full_startup_run_shutdown_pipeline() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    // Full E2E: config load -> control -> dataplane init -> run -> shutdown
+    let config_path = example_config_path();
+    let config = ruster_config::load_from_file(config_path.to_str().unwrap())
+        .expect("config load should succeed");
+
+    ruster_control::validate(&config).expect("validation should succeed");
+
+    let mut store = ruster_control::ConfigStore::new();
+    store.apply(config.clone()).expect("apply should succeed");
+    store.commit().expect("commit should succeed");
+
+    let dp = ruster_dataplane::Dataplane::init(&config).expect("dataplane init should succeed");
+
+    // Verify engines.
+    assert!(dp.nat.is_enabled());
+    assert_eq!(dp.conntrack.session_count(), 0);
+
+    // Run and shutdown.
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let shutdown_trigger = Arc::clone(&shutdown);
+
+    let handle = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(150));
+        shutdown_trigger.store(true, Ordering::Relaxed);
+    });
+
+    let result = dp.run(shutdown);
+    assert!(result.is_ok(), "full pipeline run should succeed");
+
+    handle.join().expect("trigger thread should join");
+}


### PR DESCRIPTION
## Summary
- `Dataplane::run()` 追加: shutdown flag を100msポーリングする継続実行ループ
- SIGINT/SIGTERM シグナルハンドラを raw POSIX FFI で実装（外部クレート依存なし）
- `main` が init 後に即終了せず、run loop に入るように変更
- signal-monitor スレッドでグローバル static flag → `Arc<AtomicBool>` ブリッジ
- 5テスト追加（unit 2 + integration 3）

## Test plan
- [x] `cargo test --workspace` — 293テスト全パス
- [x] `cargo clippy --workspace -- -D warnings` — クリーン
- [x] `cargo fmt --all -- --check` — クリーン
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — クリーン

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)