### PR TITLE
fix: verify ruster process liveness in containerlab E2E (#133)

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Deploy containerlab topology
         run: sudo containerlab deploy --topo tests/containerlab/topology.yml
 
+      - name: Verify ruster is running
+        run: bash tests/containerlab/scripts/check-ruster.sh
+
       - name: Run E2E tests
         run: bash tests/containerlab/scripts/run-all.sh
 
@@ -58,6 +61,13 @@ jobs:
           echo "=== Host interfaces ==="
           ip link show > "${LOG_DIR}/host-interfaces.txt" 2>&1 || true
           ip link show
+
+          echo "=== ruster process & log ==="
+          echo "--- ruster process status ---"
+          docker exec clab-ruster-e2e-ruster pgrep -a ruster > "${LOG_DIR}/ruster-pgrep.txt" 2>&1 || echo "ruster not running" | tee "${LOG_DIR}/ruster-pgrep.txt"
+          echo "--- ruster application log ---"
+          docker exec clab-ruster-e2e-ruster cat /var/log/ruster.log > "${LOG_DIR}/ruster-app.log" 2>&1 || echo "No ruster log found" | tee "${LOG_DIR}/ruster-app.log"
+          docker exec clab-ruster-e2e-ruster cat /var/log/ruster.log 2>&1 || true
 
           echo "=== Node network state ==="
           for node in ruster lan-host wan-host; do

--- a/tests/containerlab/scripts/check-ruster.sh
+++ b/tests/containerlab/scripts/check-ruster.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# check-ruster.sh — Pre-flight check: verify ruster process is running
+#
+# Validates that:
+#   1. The ruster process is alive inside the clab-ruster-e2e-ruster container
+#   2. The ruster log shows successful startup messages
+#
+# Exit codes:
+#   0 — ruster is running and healthy
+#   1 — ruster is NOT running or failed to start
+#
+# Note (v0.1): ruster uses MockPacketIo and does not perform real NIC I/O.
+# Kernel IP forwarding handles actual packet forwarding in the E2E topology.
+# This check gates on ruster *process liveness* to ensure the binary is
+# functional and doesn't crash on startup. Future versions with real
+# dataplane I/O will additionally verify that forwarding goes through ruster.
+
+set -uo pipefail
+
+TOPO_NAME="ruster-e2e"
+CONTAINER="clab-${TOPO_NAME}-ruster"
+MAX_RETRIES="${CHECK_RUSTER_RETRIES:-10}"
+RETRY_INTERVAL="${CHECK_RUSTER_INTERVAL:-2}"
+
+# ── Helpers ───────────────────────────────────────────
+
+info()  { echo "[check-ruster] $*"; }
+error() { echo "[check-ruster] ERROR: $*" >&2; }
+
+dump_diagnostics() {
+    echo ""
+    error "=== Diagnostic information ==="
+    echo ""
+
+    echo "--- Container status ---"
+    docker inspect --format '{{.State.Status}}' "${CONTAINER}" 2>&1 || true
+    echo ""
+
+    echo "--- Process list inside container ---"
+    docker exec "${CONTAINER}" ps aux 2>&1 || true
+    echo ""
+
+    echo "--- ruster log (/var/log/ruster.log) ---"
+    docker exec "${CONTAINER}" cat /var/log/ruster.log 2>&1 || echo "(log file not found or empty)"
+    echo ""
+
+    echo "--- Container stdout/stderr (docker logs) ---"
+    docker logs "${CONTAINER}" 2>&1 | tail -50 || true
+    echo ""
+}
+
+# ── Main ──────────────────────────────────────────────
+
+info "Checking ruster process in container: ${CONTAINER}"
+info "Will retry up to ${MAX_RETRIES} times (interval: ${RETRY_INTERVAL}s)"
+
+for attempt in $(seq 1 "${MAX_RETRIES}"); do
+    info "Attempt ${attempt}/${MAX_RETRIES}: checking ruster process..."
+
+    # Check if the container exists and is running
+    CONTAINER_STATE=$(docker inspect --format '{{.State.Status}}' "${CONTAINER}" 2>/dev/null || echo "not_found")
+    if [ "${CONTAINER_STATE}" != "running" ]; then
+        info "Container state: ${CONTAINER_STATE} (waiting...)"
+        sleep "${RETRY_INTERVAL}"
+        continue
+    fi
+
+    # Check if the ruster process is alive (pgrep exit code 0 = found)
+    if docker exec "${CONTAINER}" pgrep -x ruster > /dev/null 2>&1; then
+        RUSTER_PID=$(docker exec "${CONTAINER}" pgrep -x ruster 2>/dev/null)
+        info "ruster process found (PID: ${RUSTER_PID})"
+
+        # Verify startup log messages
+        if docker exec "${CONTAINER}" test -f /var/log/ruster.log; then
+            LOG_CONTENT=$(docker exec "${CONTAINER}" cat /var/log/ruster.log 2>/dev/null || echo "")
+
+            if echo "${LOG_CONTENT}" | grep -q "ruster v0.1"; then
+                info "Startup banner found in log"
+            else
+                info "WARNING: startup banner not found in log (process may still be initializing)"
+            fi
+
+            if echo "${LOG_CONTENT}" | grep -q "running"; then
+                info "Run-loop confirmation found in log"
+            else
+                info "WARNING: run-loop message not yet in log (may still be initializing)"
+            fi
+        else
+            info "WARNING: /var/log/ruster.log not found yet (process may still be starting)"
+        fi
+
+        echo ""
+        info "PASSED: ruster is running in ${CONTAINER}"
+        info "NOTE (v0.1): Kernel forwarding is active. ruster process liveness is the E2E gate."
+        exit 0
+    fi
+
+    info "ruster process not found yet (waiting...)"
+    sleep "${RETRY_INTERVAL}"
+done
+
+# All retries exhausted — ruster is not running
+echo ""
+error "FAILED: ruster process is NOT running after ${MAX_RETRIES} attempts"
+dump_diagnostics
+exit 1

--- a/tests/containerlab/scripts/run-all.sh
+++ b/tests/containerlab/scripts/run-all.sh
@@ -36,6 +36,22 @@ run_suite() {
 echo "Waiting for topology to settle (5s)..."
 sleep 5
 
+# ── Pre-flight: verify ruster is running ─────────────
+
+echo ""
+echo "================================================================"
+echo "  Pre-flight: checking ruster process"
+echo "================================================================"
+echo ""
+
+if ! bash "${SCRIPT_DIR}/check-ruster.sh"; then
+    echo ""
+    echo "FATAL: ruster process is not running. Cannot proceed with E2E tests."
+    echo "       Tests would pass using kernel routing alone, masking real failures."
+    echo "       See diagnostic output above for details."
+    exit 1
+fi
+
 # ── Run all suites ────────────────────────────────────
 
 run_suite "L2 (ARP / MAC Learning)"   "test-l2.sh"

--- a/tests/containerlab/topology.yml
+++ b/tests/containerlab/topology.yml
@@ -26,6 +26,10 @@ topology:
         - ip addr add 192.168.1.1/24 dev eth1
         - ip addr add 10.0.0.1/24 dev eth2
         - sysctl -w net.ipv4.ip_forward=1
+        # Start ruster process in background.
+        # v0.1 uses MockPacketIo so kernel forwarding remains enabled;
+        # the E2E gate is ruster process liveness, not dataplane bypass.
+        - bash -c "nohup /usr/local/bin/ruster --config /etc/ruster/router.toml > /var/log/ruster.log 2>&1 &"
 
     lan-host:
       kind: linux


### PR DESCRIPTION
## Summary
- Start ruster process in containerlab ruster node via `nohup` exec command in `topology.yml`
- Add `check-ruster.sh` pre-flight script with retry logic (10 attempts x 2s), diagnostic output on failure
- Gate `run-all.sh` on ruster liveness check — fails immediately if ruster not running
- Add "Verify ruster is running" CI step to `integration-test.yml`
- Add ruster-specific log collection to failure diagnostics

## Test plan
- [x] `bash -n check-ruster.sh` — syntax valid
- [x] `bash -n run-all.sh` — syntax valid
- [x] check-ruster.sh is executable
- [x] ruster未起動時にE2Eが確実にFAIL

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)