### PR TITLE
fix: strict NAT/FW E2E tests, no false-positive PASS (#134)

### DIFF
--- a/tests/containerlab/scripts/test-fw.sh
+++ b/tests/containerlab/scripts/test-fw.sh
@@ -6,6 +6,9 @@
 #   2. Allowed traffic: LAN -> ruster ICMP input is permitted
 #   3. Blocked traffic: WAN -> ruster new connections are dropped
 #   4. Blocked traffic: WAN -> LAN unsolicited forward is dropped
+#
+# Quality gate: tests that cannot verify expected behavior report FAIL,
+# never silently PASS. See issue #134.
 
 set -euo pipefail
 
@@ -13,9 +16,10 @@ TOPO_NAME="ruster-e2e"
 PREFIX="clab-${TOPO_NAME}"
 PASS=0
 FAIL=0
+SKIP=0
 ERRORS=""
 
-# ── Helpers ───────────────────────────────────────────
+# -- Helpers ---------------------------------------------------
 
 run_on() {
     local node="$1"; shift
@@ -24,21 +28,33 @@ run_on() {
 
 report() {
     local name="$1" result="$2"
-    if [ "$result" = "PASS" ]; then
-        PASS=$((PASS + 1))
-        echo "  [PASS] ${name}"
-    else
-        FAIL=$((FAIL + 1))
-        ERRORS="${ERRORS}  - ${name}\n"
-        echo "  [FAIL] ${name}"
-    fi
+    case "$result" in
+        PASS)
+            PASS=$((PASS + 1))
+            echo "  [PASS] ${name}"
+            ;;
+        FAIL)
+            FAIL=$((FAIL + 1))
+            ERRORS="${ERRORS}  - ${name}\n"
+            echo "  [FAIL] ${name}"
+            ;;
+        SKIP)
+            SKIP=$((SKIP + 1))
+            echo "  [SKIP] ${name}"
+            ;;
+        *)
+            echo "  [ERROR] unknown result '${result}' for ${name}"
+            FAIL=$((FAIL + 1))
+            ERRORS="${ERRORS}  - ${name} (bad result)\n"
+            ;;
+    esac
 }
 
-# ── Tests ─────────────────────────────────────────────
+# -- Tests -----------------------------------------------------
 
 echo "=== Firewall Tests ==="
 
-# Test 1: Allowed — LAN to WAN forwarding (should pass per rule allow-lan-to-wan)
+# Test 1: Allowed -- LAN to WAN forwarding (should pass per rule allow-lan-to-wan)
 echo ""
 echo "-- Test 1: Allowed (lan-host -> wan-host forward) --"
 if run_on lan-host ping -c 3 -W 5 10.0.0.100 > /dev/null 2>&1; then
@@ -51,7 +67,7 @@ else
     report "fw-allow-lan-to-wan" "FAIL"
 fi
 
-# Test 2: Allowed — LAN ICMP to ruster input (should pass per rule allow-lan-input-icmp)
+# Test 2: Allowed -- LAN ICMP to ruster input (should pass per rule allow-lan-input-icmp)
 echo ""
 echo "-- Test 2: Allowed (lan-host -> ruster ICMP input) --"
 if run_on lan-host ping -c 3 -W 3 192.168.1.1 > /dev/null 2>&1; then
@@ -64,62 +80,59 @@ else
     report "fw-allow-lan-icmp-input" "FAIL"
 fi
 
-# Test 3: Blocked — WAN new connections to ruster input (should be dropped per block-wan-input)
-#   We expect ping from wan-host to ruster's WAN interface to be DROPPED.
-#   Note: In the containerlab topology, Linux kernel handles the connectivity
-#   before ruster's dataplane is active. The kernel does NOT enforce ruster's
-#   firewall rules. This test verifies the INTENT; when ruster's dataplane is
-#   active, this traffic should be blocked.
+# Test 3: Blocked -- WAN new connections to ruster input (should be dropped)
+#   When the firewall is active, ping from wan-host to ruster's WAN interface
+#   should be DROPPED. A dropped ping means the firewall is working correctly.
 #
-#   For the infrastructure test (kernel routing only): we mark it as a
-#   "baseline" — the kernel will allow it. The real test applies when
-#   ruster's dataplane takes over.
+#   NOTE (v0.1): ruster uses MockPacketIo so the kernel handles connectivity
+#   and does NOT enforce ruster's firewall rules. This test correctly FAILs
+#   in v0.1. Once ruster's dataplane takes over, this test will PASS.
 echo ""
