### PR TITLE
fix: split E2E into v0.1 gate and NAT/FW strict jobs (#141)

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -11,8 +11,11 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # ── v0.1 gate: ruster liveness + L2/L3 connectivity ─────────
+  # This job validates what v0.1 (MockPacketIo) can actually verify:
+  # process startup, L2 ARP/MAC, L3 routing via kernel.
   containerlab-e2e:
-    name: Containerlab E2E
+    name: Containerlab E2E (v0.1 gate)
     runs-on: [self-hosted, linux, kvm]
     timeout-minutes: 30
 
@@ -34,8 +37,8 @@ jobs:
       - name: Verify ruster is running
         run: bash tests/containerlab/scripts/check-ruster.sh
 
-      - name: Run E2E tests
-        run: bash tests/containerlab/scripts/run-all.sh
+      - name: Run E2E tests (L2 + L3)
+        run: E2E_SUITES=l2,l3 bash tests/containerlab/scripts/run-all.sh
 
       - name: Collect logs on failure
         if: failure()
@@ -85,6 +88,63 @@ jobs:
         with:
           name: e2e-logs
           path: /tmp/ruster-e2e-logs/
+          retention-days: 7
+
+      - name: Destroy topology
+        if: always()
+        run: sudo containerlab destroy --topo tests/containerlab/topology.yml --cleanup
+
+  # ── NAT/FW strict: real dataplane required ───────────────────
+  # These tests require ruster's dataplane to handle real packets.
+  # In v0.1 (MockPacketIo), these are expected to FAIL.
+  # This job is non-blocking (continue-on-error) so it does not
+  # break CI, but still runs to track readiness for v0.2+.
+  containerlab-e2e-strict:
+    name: Containerlab E2E (NAT/FW strict — expected-fail in v0.1)
+    runs-on: [self-hosted, linux, kvm]
+    timeout-minutes: 30
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry & build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: cargo build --release
+
+      - name: Deploy containerlab topology
+        run: sudo containerlab deploy --topo tests/containerlab/topology.yml
+
+      - name: Verify ruster is running
+        run: bash tests/containerlab/scripts/check-ruster.sh
+
+      - name: Run E2E tests (NAT + FW strict)
+        run: E2E_SUITES=nat,fw bash tests/containerlab/scripts/run-all.sh
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          LOG_DIR=/tmp/ruster-e2e-strict-logs
+          mkdir -p "$LOG_DIR"
+
+          for node in ruster lan-host wan-host; do
+            docker logs clab-ruster-e2e-${node} > "${LOG_DIR}/${node}.log" 2>&1 || true
+          done
+
+          docker exec clab-ruster-e2e-ruster cat /var/log/ruster.log > "${LOG_DIR}/ruster-app.log" 2>&1 || true
+          docker ps -a > "${LOG_DIR}/docker-ps.txt" 2>&1 || true
+
+      - name: Upload logs artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-strict-logs
+          path: /tmp/ruster-e2e-strict-logs/
           retention-days: 7
 
       - name: Destroy topology

--- a/tests/containerlab/scripts/run-all.sh
+++ b/tests/containerlab/scripts/run-all.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
-# run-all.sh — Execute all containerlab E2E test scenarios
+# run-all.sh — Execute containerlab E2E test scenarios
 #
 # Runs each test script and collects results into a summary.
 # Exits with non-zero if any test scenario failed.
+#
+# Environment variables:
+#   E2E_SUITES  — Comma-separated list of suites to run.
+#                 Available: l2, l3, nat, fw
+#                 Default: all suites (l2,l3,nat,fw)
+#
+# Examples:
+#   bash run-all.sh                       # Run all suites
+#   E2E_SUITES=l2,l3 bash run-all.sh      # v0.1 gate (L2 + L3 only)
+#   E2E_SUITES=nat,fw bash run-all.sh     # NAT/FW strict tests only
 
 set -uo pipefail
 
@@ -11,7 +21,13 @@ TOTAL_PASS=0
 TOTAL_FAIL=0
 RESULTS=""
 
+E2E_SUITES="${E2E_SUITES:-l2,l3,nat,fw}"
+
 # ── Helpers ───────────────────────────────────────────
+
+suite_enabled() {
+    echo ",$E2E_SUITES," | grep -q ",$1,"
+}
 
 run_suite() {
     local name="$1"
@@ -52,12 +68,15 @@ if ! bash "${SCRIPT_DIR}/check-ruster.sh"; then
     exit 1
 fi
 
-# ── Run all suites ────────────────────────────────────
+echo ""
+echo "Suites to run: ${E2E_SUITES}"
 
-run_suite "L2 (ARP / MAC Learning)"   "test-l2.sh"
-run_suite "L3 (Routing)"              "test-l3.sh"
-run_suite "NAT (NAPT44)"              "test-nat.sh"
-run_suite "Firewall"                  "test-fw.sh"
+# ── Run selected suites ──────────────────────────────
+
+suite_enabled "l2"  && run_suite "L2 (ARP / MAC Learning)"   "test-l2.sh"
+suite_enabled "l3"  && run_suite "L3 (Routing)"              "test-l3.sh"
+suite_enabled "nat" && run_suite "NAT (NAPT44)"              "test-nat.sh"
+suite_enabled "fw"  && run_suite "Firewall"                  "test-fw.sh"
 
 # ── Summary ───────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Add `E2E_SUITES` env var to `run-all.sh` for suite selection (default: all)
- Split `integration-test.yml` into two jobs:
  - **v0.1 gate** (`E2E_SUITES=l2,l3`): ruster liveness + L2/L3 connectivity — required, passable in v0.1
  - **NAT/FW strict** (`E2E_SUITES=nat,fw`): real dataplane tests — `continue-on-error: true`, expected-fail in v0.1
- CI red/green now correctly reflects v0.1 quality state

## Test plan
- [x] `bash -n run-all.sh` — syntax valid
- [x] `cargo test --workspace` — all tests pass
- [x] v0.1 gate job only runs L2+L3 (won't fail due to MockPacketIo)
- [x] NAT/FW strict job is non-blocking (`continue-on-error`)

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)