### PR TITLE
fix(test): validate E2E_SUITES to prevent silent 0-suite pass (#163)

### DIFF
--- a/tests/containerlab/scripts/run-all.sh
+++ b/tests/containerlab/scripts/run-all.sh
@@ -19,15 +19,53 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TOTAL_PASS=0
 TOTAL_FAIL=0
+TOTAL_SKIP=0
 RESULTS=""
 
 E2E_SUITES="${E2E_SUITES:-l2,l3,nat,fw}"
+
+# ── Known suites ──────────────────────────────────────
+KNOWN_SUITES=("l2" "l3" "nat" "fw")
 
 # ── Helpers ───────────────────────────────────────────
 
 suite_enabled() {
     echo ",$E2E_SUITES," | grep -q ",$1,"
 }
+
+# ── Validate E2E_SUITES ──────────────────────────────
+# Check that at least one known suite is requested.
+# This prevents typos like E2E_SUITES=l2,l33 from silently
+# running 0 suites and exiting 0.
+VALID_COUNT=0
+INVALID_NAMES=()
+IFS=',' read -ra REQUESTED_SUITES <<< "$E2E_SUITES"
+for s in "${REQUESTED_SUITES[@]}"; do
+    is_known=false
+    for k in "${KNOWN_SUITES[@]}"; do
+        if [ "$s" = "$k" ]; then
+            is_known=true
+            VALID_COUNT=$((VALID_COUNT + 1))
+            break
+        fi
+    done
+    if [ "$is_known" = false ] && [ -n "$s" ]; then
+        INVALID_NAMES+=("$s")
+    fi
+done
+
+if [ "${#INVALID_NAMES[@]}" -gt 0 ]; then
+    echo "WARNING: Unknown suite(s) in E2E_SUITES: ${INVALID_NAMES[*]}"
+    echo "         Known suites: ${KNOWN_SUITES[*]}"
+fi
+
+if [ "$VALID_COUNT" -eq 0 ]; then
+    echo ""
+    echo "ERROR: E2E_SUITES='${E2E_SUITES}' contains no valid suite names."
+    echo "       Known suites: ${KNOWN_SUITES[*]}"
+    echo "       At least one valid suite must be specified."
+    exit 1
+fi
 
 run_suite() {
     local name="$1"
@@ -80,7 +118,8 @@ suite_enabled "fw"  && run_suite "Firewall"                  "test-fw.sh"
 
 # ── Summary ───────────────────────────────────────────
 
-TOTAL=$((TOTAL_PASS + TOTAL_FAIL))
+TOTAL_RAN=$((TOTAL_PASS + TOTAL_FAIL))
+TOTAL_SKIP=$((VALID_COUNT - TOTAL_RAN))
 
 echo ""
 echo "================================================================"
@@ -88,10 +127,15 @@ echo "  E2E Test Summary"
 echo "================================================================"
 echo ""
 echo -e "$RESULTS"
-echo "Total: ${TOTAL} suites, ${TOTAL_PASS} passed, ${TOTAL_FAIL} failed"
+echo "Suites: ${TOTAL_RAN} ran (${TOTAL_PASS} passed, ${TOTAL_FAIL} failed), ${TOTAL_SKIP} skipped"
 echo ""
 
-if [ "$TOTAL_FAIL" -gt 0 ]; then
+if [ "$TOTAL_RAN" -eq 0 ]; then
+    echo "ERROR: No test suites were executed. This should not happen"
+    echo "       after validation. Check suite scripts exist."
+    echo "RESULT: FAIL"
+    exit 1
+elif [ "$TOTAL_FAIL" -gt 0 ]; then
     echo "RESULT: FAIL"
     exit 1
 else

--- a/tests/containerlab/scripts/test-e2e-suites-guard.sh
+++ b/tests/containerlab/scripts/test-e2e-suites-guard.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# test-e2e-suites-guard.sh — Unit test for E2E_SUITES validation in run-all.sh
+#
+# Tests the upfront validation logic that rejects invalid suite names.
+# This script extracts and tests the validation portion of run-all.sh
+# without requiring containerlab infrastructure.
+#
+# Usage:
+#   bash tests/containerlab/scripts/test-e2e-suites-guard.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+
+# ── Test helper ──────────────────────────────────────
+
+assert_exit_code() {
+    local desc="$1"
+    local expected="$2"
+    local actual="$3"
+    if [ "$expected" -eq "$actual" ]; then
+        echo "  [PASS] ${desc}"
+        PASS=$((PASS + 1))
+    else
+        echo "  [FAIL] ${desc} (expected exit ${expected}, got ${actual})"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_output_contains() {
+    local desc="$1"
+    local expected_text="$2"
+    local actual_output="$3"
+    if echo "$actual_output" | grep -qF "$expected_text"; then
+        echo "  [PASS] ${desc}"
+        PASS=$((PASS + 1))
+    else
+        echo "  [FAIL] ${desc} (expected output to contain: '${expected_text}')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ── Inline validation function (mirrors run-all.sh logic) ──
+
+validate_e2e_suites() {
+    local E2E_SUITES="$1"
+    local KNOWN_SUITES=("l2" "l3" "nat" "fw")
+    local VALID_COUNT=0
+    local INVALID_NAMES=()
+    local output=""
+
+    IFS=',' read -ra REQUESTED_SUITES <<< "$E2E_SUITES"
+    for s in "${REQUESTED_SUITES[@]}"; do
+        local is_known=false
+        for k in "${KNOWN_SUITES[@]}"; do
+            if [ "$s" = "$k" ]; then
+                is_known=true
+                VALID_COUNT=$((VALID_COUNT + 1))
+                break
+            fi
+        done
+        if [ "$is_known" = false ] && [ -n "$s" ]; then
+            INVALID_NAMES+=("$s")
+        fi
+    done
+
+    if [ "${#INVALID_NAMES[@]}" -gt 0 ]; then
+        output="WARNING: Unknown suite(s) in E2E_SUITES: ${INVALID_NAMES[*]}"
+    fi
+
+    if [ "$VALID_COUNT" -eq 0 ]; then
+        echo "${output}"
+        echo "ERROR: E2E_SUITES='${E2E_SUITES}' contains no valid suite names."
+        return 1
+    fi
+
+    echo "${output}"
+    return 0
+}
+
+# ── Tests ────────────────────────────────────────────
+
+echo ""
+echo "================================================================"
+echo "  E2E_SUITES Validation Guard — Unit Tests"
+echo "================================================================"
+echo ""
+
+# Test 1: All defaults (should pass)
+echo "--- Test group: valid suites ---"
+output=$(validate_e2e_suites "l2,l3,nat,fw" 2>&1); rc=$?
+assert_exit_code "All four suites (l2,l3,nat,fw) -> exit 0" 0 "$rc"
+
+# Test 2: Single valid suite
+output=$(validate_e2e_suites "l2" 2>&1); rc=$?
+assert_exit_code "Single suite (l2) -> exit 0" 0 "$rc"
+
+# Test 3: Two valid suites
+output=$(validate_e2e_suites "nat,fw" 2>&1); rc=$?
+assert_exit_code "Two suites (nat,fw) -> exit 0" 0 "$rc"
+
+# Test 4: All invalid suites (should fail)
+echo ""
+echo "--- Test group: invalid suites ---"
+output=$(validate_e2e_suites "l33,natt" 2>&1); rc=$?
+assert_exit_code "All invalid (l33,natt) -> exit 1" 1 "$rc"
+assert_output_contains "Error message mentions no valid suite names" "contains no valid suite names" "$output"
+
+# Test 5: Single invalid suite
+output=$(validate_e2e_suites "typo" 2>&1); rc=$?
+assert_exit_code "Single invalid (typo) -> exit 1" 1 "$rc"
+
+# Test 6: Empty string
+output=$(validate_e2e_suites "" 2>&1); rc=$?
+assert_exit_code "Empty string -> exit 1" 1 "$rc"
+
+# Test 7: Mixed valid + invalid (should pass with warning)
+echo ""
+echo "--- Test group: mixed valid/invalid ---"
+output=$(validate_e2e_suites "l2,l33" 2>&1); rc=$?
+assert_exit_code "Mixed (l2,l33) -> exit 0 (l2 is valid)" 0 "$rc"
+assert_output_contains "Warning about unknown suite" "WARNING: Unknown suite(s)" "$output"
+
+# Test 8: Valid with trailing comma
+output=$(validate_e2e_suites "l2,l3," 2>&1); rc=$?
+assert_exit_code "Trailing comma (l2,l3,) -> exit 0" 0 "$rc"
+
+# Test 9: Case sensitivity (uppercase should fail)
+output=$(validate_e2e_suites "L2,L3" 2>&1); rc=$?
+assert_exit_code "Uppercase (L2,L3) -> exit 1 (case sensitive)" 1 "$rc"
+
+# ── Summary ──────────────────────────────────────────
+
+TOTAL=$((PASS + FAIL))
+echo ""
+echo "================================================================"
+echo "  Results: ${TOTAL} tests, ${PASS} passed, ${FAIL} failed"
+echo "================================================================"
+echo ""
+
+if [ "$FAIL" -gt 0 ]; then
+    echo "RESULT: FAIL"
+    exit 1
+else
+    echo "RESULT: PASS"
+    exit 0
+fi


### PR DESCRIPTION
## Summary
- Add upfront validation: check E2E_SUITES against known suites (l2, l3, nat, fw)
- Warn on unknown suite names, error+exit if zero valid suites
- Add post-run summary guard: if 0 suites actually ran, exit 1
- Add test script with 11 test cases covering valid, invalid, mixed, and edge cases

Closes #163

## Test plan
- [x] 11 unit tests in `test-e2e-suites-guard.sh` pass
- [x] `scripts/rfc-deviation-lint.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)