-echo "-- Test 3: Blocked (wan-host -> ruster new input) [baseline] --"
-echo "  Note: With kernel routing, wan->ruster ICMP is allowed."
-echo "  When ruster dataplane is active, rule 'block-wan-input' drops this."
+echo "-- Test 3: Blocked (wan-host -> ruster new input) --"
 
-# Install nmap/ncat for TCP probe if available, otherwise use ping timing
-# Try a TCP connect to a port that should be closed/filtered
-if run_on wan-host bash -c "echo | timeout 3 bash -c 'cat > /dev/tcp/10.0.0.1/22' 2>/dev/null"; then
-    echo "  TCP/22 to ruster from WAN: OPEN (kernel baseline — ruster FW would block)"
-    report "fw-block-wan-input-baseline" "PASS"
+if run_on wan-host ping -c 2 -W 3 10.0.0.1 > /dev/null 2>&1; then
+    echo "  Ping from WAN to ruster succeeded -- firewall is NOT blocking."
+    echo "  Expected: ping should be dropped by rule 'block-wan-input'."
+    report "fw-block-wan-input" "FAIL"
 else
-    echo "  TCP/22 to ruster from WAN: REFUSED/TIMEOUT (expected)"
-    report "fw-block-wan-input-baseline" "PASS"
+    echo "  Ping from WAN to ruster timed out/refused -- firewall is blocking."
+    report "fw-block-wan-input" "PASS"
 fi
 
-# Test 4: Blocked — WAN unsolicited forward to LAN
-#   With kernel ip_forward=1 and static routes, this will work at kernel level.
-#   When ruster's dataplane is active, default_forward=drop + no wan-to-lan rule
-#   means this should be blocked.
+# Test 4: Blocked -- WAN unsolicited forward to LAN (should be dropped)
+#   With the firewall active, unsolicited packets from WAN to LAN should be
+#   dropped (default_forward=drop, no wan-to-lan rule).
+#
+#   NOTE (v0.1): With kernel ip_forward=1 and static routes, this traffic is
+#   forwarded by the kernel. This test correctly FAILs in v0.1. Once ruster's
+#   dataplane handles real packets, this test will PASS.
 echo ""
-echo "-- Test 4: Blocked (wan-host -> lan-host unsolicited forward) [baseline] --"
-echo "  Note: With kernel routing, wan->lan forward is allowed."
-echo "  When ruster dataplane is active, default_forward=drop blocks this."
+echo "-- Test 4: Blocked (wan-host -> lan-host unsolicited forward) --"
 
-# Verify the route exists (wan-host has route to 192.168.1.0/24 via 10.0.0.1)
+# Verify the route exists so we know the test is meaningful
 WAN_ROUTES=$(run_on wan-host ip route show 2>/dev/null || true)
-if echo "$WAN_ROUTES" | grep -q "192.168.1.0/24"; then
-    echo "  Route to LAN exists on wan-host: OK"
-    # In kernel mode, this ping succeeds. Under ruster FW, it would fail.
-    if run_on wan-host ping -c 2 -W 3 192.168.1.100 > /dev/null 2>&1; then
-        echo "  Ping succeeded (kernel baseline — ruster FW would block)"
-    else
-        echo "  Ping failed (may indicate FW is active)"
-    fi
-    report "fw-block-wan-to-lan-baseline" "PASS"
-else
-    echo "  Diagnostic: no route to 192.168.1.0/24 on wan-host"
+if ! echo "$WAN_ROUTES" | grep -q "192.168.1.0/24"; then
+    echo "  Diagnostic: no route to 192.168.1.0/24 on wan-host."
+    echo "  Cannot test WAN->LAN forwarding without a route."
     echo "  Routes:"
     echo "$WAN_ROUTES" | sed 's/^/    /'
-    report "fw-block-wan-to-lan-baseline" "FAIL"
+    report "fw-block-wan-to-lan" "FAIL"
+else
+    echo "  Route to LAN exists on wan-host: OK"
+    if run_on wan-host ping -c 2 -W 3 192.168.1.100 > /dev/null 2>&1; then
+        echo "  Ping from WAN to LAN succeeded -- firewall is NOT blocking."
+        echo "  Expected: forward should be dropped by default_forward=drop."
+        report "fw-block-wan-to-lan" "FAIL"
+    else
+        echo "  Ping from WAN to LAN timed out/refused -- firewall is blocking."
+        report "fw-block-wan-to-lan" "PASS"
+    fi
 fi
 
-# ── Summary ───────────────────────────────────────────
+# -- Summary ---------------------------------------------------
 
 echo ""
-echo "--- Firewall Summary: ${PASS} passed, ${FAIL} failed ---"
+echo "--- Firewall Summary: ${PASS} passed, ${FAIL} failed, ${SKIP} skipped ---"
 if [ "$FAIL" -gt 0 ]; then
     echo "Failed tests:"
     echo -e "$ERRORS"

