### PR TITLE
feat(dataplane): connect RX/TX pipeline to run loop (#125)

### DIFF
--- a/crates/dataplane/src/io.rs
+++ b/crates/dataplane/src/io.rs
@@ -1,0 +1,195 @@
+//! Packet I/O abstraction for the ruster dataplane.
+//!
+//! Defines the [`PacketIo`] trait that abstracts over the packet
+//! receive/transmit backend. In v0.1 the backend is mocked for testing;
+//! a future DPDK backend will implement this trait for real NIC I/O.
+
+use std::collections::VecDeque;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+// ── Error ────────────────────────────────────────────────────────────
+
+/// Error returned by [`PacketIo::tx`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IoError {
+    /// The specified egress interface does not exist.
+    InterfaceNotFound(String),
+    /// The transmit operation failed for a backend-specific reason.
+    TxFailed(String),
+}
+
+impl fmt::Display for IoError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            IoError::InterfaceNotFound(name) => {
+                write!(f, "interface not found: {name}")
+            }
+            IoError::TxFailed(reason) => write!(f, "tx failed: {reason}"),
+        }
+    }
+}
+
+impl std::error::Error for IoError {}
+
+// ── RawPacket ────────────────────────────────────────────────────────
+
+/// A raw packet buffer with metadata about which interface it arrived on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawPacket {
+    /// Name of the interface this packet was received on.
+    pub ingress_iface: String,
+    /// Raw packet bytes (Ethernet frame).
+    pub data: Vec<u8>,
+}
+
+// ── PacketIo trait ───────────────────────────────────────────────────
+
+/// Abstraction over packet receive/transmit backends.
+///
+/// In v0.1 this is used for testing via [`MockPacketIo`]; a future
+/// DPDK backend will implement this trait for real NIC poll-mode I/O.
+pub trait PacketIo: Send + Sync {
+    /// Receive a batch of packets.
+    ///
+    /// Returns an empty `Vec` if no packets are currently available.
+    /// The implementation should not block.
+    fn rx(&self) -> Vec<RawPacket>;
+
+    /// Transmit a packet on the specified egress interface.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IoError::InterfaceNotFound`] if the interface does not
+    /// exist, or [`IoError::TxFailed`] for backend-specific failures.
+    fn tx(&self, iface: &str, packet: &RawPacket) -> Result<(), IoError>;
+}
+
+// ── MockPacketIo ─────────────────────────────────────────────────────
+
+/// A mock packet I/O backend for testing.
+///
+/// Allows injecting packets into the RX queue and capturing packets
+/// sent via TX. Both queues are protected by mutexes so the mock can
+/// be shared with the dataplane run loop.
+#[derive(Debug, Clone)]
+pub struct MockPacketIo {
+    /// Queue of packets waiting to be received.
+    rx_queue: Arc<Mutex<VecDeque<RawPacket>>>,
+    /// Capture of all transmitted packets.
+    tx_capture: Arc<Mutex<Vec<(String, RawPacket)>>>,
+}
+
+impl MockPacketIo {
+    /// Create a new mock I/O backend with empty queues.
+    pub fn new() -> Self {
+        Self {
+            rx_queue: Arc::new(Mutex::new(VecDeque::new())),
+            tx_capture: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Enqueue a packet for the next `rx()` call.
+    pub fn inject(&self, packet: RawPacket) {
+        self.rx_queue.lock().unwrap().push_back(packet);
+    }
+
+    /// Return all captured TX packets as `(egress_iface, packet)` pairs.
+    pub fn tx_captured(&self) -> Vec<(String, RawPacket)> {
+        self.tx_capture.lock().unwrap().clone()
+    }
+
+    /// Return the number of captured TX packets.
+    pub fn tx_count(&self) -> usize {
+        self.tx_capture.lock().unwrap().len()
+    }
+}
+
+impl Default for MockPacketIo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PacketIo for MockPacketIo {
+    fn rx(&self) -> Vec<RawPacket> {
+        let mut queue = self.rx_queue.lock().unwrap();
+        queue.drain(..).collect()
+    }
+
+    fn tx(&self, iface: &str, packet: &RawPacket) -> Result<(), IoError> {
+        self.tx_capture
+            .lock()
+            .unwrap()
+            .push((iface.to_string(), packet.clone()));
+        Ok(())
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_io_rx_empty() {
+        let io = MockPacketIo::new();
+        assert!(io.rx().is_empty());
+    }
+
+    #[test]
+    fn mock_io_inject_and_rx() {
+        let io = MockPacketIo::new();
+        io.inject(RawPacket {
+            ingress_iface: "eth0".to_string(),
+            data: vec![0xAA, 0xBB],
+        });
+        io.inject(RawPacket {
+            ingress_iface: "eth1".to_string(),
+            data: vec![0xCC],
+        });
+
+        let batch = io.rx();
+        assert_eq!(batch.len(), 2);
+        assert_eq!(batch[0].ingress_iface, "eth0");
+        assert_eq!(batch[1].ingress_iface, "eth1");
+
+        // Second call returns empty (queue drained).
+        assert!(io.rx().is_empty());
+    }
+
+    #[test]
+    fn mock_io_tx_captures() {
+        let io = MockPacketIo::new();
+        let pkt = RawPacket {
+            ingress_iface: "eth0".to_string(),
+            data: vec![0x01, 0x02, 0x03],
+        };
+
+        io.tx("wan0", &pkt).unwrap();
+        io.tx("lan0", &pkt).unwrap();
+
+        let captured = io.tx_captured();
+        assert_eq!(captured.len(), 2);
+        assert_eq!(captured[0].0, "wan0");
+        assert_eq!(captured[1].0, "lan0");
+        assert_eq!(io.tx_count(), 2);
+    }
+
+    #[test]
+    fn io_error_display() {
+        let e1 = IoError::InterfaceNotFound("eth99".to_string());
+        assert_eq!(format!("{e1}"), "interface not found: eth99");
+
+        let e2 = IoError::TxFailed("queue full".to_string());
+        assert_eq!(format!("{e2}"), "tx failed: queue full");
+    }
+
+    #[test]
+    fn mock_io_default() {
+        let io = MockPacketIo::default();
+        assert!(io.rx().is_empty());
+        assert_eq!(io.tx_count(), 0);
+    }
+}

--- a/crates/dataplane/src/lib.rs
+++ b/crates/dataplane/src/lib.rs
@@ -2,9 +2,11 @@ pub mod arp;
 pub mod conntrack;
 pub mod dpdk;
 pub mod firewall;
+pub mod io;
 pub mod l2;
 pub mod nat;
 pub mod packet;
+pub mod pipeline;
 pub mod routing;
 
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -72,18 +74,34 @@ impl Dataplane {
 
     /// Run the dataplane event loop until the shutdown flag is set.
     ///
-    /// In v0.1 there is no real packet I/O (DPDK backend is mocked), so the
-    /// loop simply polls the `shutdown` flag at a fixed interval. When actual
-    /// DPDK integration is added, this loop will drive the poll-mode driver.
+    /// Receives packets via [`io::PacketIo::rx`], processes them through
+    /// the pipeline (parse -> L3 route -> firewall), and transmits
+    /// forwarded packets via [`io::PacketIo::tx`].
+    ///
+    /// If the RX queue is empty the loop sleeps briefly to avoid busy-spinning.
     ///
     /// Returns `Ok(())` on clean shutdown.
-    pub fn run(&self, shutdown: Arc<AtomicBool>) -> Result<(), DataplaneError> {
-        const POLL_INTERVAL: Duration = Duration::from_millis(100);
-
+    pub fn run(
+        &self,
+        shutdown: Arc<AtomicBool>,
+        io: Box<dyn io::PacketIo>,
+    ) -> Result<(), DataplaneError> {
         while !shutdown.load(Ordering::Relaxed) {
-            // v0.1: no real packet I/O — sleep until shutdown signal.
-            // Future: call DPDK rx_burst / tx_burst here.
-            std::thread::sleep(POLL_INTERVAL);
+            let batch = io.rx();
+            if batch.is_empty() {
+                std::thread::sleep(Duration::from_millis(1));
+                continue;
+            }
+            for raw_pkt in &batch {
+                let result =
+                    pipeline::process_packet(raw_pkt, &self.l3, &self.firewall, &self.conntrack);
+                match result {
+                    pipeline::PipelineResult::Forward { egress_iface } => {
+                        let _ = io.tx(&egress_iface, raw_pkt);
+                    }
+                    pipeline::PipelineResult::Drop { .. } | pipeline::PipelineResult::Consumed => {}
+                }
+            }
         }
 
         Ok(())
@@ -141,7 +159,8 @@ mod tests {
         });
 
         // run() should block until the shutdown flag is set, then return Ok.
-        let result = dp.run(shutdown);
+        let mock_io = io::MockPacketIo::new();
+        let result = dp.run(shutdown, Box::new(mock_io));
         assert!(result.is_ok(), "run should return Ok on clean shutdown");
 
         handle.join().expect("trigger thread should join cleanly");
@@ -156,7 +175,8 @@ mod tests {
         let shutdown = Arc::new(AtomicBool::new(true));
 
         let start = std::time::Instant::now();
-        let result = dp.run(shutdown);
+        let mock_io = io::MockPacketIo::new();
+        let result = dp.run(shutdown, Box::new(mock_io));
         let elapsed = start.elapsed();
 
         assert!(result.is_ok(), "run should return Ok");

--- a/crates/dataplane/src/pipeline.rs
+++ b/crates/dataplane/src/pipeline.rs
@@ -1,0 +1,551 @@
+//! Pipeline processing orchestration for the ruster dataplane.
+//!
+//! Processes a single packet through the forwarding path:
+//!
+//! ```text
+//! parse -> L3 route -> firewall -> forward/drop
+//! ```
+//!
+//! The main entry point is [`process_packet`], which takes a raw packet
+//! and references to the forwarding engines, then returns a
+//! [`PipelineResult`] indicating whether the packet should be forwarded,
+//! dropped, or was consumed internally.
+
+use crate::firewall::{FirewallEngine, FwChain, FwContext, FwVerdict};
+use crate::io::RawPacket;
+use crate::packet;
+use crate::routing::{L3Decision, L3DropReason, L3Engine};
+
+use ruster_config::model::FirewallZone;
+
+use crate::conntrack::ConntrackEngine;
+
+// ── Pipeline result types ───────────────────────────────────────────
+
+/// Result of processing a single packet through the pipeline.
+#[derive(Debug)]
+pub enum PipelineResult {
+    /// Packet should be forwarded out the given interface.
+    Forward {
+        /// Name of the egress interface.
+        egress_iface: String,
+    },
+    /// Packet was dropped.
+    Drop {
+        /// Why the packet was dropped.
+        reason: DropReason,
+    },
+    /// Packet was consumed (e.g., ARP reply generated internally).
+    Consumed,
+}
+
+/// Reason a packet was dropped during pipeline processing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DropReason {
+    /// The raw bytes could not be parsed into a valid packet.
+    ParseError,
+    /// L2 engine dropped the packet.
+    L2Drop,
+    /// L3 engine found no matching route.
+    L3NoRoute,
+    /// L3 engine detected TTL expiration.
+    L3TtlExpired,
+    /// L3 engine received a non-IPv4 packet.
+    L3NotIpv4,
+    /// Firewall dropped the packet.
+    FirewallDrop,
+    /// NAT engine dropped the packet.
+    NatDrop,
+}
+
+// ── Pipeline function ───────────────────────────────────────────────
+
+/// Process a single raw packet through the forwarding pipeline.
+///
+/// The simplified v0.1 flow is:
+/// 1. Parse the raw bytes into a [`PacketMeta`](packet::PacketMeta).
+/// 2. If parsing fails, return `Drop(ParseError)`.
+/// 3. Check L3 routing via [`L3Engine::process`].
+/// 4. Based on the L3 decision:
+///    - `Forward { .. }` -> check firewall -> return `Forward` or `Drop(FirewallDrop)`.
+///    - `LocalDelivery` -> `Consumed`.
+///    - `Drop(reason)` -> `Drop` with a mapped reason.
+/// 5. If the firewall blocks the packet, return `Drop(FirewallDrop)`.
+pub fn process_packet(
+    raw_pkt: &RawPacket,
+    l3: &L3Engine,
+    firewall: &FirewallEngine,
+    conntrack: &ConntrackEngine,
+) -> PipelineResult {
+    // Step 1: Parse raw bytes.
+    let meta = match packet::parse_packet(&raw_pkt.data, &raw_pkt.ingress_iface) {
+        Ok(m) => m,
+        Err(_) => {
+            return PipelineResult::Drop {
+                reason: DropReason::ParseError,
+            }
+        }
+    };
+
+    // Step 2: L3 routing decision.
+    let l3_decision = l3.process(&meta);
+
+    match l3_decision {
+        L3Decision::Forward {
+            out_ifname,
+            next_hop: _,
+            new_ttl: _,
+        } => {
+            // Step 3: Firewall check on the forward chain.
+            // RFC-DEVIATION:
+            // reason: v0.1 uses placeholder zones (Lan/Lan) for simplicity
+            // impact: zone-based firewall filtering is not fully functional
+            // issue: #125
+            // plan: v0.2 will resolve zones from interface config
+            let fw_ctx = FwContext::from_packet(
+                &meta,
+                FwChain::Forward,
+                FirewallZone::Lan,
+                FirewallZone::Lan,
+                conntrack,
+            );
+            let verdict = firewall.evaluate(&fw_ctx);
+
+            match verdict {
+                FwVerdict::Accept | FwVerdict::AcceptRule { .. } => PipelineResult::Forward {
+                    egress_iface: out_ifname,
+                },
+                FwVerdict::Drop | FwVerdict::DropRule { .. } => PipelineResult::Drop {
+                    reason: DropReason::FirewallDrop,
+                },
+            }
+        }
+        L3Decision::LocalDelivery => PipelineResult::Consumed,
+        L3Decision::Drop { reason } => PipelineResult::Drop {
+            reason: map_l3_drop_reason(reason),
+        },
+    }
+}
+
+/// Map an L3 drop reason to a pipeline drop reason.
+fn map_l3_drop_reason(reason: L3DropReason) -> DropReason {
+    match reason {
+        L3DropReason::NotIpv4 => DropReason::L3NotIpv4,
+        L3DropReason::TtlExpired => DropReason::L3TtlExpired,
+        L3DropReason::NoRoute => DropReason::L3NoRoute,
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conntrack::{ConntrackConfig, ConntrackEngine};
+    use crate::io::RawPacket;
+    use ruster_config::model::{
+        DefaultPolicy, FirewallConfig, InterfaceConfig, InterfaceRole, InterfaceZone,
+        RoutingConfig, StaticRoute,
+    };
+
+    // ── Test helpers ────────────────────────────────────────────────
+
+    fn make_routing_config() -> RoutingConfig {
+        RoutingConfig {
+            ipv4_static_routes: vec![
+                StaticRoute {
+                    prefix: "0.0.0.0/0".to_string(),
+                    next_hop: "10.0.0.1".to_string(),
+                    out_if: "wan0".to_string(),
+                    metric: 100,
+                },
+                StaticRoute {
+                    prefix: "192.168.1.0/24".to_string(),
+                    next_hop: "0.0.0.0".to_string(),
+                    out_if: "lan0".to_string(),
+                    metric: 10,
+                },
+            ],
+        }
+    }
+
+    fn make_interfaces() -> Vec<InterfaceConfig> {
+        vec![
+            InterfaceConfig {
+                name: "wan0".to_string(),
+                port_id: 0,
+                role: InterfaceRole::Wan,
+                admin_up: true,
+                mtu: 1500,
+                mac: "00:11:22:33:44:55".to_string(),
+                ipv4_addrs: vec!["10.0.0.2/24".to_string()],
+                zone: InterfaceZone::Wan,
+                l2_domain: "br0".to_string(),
+            },
+            InterfaceConfig {
+                name: "lan0".to_string(),
+                port_id: 1,
+                role: InterfaceRole::Lan,
+                admin_up: true,
+                mtu: 1500,
+                mac: "00:AA:BB:CC:DD:EE".to_string(),
+                ipv4_addrs: vec!["192.168.1.1/24".to_string()],
+                zone: InterfaceZone::Lan,
+                l2_domain: "br0".to_string(),
+            },
+        ]
+    }
+
+    fn make_l3_engine() -> L3Engine {
+        L3Engine::from_config(&make_routing_config(), &make_interfaces()).unwrap()
+    }
+
+    fn make_fw_accept_all() -> FirewallEngine {
+        FirewallEngine::from_config(&FirewallConfig {
+            enabled: false,
+            default_input: DefaultPolicy::Accept,
+            default_forward: DefaultPolicy::Accept,
+            default_output: DefaultPolicy::Accept,
+            allow_established_related: false,
+            rules: vec![],
+        })
+    }
+
+    fn make_fw_drop_all() -> FirewallEngine {
+        FirewallEngine::from_config(&FirewallConfig {
+            enabled: true,
+            default_input: DefaultPolicy::Drop,
+            default_forward: DefaultPolicy::Drop,
+            default_output: DefaultPolicy::Drop,
+            allow_established_related: false,
+            rules: vec![],
+        })
+    }
+
+    fn make_conntrack() -> ConntrackEngine {
+        ConntrackEngine::new(ConntrackConfig {
+            max_sessions: 1000,
+            tcp_established_timeout_sec: 7200,
+            tcp_transitory_timeout_sec: 120,
+            udp_timeout_sec: 300,
+            icmp_timeout_sec: 30,
+        })
+    }
+
+    /// Compute IPv4 header checksum and write it into the header.
+    fn set_ipv4_checksum(hdr: &mut [u8]) {
+        hdr[10] = 0x00;
+        hdr[11] = 0x00;
+        let mut sum: u32 = 0;
+        for i in (0..hdr.len()).step_by(2) {
+            let word = if i + 1 < hdr.len() {
+                u16::from_be_bytes([hdr[i], hdr[i + 1]])
+            } else {
+                u16::from_be_bytes([hdr[i], 0])
+            };
+            sum += word as u32;
+        }
+        while (sum >> 16) != 0 {
+            sum = (sum & 0xFFFF) + (sum >> 16);
+        }
+        let cksum = !(sum as u16);
+        hdr[10] = (cksum >> 8) as u8;
+        hdr[11] = (cksum & 0xFF) as u8;
+    }
+
+    /// Build a valid Ethernet + IPv4 + UDP packet.
+    fn make_ipv4_packet(
+        src_mac: [u8; 6],
+        dst_mac: [u8; 6],
+        src_ip: [u8; 4],
+        dst_ip: [u8; 4],
+        ttl: u8,
+    ) -> Vec<u8> {
+        let mut pkt = Vec::new();
+        // Ethernet header (14 bytes)
+        pkt.extend_from_slice(&dst_mac);
+        pkt.extend_from_slice(&src_mac);
+        pkt.extend_from_slice(&[0x08, 0x00]); // EtherType IPv4
+
+        // IPv4 header (20 bytes minimum)
+        let ipv4_start = pkt.len();
+        pkt.push(0x45); // version=4, IHL=5
+        pkt.push(0x00); // DSCP/ECN
+        let total_len: u16 = 20 + 8; // IP header + 8 bytes UDP
+        pkt.extend_from_slice(&total_len.to_be_bytes());
+        pkt.extend_from_slice(&[0x00, 0x00]); // identification
+        pkt.extend_from_slice(&[0x00, 0x00]); // flags/fragment
+        pkt.push(ttl);
+        pkt.push(17); // protocol: UDP
+        pkt.extend_from_slice(&[0x00, 0x00]); // checksum placeholder
+        pkt.extend_from_slice(&src_ip);
+        pkt.extend_from_slice(&dst_ip);
+
+        // Compute IPv4 checksum
+        set_ipv4_checksum(&mut pkt[ipv4_start..ipv4_start + 20]);
+
+        // Minimal UDP header (8 bytes)
+        pkt.extend_from_slice(&[0x00, 0x50]); // src port: 80
+        pkt.extend_from_slice(&[0x00, 0x51]); // dst port: 81
+        pkt.extend_from_slice(&[0x00, 0x08]); // length: 8
+        pkt.extend_from_slice(&[0x00, 0x00]); // checksum: 0
+        pkt
+    }
+
+    // ── Pipeline tests ──────────────────────────────────────────────
+
+    #[test]
+    fn forward_routed_packet() {
+        let l3 = make_l3_engine();
+        let fw = make_fw_accept_all();
+        let ct = make_conntrack();
+
+        // Packet from LAN to internet (8.8.8.8) -> default route via wan0.
+        let data = make_ipv4_packet(
+            [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
+            [0x00, 0x11, 0x22, 0x33, 0x44, 0x55],
+            [192, 168, 1, 100],
+            [8, 8, 8, 8],
+            64,
+        );
+        let raw_pkt = RawPacket {
+            ingress_iface: "lan0".to_string(),
+            data,
+        };
+
+        let result = process_packet(&raw_pkt, &l3, &fw, &ct);
+        match result {
+            PipelineResult::Forward { egress_iface } => {
+                assert_eq!(egress_iface, "wan0");
+            }
+            other => panic!("expected Forward, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn drop_parse_error_too_short() {
+        let l3 = make_l3_engine();
+        let fw = make_fw_accept_all();
+        let ct = make_conntrack();
+
+        // Packet too short to parse (< 14 bytes).
+        let raw_pkt = RawPacket {
+            ingress_iface: "eth0".to_string(),
+            data: vec![0x00; 5],
+        };
+
+        let result = process_packet(&raw_pkt, &l3, &fw, &ct);
+        match result {
+            PipelineResult::Drop { reason } => {
+                assert_eq!(reason, DropReason::ParseError);
+            }
+            other => panic!("expected Drop(ParseError), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn drop_no_route() {
+        // L3 engine with only a /24 route (no default route).
+        let routing = RoutingConfig {
+            ipv4_static_routes: vec![StaticRoute {
+                prefix: "192.168.1.0/24".to_string(),
+                next_hop: "0.0.0.0".to_string(),
+                out_if: "lan0".to_string(),
+                metric: 10,
+            }],
+        };
+        let l3 = L3Engine::from_config(&routing, &make_interfaces()).unwrap();
+        let fw = make_fw_accept_all();
+        let ct = make_conntrack();
+
+        // Destination 8.8.8.8 has no matching route.
+        let data = make_ipv4_packet(
+            [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
+            [0x00, 0x11, 0x22, 0x33, 0x44, 0x55],
+            [192, 168, 1, 100],
+            [8, 8, 8, 8],
+            64,
+        );
+        let raw_pkt = RawPacket {
+            ingress_iface: "lan0".to_string(),
+            data,
+        };
+
+        let result = process_packet(&raw_pkt, &l3, &fw, &ct);
+        match result {
+            PipelineResult::Drop { reason } => {
+                assert_eq!(reason, DropReason::L3NoRoute);
+            }
+            other => panic!("expected Drop(L3NoRoute), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn drop_ttl_expired() {
+        let l3 = make_l3_engine();
+        let fw = make_fw_accept_all();
+        let ct = make_conntrack();
+
+        // TTL = 1 -> after decrement would be 0, so L3 engine drops.
+        let data = make_ipv4_packet(
+            [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
+            [0x00, 0x11, 0x22, 0x33, 0x44, 0x55],
+            [192, 168, 1, 100],
+            [8, 8, 8, 8],
+            1, // TTL expired
+        );
+        let raw_pkt = RawPacket {
+            ingress_iface: "lan0".to_string(),
+            data,
+        };
+
+        let result = process_packet(&raw_pkt, &l3, &fw, &ct);
+        match result {
+            PipelineResult::Drop { reason } => {
+                assert_eq!(reason, DropReason::L3TtlExpired);
+            }
+            other => panic!("expected Drop(L3TtlExpired), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn consumed_local_delivery() {
+        let l3 = make_l3_engine();
+        let fw = make_fw_accept_all();
+        let ct = make_conntrack();
+
+        // Destination is our local IP (10.0.0.2) -> LocalDelivery -> Consumed.
+        let data = make_ipv4_packet(
+            [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
+            [0x00, 0x11, 0x22, 0x33, 0x44, 0x55],
+            [192, 168, 1, 100],
+            [10, 0, 0, 2], // our WAN IP
+            64,
+        );
+        let raw_pkt = RawPacket {
+            ingress_iface: "lan0".to_string(),
+            data,
+        };
+
+        let result = process_packet(&raw_pkt, &l3, &fw, &ct);
+        assert!(matches!(result, PipelineResult::Consumed));
+    }
+
+    #[test]
+    fn drop_firewall_blocks() {
+        let l3 = make_l3_engine();
+        let fw = make_fw_drop_all();
+        let ct = make_conntrack();
+
+        // Packet should be routed, but firewall drops everything.
+        let data = make_ipv4_packet(
+            [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
+            [0x00, 0x11, 0x22, 0x33, 0x44, 0x55],
+            [192, 168, 1, 100],
+            [8, 8, 8, 8],
+            64,
+        );
+        let raw_pkt = RawPacket {
+            ingress_iface: "lan0".to_string(),
+            data,
+        };
+
+        let result = process_packet(&raw_pkt, &l3, &fw, &ct);
+        match result {
+            PipelineResult::Drop { reason } => {
+                assert_eq!(reason, DropReason::FirewallDrop);
+            }
+            other => panic!("expected Drop(FirewallDrop), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn drop_not_ipv4() {
+        let l3 = make_l3_engine();
+        let fw = make_fw_accept_all();
+        let ct = make_conntrack();
+
+        // ARP packet -> L3 engine returns Drop(NotIpv4).
+        let mut data = Vec::new();
+        // Ethernet header
+        data.extend_from_slice(&[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]); // dst: broadcast
+        data.extend_from_slice(&[0x00, 0x11, 0x22, 0x33, 0x44, 0x55]); // src
+        data.extend_from_slice(&[0x08, 0x06]); // EtherType: ARP
+                                               // ARP payload (28 bytes)
+        data.extend_from_slice(&[0x00, 0x01]); // HW Type: Ethernet
+        data.extend_from_slice(&[0x08, 0x00]); // Proto Type: IPv4
+        data.push(0x06); // HW Addr Len
+        data.push(0x04); // Proto Addr Len
+        data.extend_from_slice(&[0x00, 0x01]); // Operation: Request
+        data.extend_from_slice(&[0x00, 0x11, 0x22, 0x33, 0x44, 0x55]); // Sender MAC
+        data.extend_from_slice(&[192, 168, 1, 1]); // Sender IP
+        data.extend_from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00]); // Target MAC
+        data.extend_from_slice(&[192, 168, 1, 2]); // Target IP
+
+        let raw_pkt = RawPacket {
+            ingress_iface: "lan0".to_string(),
+            data,
+        };
+
+        let result = process_packet(&raw_pkt, &l3, &fw, &ct);
+        match result {
+            PipelineResult::Drop { reason } => {
+                assert_eq!(reason, DropReason::L3NotIpv4);
+            }
+            other => panic!("expected Drop(L3NotIpv4), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn drop_reason_counters_can_be_tracked() {
+        // This test demonstrates that pipeline results can be used to
+        // accumulate per-reason drop counters.
+        let l3 = make_l3_engine();
+        let fw = make_fw_accept_all();
+        let ct = make_conntrack();
+
+        let mut parse_errors = 0u64;
+        let mut ttl_drops = 0u64;
+        let mut forwards = 0u64;
+
+        // 1. Too-short packet -> ParseError
+        let short_pkt = RawPacket {
+            ingress_iface: "eth0".to_string(),
+            data: vec![0x00; 5],
+        };
+        match process_packet(&short_pkt, &l3, &fw, &ct) {
+            PipelineResult::Drop {
+                reason: DropReason::ParseError,
+            } => parse_errors += 1,
+            _ => {}
+        }
+
+        // 2. TTL=1 packet -> TtlExpired
+        let ttl_data = make_ipv4_packet([0xAA; 6], [0xBB; 6], [192, 168, 1, 100], [8, 8, 8, 8], 1);
+        let ttl_pkt = RawPacket {
+            ingress_iface: "lan0".to_string(),
+            data: ttl_data,
+        };
+        match process_packet(&ttl_pkt, &l3, &fw, &ct) {
+            PipelineResult::Drop {
+                reason: DropReason::L3TtlExpired,
+            } => ttl_drops += 1,
+            _ => {}
+        }
+
+        // 3. Routable packet -> Forward
+        let fwd_data = make_ipv4_packet([0xAA; 6], [0xBB; 6], [192, 168, 1, 100], [8, 8, 8, 8], 64);
+        let fwd_pkt = RawPacket {
+            ingress_iface: "lan0".to_string(),
+            data: fwd_data,
+        };
+        match process_packet(&fwd_pkt, &l3, &fw, &ct) {
+            PipelineResult::Forward { .. } => forwards += 1,
+            _ => {}
+        }
+
+        assert_eq!(parse_errors, 1);
+        assert_eq!(ttl_drops, 1);
+        assert_eq!(forwards, 1);
+    }
+}

--- a/crates/main/src/main.rs
+++ b/crates/main/src/main.rs
@@ -105,8 +105,10 @@ fn main() {
 
     println!("\nruster: running (press Ctrl+C to stop)");
 
-    // Enter the dataplane run loop (blocks until shutdown)
-    if let Err(e) = dataplane.run(shutdown) {
+    // Enter the dataplane run loop (blocks until shutdown).
+    // v0.1: no real NIC I/O — use a mock backend that produces no packets.
+    let mock_io = ruster_dataplane::io::MockPacketIo::new();
+    if let Err(e) = dataplane.run(shutdown, Box::new(mock_io)) {
         eprintln!("Error: dataplane run failed: {}", e);
         process::exit(1);
     }

--- a/crates/main/tests/startup.rs
+++ b/crates/main/tests/startup.rs
@@ -155,7 +155,8 @@ fn dataplane_run_exits_on_shutdown_signal() {
         shutdown_trigger.store(true, Ordering::Relaxed);
     });
 
-    let result = dp.run(shutdown);
+    let mock_io = ruster_dataplane::io::MockPacketIo::new();
+    let result = dp.run(shutdown, Box::new(mock_io));
     assert!(result.is_ok(), "run should return Ok on clean shutdown");
 
     handle.join().expect("trigger thread should join cleanly");
@@ -175,7 +176,8 @@ fn dataplane_run_immediate_shutdown() {
     let shutdown = Arc::new(AtomicBool::new(true));
 
     let start = std::time::Instant::now();
-    let result = dp.run(shutdown);
+    let mock_io = ruster_dataplane::io::MockPacketIo::new();
+    let result = dp.run(shutdown, Box::new(mock_io));
     let elapsed = start.elapsed();
 
     assert!(result.is_ok(), "run should return Ok");
@@ -218,7 +220,8 @@ fn full_startup_run_shutdown_pipeline() {
         shutdown_trigger.store(true, Ordering::Relaxed);
     });
 
-    let result = dp.run(shutdown);
+    let mock_io = ruster_dataplane::io::MockPacketIo::new();
+    let result = dp.run(shutdown, Box::new(mock_io));
     assert!(result.is_ok(), "full pipeline run should succeed");
 
     handle.join().expect("trigger thread should join");


### PR DESCRIPTION
## Summary
- `PacketIo` trait + `MockPacketIo` によるパケットI/O抽象化
- `pipeline::process_packet()` で L3→FW→forward/drop のパイプライン処理
- `Dataplane::run()` に `Box<dyn PacketIo>` を渡してRX→処理→TXのループ実装
- `PipelineResult` (Forward/Drop/Consumed) + `DropReason` による結果分類
- 13テスト追加（io: 5, pipeline: 8）

## Test plan
- [x] `cargo test --workspace` — 306テスト全パス
- [x] `cargo clippy --workspace -- -D warnings` — クリーン
- [x] `cargo fmt --all -- --check` — クリーン  
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — クリーン

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)