--- a/tests/containerlab/scripts/test-nat.sh
+++ b/tests/containerlab/scripts/test-nat.sh
@@ -5,6 +5,9 @@
 #   1. LAN-host can reach WAN-host (basic NAT traversal)
 #   2. Source IP is translated (wan-host sees ruster's WAN IP, not lan-host's IP)
 #   3. Conntrack state exists on ruster after NAT session
+#
+# Quality gate: tests that cannot verify expected behavior report FAIL,
+# never silently PASS. See issue #134.
 
 set -euo pipefail
 
@@ -12,9 +15,10 @@ TOPO_NAME="ruster-e2e"
 PREFIX="clab-${TOPO_NAME}"
 PASS=0
 FAIL=0
+SKIP=0
 ERRORS=""
 
-# ── Helpers ───────────────────────────────────────────
+# -- Helpers ---------------------------------------------------
 
 run_on() {
     local node="$1"; shift
@@ -23,21 +27,33 @@ run_on() {
 
 report() {
     local name="$1" result="$2"
-    if [ "$result" = "PASS" ]; then
-        PASS=$((PASS + 1))
-        echo "  [PASS] ${name}"
-    else
-        FAIL=$((FAIL + 1))
-        ERRORS="${ERRORS}  - ${name}\n"
-        echo "  [FAIL] ${name}"
-    fi
+    case "$result" in
+        PASS)
+            PASS=$((PASS + 1))
+            echo "  [PASS] ${name}"
+            ;;
+        FAIL)
+            FAIL=$((FAIL + 1))
+            ERRORS="${ERRORS}  - ${name}\n"
+            echo "  [FAIL] ${name}"
+            ;;
+        SKIP)
+            SKIP=$((SKIP + 1))
+            echo "  [SKIP] ${name}"
+            ;;
+        *)
+            echo "  [ERROR] unknown result '${result}' for ${name}"
+            FAIL=$((FAIL + 1))
+            ERRORS="${ERRORS}  - ${name} (bad result)\n"
+            ;;
+    esac
 }
 
-# ── Tests ─────────────────────────────────────────────
+# -- Tests -----------------------------------------------------
 
 echo "=== NAT Tests ==="
 
-# Test 1: Basic NAT traversal — lan-host pings wan-host
+# Test 1: Basic NAT traversal -- lan-host pings wan-host
 echo ""
 echo "-- Test 1: NAT traversal (lan-host -> wan-host via NAT) --"
 if run_on lan-host ping -c 3 -W 5 10.0.0.100 > /dev/null 2>&1; then
@@ -52,17 +68,28 @@ else
     report "nat-traversal-ping" "FAIL"
 fi
 
-# Test 2: Source NAT verification — wan-host should see ruster's WAN IP
+# Test 2: Source NAT verification -- wan-host should see ruster's WAN IP
 #   We start a tcpdump on wan-host, send ICMP from lan-host, then check
-#   that the source IP seen by wan-host is ruster's WAN address (10.0.0.1)
+#   that the source IP seen by wan-host is ruster's WAN address (10.0.0.1).
+#
+#   NOTE (v0.1): ruster uses MockPacketIo so actual SNAT is not performed
+#   at the kernel level. The kernel handles forwarding and the source IP
+#   will remain 192.168.1.100. This test correctly FAILs in v0.1 to signal
+#   that SNAT is not yet wired into the data path. Once the real dataplane
+#   is active, this test will PASS.
 echo ""
 echo "-- Test 2: Source NAT verification (wan-host sees 10.0.0.1) --"
-# Ensure tcpdump is available on wan-host
+
+# tcpdump is a mandatory prerequisite
 if ! run_on wan-host which tcpdump > /dev/null 2>&1; then
+    echo "  Installing tcpdump on wan-host..."
     run_on wan-host bash -c "apt-get update -qq && apt-get install -y -qq tcpdump" > /dev/null 2>&1 || true
 fi
 
-if run_on wan-host which tcpdump > /dev/null 2>&1; then
+if ! run_on wan-host which tcpdump > /dev/null 2>&1; then
+    echo "  ERROR: tcpdump required for SNAT verification but not available on wan-host"
+    report "snat-verification" "FAIL"
+else
     # Start tcpdump in background on wan-host, capture ICMP on eth1
     run_on wan-host bash -c "tcpdump -i eth1 -c 5 -n icmp -w /tmp/nat-capture.pcap &" 2>/dev/null || true
     sleep 1
@@ -79,32 +106,19 @@ if run_on wan-host which tcpdump > /dev/null 2>&1; then
     if echo "$CAPTURE" | grep -q "10.0.0.1"; then
         report "snat-verification" "PASS"
     else
-        # If NAT is not set up via iptables (ruster handles it in userspace),
-        # the source may still be 192.168.1.100 at the kernel level.
-        # In that case, connectivity itself is the NAT proof.
-        echo "  Note: source IP translation not observed at kernel level."
-        echo "  This may be expected if ruster performs NAT in userspace/DPDK."
-        echo "  Marking as PASS if basic connectivity succeeded."
-        if run_on lan-host ping -c 1 -W 3 10.0.0.100 > /dev/null 2>&1; then
-            report "snat-verification" "PASS"
-        else
-            report "snat-verification" "FAIL"
-        fi
+        echo "  Source IP 10.0.0.1 not observed in captured packets."
+        echo "  SNAT is not active in the data path."
+        report "snat-verification" "FAIL"
     fi
 
     # Cleanup
     run_on wan-host rm -f /tmp/nat-capture.pcap 2>/dev/null || true
-else
-    echo "  Skipping: tcpdump not available on wan-host"
-    echo "  Falling back to connectivity check"
-    if run_on lan-host ping -c 1 -W 3 10.0.0.100 > /dev/null 2>&1; then
-        report "snat-verification" "PASS"
-    else
-        report "snat-verification" "FAIL"
-    fi
 fi
 
 # Test 3: Conntrack state on ruster
+#   After NAT traversal, there should be conntrack entries tracking the
+#   translated session. If neither the conntrack tool nor /proc/net/nf_conntrack
+#   is available, the test FAILs — the infrastructure must provide observability.
 echo ""
 echo "-- Test 3: Conntrack state on ruster --"
 # Generate traffic first
@@ -119,9 +133,9 @@ if run_on ruster which conntrack > /dev/null 2>&1; then
     if echo "$CONNTRACK" | grep -q "10.0.0.100"; then
         report "conntrack-state" "PASS"
     else
-        echo "  Note: No conntrack entries found for 10.0.0.100"
-        echo "  This may be expected if ruster manages sessions internally."
-        report "conntrack-state" "PASS"
+        echo "  No conntrack entries found for 10.0.0.100."
+        echo "  NAT session tracking is not active."
+        report "conntrack-state" "FAIL"
     fi
 elif run_on ruster cat /proc/net/nf_conntrack > /dev/null 2>&1; then
     NF_CONNTRACK=$(run_on ruster cat /proc/net/nf_conntrack 2>/dev/null || true)
@@ -130,20 +144,20 @@ elif run_on ruster cat /proc/net/nf_conntrack > /dev/null 2>&1; then
     if echo "$NF_CONNTRACK" | grep -q "10.0.0.100"; then
         report "conntrack-state" "PASS"
     else
-        echo "  Note: No nf_conntrack entries for 10.0.0.100"
-        echo "  Ruster may manage NAT sessions internally."
-        report "conntrack-state" "PASS"
+        echo "  No nf_conntrack entries found for 10.0.0.100."
+        echo "  NAT session tracking is not active."
+        report "conntrack-state" "FAIL"
     fi
 else
-    echo "  Note: conntrack tool and /proc/net/nf_conntrack not available"
-    echo "  Ruster manages NAT sessions in its own dataplane."
-    report "conntrack-state" "PASS"
+    echo "  ERROR: Neither conntrack tool nor /proc/net/nf_conntrack available."
+    echo "  Install conntrack-tools to enable NAT session observability."
+    report "conntrack-state" "FAIL"
 fi
 
-# ── Summary ───────────────────────────────────────────
+# -- Summary ---------------------------------------------------
 
 echo ""
-echo "--- NAT Summary: ${PASS} passed, ${FAIL} failed ---"
+echo "--- NAT Summary: ${PASS} passed, ${FAIL} failed, ${SKIP} skipped ---"
 if [ "$FAIL" -gt 0 ]; then
     echo "Failed tests:"
     echo -e "$ERRORS"


### PR DESCRIPTION
## Summary
- Remove all fallback-PASS logic from `test-nat.sh` and `test-fw.sh`
- SNAT not observed via tcpdump = FAIL (was silent PASS)
- Conntrack entries not found = FAIL (was silent PASS)
- WAN→ruster firewall not blocking = FAIL (was baseline PASS regardless)
- WAN→LAN firewall not blocking = FAIL (was baseline PASS regardless)
- Add SKIP counter for future use

## Test plan
- [x] `bash -n test-nat.sh` — syntax valid
- [x] `bash -n test-fw.sh` — syntax valid
- [x] All fallback-PASS paths removed
- [x] NOTE (v0.1) comments explain expected behavior with MockPacketIo

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)