### PR TITLE
fix(test): use unique containerlab topology name per run (#164)

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -18,6 +18,8 @@ jobs:
     name: Containerlab E2E (v0.1 gate)
     runs-on: [self-hosted, linux, kvm]
     timeout-minutes: 30
+    env:
+      CLAB_TOPO_NAME: ruster-e2e-${{ github.run_id }}
 
     steps:
       - uses: actions/checkout@v4
@@ -32,7 +34,7 @@ jobs:
         run: cargo build --release
 
       - name: Deploy containerlab topology
-        run: sudo containerlab deploy --topo tests/containerlab/topology.yml
+        run: sudo containerlab deploy --topo tests/containerlab/topology.yml --name "$CLAB_TOPO_NAME"
 
       - name: Verify ruster is running
         run: bash tests/containerlab/scripts/check-ruster.sh
@@ -43,19 +45,19 @@ jobs:
       - name: Collect logs on failure
         if: failure()
         run: |
-          LOG_DIR=/tmp/ruster-e2e-logs
+          LOG_DIR="/tmp/${CLAB_TOPO_NAME}-logs"
           mkdir -p "$LOG_DIR"
 
           echo "=== Container logs ==="
           for node in ruster lan-host wan-host; do
-            echo "--- clab-ruster-e2e-${node} ---"
-            docker logs clab-ruster-e2e-${node} > "${LOG_DIR}/${node}.log" 2>&1 || true
-            docker logs clab-ruster-e2e-${node} 2>&1 || true
+            echo "--- clab-${CLAB_TOPO_NAME}-${node} ---"
+            docker logs "clab-${CLAB_TOPO_NAME}-${node}" > "${LOG_DIR}/${node}.log" 2>&1 || true
+            docker logs "clab-${CLAB_TOPO_NAME}-${node}" 2>&1 || true
           done
 
           echo "=== Topology inspect ==="
-          sudo containerlab inspect --topo tests/containerlab/topology.yml > "${LOG_DIR}/topology-inspect.txt" 2>&1 || true
-          sudo containerlab inspect --topo tests/containerlab/topology.yml || true
+          sudo containerlab inspect --name "$CLAB_TOPO_NAME" > "${LOG_DIR}/topology-inspect.txt" 2>&1 || true
+          sudo containerlab inspect --name "$CLAB_TOPO_NAME" || true
 
           echo "=== Docker ps ==="
           docker ps -a > "${LOG_DIR}/docker-ps.txt" 2>&1 || true
@@ -67,32 +69,32 @@ jobs:
 
           echo "=== ruster process & log ==="
           echo "--- ruster process status ---"
-          docker exec clab-ruster-e2e-ruster pgrep -a ruster > "${LOG_DIR}/ruster-pgrep.txt" 2>&1 || echo "ruster not running" | tee "${LOG_DIR}/ruster-pgrep.txt"
+          docker exec "clab-${CLAB_TOPO_NAME}-ruster" pgrep -a ruster > "${LOG_DIR}/ruster-pgrep.txt" 2>&1 || echo "ruster not running" | tee "${LOG_DIR}/ruster-pgrep.txt"
           echo "--- ruster application log ---"
-          docker exec clab-ruster-e2e-ruster cat /var/log/ruster.log > "${LOG_DIR}/ruster-app.log" 2>&1 || echo "No ruster log found" | tee "${LOG_DIR}/ruster-app.log"
-          docker exec clab-ruster-e2e-ruster cat /var/log/ruster.log 2>&1 || true
+          docker exec "clab-${CLAB_TOPO_NAME}-ruster" cat /var/log/ruster.log > "${LOG_DIR}/ruster-app.log" 2>&1 || echo "No ruster log found" | tee "${LOG_DIR}/ruster-app.log"
+          docker exec "clab-${CLAB_TOPO_NAME}-ruster" cat /var/log/ruster.log 2>&1 || true
 
           echo "=== Node network state ==="
           for node in ruster lan-host wan-host; do
             echo "--- ${node} interfaces ---"
-            docker exec clab-ruster-e2e-${node} ip addr show >> "${LOG_DIR}/${node}-debug.log" 2>&1 || true
+            docker exec "clab-${CLAB_TOPO_NAME}-${node}" ip addr show >> "${LOG_DIR}/${node}-debug.log" 2>&1 || true
             echo "--- ${node} routes ---"
-            docker exec clab-ruster-e2e-${node} ip route show >> "${LOG_DIR}/${node}-debug.log" 2>&1 || true
+            docker exec "clab-${CLAB_TOPO_NAME}-${node}" ip route show >> "${LOG_DIR}/${node}-debug.log" 2>&1 || true
             echo "--- ${node} arp ---"
-            docker exec clab-ruster-e2e-${node} ip neigh show >> "${LOG_DIR}/${node}-debug.log" 2>&1 || true
+            docker exec "clab-${CLAB_TOPO_NAME}-${node}" ip neigh show >> "${LOG_DIR}/${node}-debug.log" 2>&1 || true
           done
 
       - name: Upload logs artifact
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-logs
-          path: /tmp/ruster-e2e-logs/
+          name: e2e-logs-${{ github.run_id }}
+          path: /tmp/${{ env.CLAB_TOPO_NAME }}-logs/
           retention-days: 7
 
       - name: Destroy topology
         if: always()
-        run: sudo containerlab destroy --topo tests/containerlab/topology.yml --cleanup
+        run: sudo containerlab destroy --name "$CLAB_TOPO_NAME" --cleanup
 
   # ── NAT/FW strict: real dataplane required ───────────────────
   # These tests require ruster's dataplane to handle real packets.
@@ -104,6 +106,8 @@ jobs:
     runs-on: [self-hosted, linux, kvm]
     timeout-minutes: 30
     continue-on-error: true
+    env:
+      CLAB_TOPO_NAME: ruster-e2e-strict-${{ github.run_id }}
 
     steps:
       - uses: actions/checkout@v4
@@ -118,7 +122,7 @@ jobs:
         run: cargo build --release
 
       - name: Deploy containerlab topology
-        run: sudo containerlab deploy --topo tests/containerlab/topology.yml
+        run: sudo containerlab deploy --topo tests/containerlab/topology.yml --name "$CLAB_TOPO_NAME"
 
       - name: Verify ruster is running
         run: bash tests/containerlab/scripts/check-ruster.sh
@@ -129,24 +133,24 @@ jobs:
       - name: Collect logs on failure
         if: failure()
         run: |
-          LOG_DIR=/tmp/ruster-e2e-strict-logs
+          LOG_DIR="/tmp/${CLAB_TOPO_NAME}-logs"
           mkdir -p "$LOG_DIR"
 
           for node in ruster lan-host wan-host; do
-            docker logs clab-ruster-e2e-${node} > "${LOG_DIR}/${node}.log" 2>&1 || true
+            docker logs "clab-${CLAB_TOPO_NAME}-${node}" > "${LOG_DIR}/${node}.log" 2>&1 || true
           done
 
-          docker exec clab-ruster-e2e-ruster cat /var/log/ruster.log > "${LOG_DIR}/ruster-app.log" 2>&1 || true
+          docker exec "clab-${CLAB_TOPO_NAME}-ruster" cat /var/log/ruster.log > "${LOG_DIR}/ruster-app.log" 2>&1 || true
           docker ps -a > "${LOG_DIR}/docker-ps.txt" 2>&1 || true
 
       - name: Upload logs artifact
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-strict-logs
-          path: /tmp/ruster-e2e-strict-logs/
+          name: e2e-strict-logs-${{ github.run_id }}
+          path: /tmp/${{ env.CLAB_TOPO_NAME }}-logs/
           retention-days: 7
 
       - name: Destroy topology
         if: always()
-        run: sudo containerlab destroy --topo tests/containerlab/topology.yml --cleanup
+        run: sudo containerlab destroy --name "$CLAB_TOPO_NAME" --cleanup

--- a/Makefile
+++ b/Makefile
@@ -83,15 +83,20 @@ team-stop:
 	fi
 
 # ── Containerlab E2E ──────────────────────────────────
+# Use CLAB_TOPO_NAME to override the topology name (default: ruster-e2e).
+# Example: make clab-deploy CLAB_TOPO_NAME=ruster-e2e-dev
+
+CLAB_TOPO_NAME ?= ruster-e2e
+export CLAB_TOPO_NAME
 
 clab-deploy:
-	cd tests/containerlab && sudo containerlab deploy --topo topology.yml
+	cd tests/containerlab && sudo containerlab deploy --topo topology.yml --name $(CLAB_TOPO_NAME)
 
 clab-test: clab-deploy
 	cd tests/containerlab && bash scripts/run-all.sh
 
 clab-destroy:
-	cd tests/containerlab && sudo containerlab destroy --topo topology.yml
+	cd tests/containerlab && sudo containerlab destroy --name $(CLAB_TOPO_NAME) --cleanup
 
 clab-e2e: clab-test clab-destroy
 

--- a/tests/containerlab/scripts/check-ruster.sh
+++ b/tests/containerlab/scripts/check-ruster.sh
@@ -17,7 +17,7 @@
 
 set -uo pipefail
 
-TOPO_NAME="ruster-e2e"
+TOPO_NAME="${CLAB_TOPO_NAME:-ruster-e2e}"
 CONTAINER="clab-${TOPO_NAME}-ruster"
 MAX_RETRIES="${CHECK_RUSTER_RETRIES:-10}"
 RETRY_INTERVAL="${CHECK_RUSTER_INTERVAL:-2}"

--- a/tests/containerlab/scripts/run-all.sh
+++ b/tests/containerlab/scripts/run-all.sh
@@ -5,9 +5,11 @@
 # Exits with non-zero if any test scenario failed.
 #
 # Environment variables:
-#   E2E_SUITES  — Comma-separated list of suites to run.
-#                 Available: l2, l3, nat, fw
-#                 Default: all suites (l2,l3,nat,fw)
+#   E2E_SUITES      — Comma-separated list of suites to run.
+#                     Available: l2, l3, nat, fw
+#                     Default: all suites (l2,l3,nat,fw)
+#   CLAB_TOPO_NAME  — Containerlab topology name override.
+#                     Default: ruster-e2e (from topology.yml)
 #
 # Examples:
 #   bash run-all.sh                       # Run all suites

--- a/tests/containerlab/scripts/test-fw.sh
+++ b/tests/containerlab/scripts/test-fw.sh
@@ -12,7 +12,7 @@
 
 set -euo pipefail
 
-TOPO_NAME="ruster-e2e"
+TOPO_NAME="${CLAB_TOPO_NAME:-ruster-e2e}"
 PREFIX="clab-${TOPO_NAME}"
 PASS=0
 FAIL=0

--- a/tests/containerlab/scripts/test-l2.sh
+++ b/tests/containerlab/scripts/test-l2.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-TOPO_NAME="ruster-e2e"
+TOPO_NAME="${CLAB_TOPO_NAME:-ruster-e2e}"
 PREFIX="clab-${TOPO_NAME}"
 PASS=0
 FAIL=0

--- a/tests/containerlab/scripts/test-l3.sh
+++ b/tests/containerlab/scripts/test-l3.sh
@@ -9,7 +9,7 @@
 
 set -euo pipefail
 
-TOPO_NAME="ruster-e2e"
+TOPO_NAME="${CLAB_TOPO_NAME:-ruster-e2e}"
 PREFIX="clab-${TOPO_NAME}"
 PASS=0
 FAIL=0

--- a/tests/containerlab/scripts/test-nat.sh
+++ b/tests/containerlab/scripts/test-nat.sh
@@ -11,7 +11,7 @@
 
 set -euo pipefail
 
-TOPO_NAME="ruster-e2e"
+TOPO_NAME="${CLAB_TOPO_NAME:-ruster-e2e}"
 PREFIX="clab-${TOPO_NAME}"
 PASS=0
 FAIL=0

--- a/tests/soak/soak-test.sh
+++ b/tests/soak/soak-test.sh
@@ -18,6 +18,7 @@
 #   SOAK_OUTPUT_DIR      — Output directory for reports (default: auto-generated)
 #   RUSTER_BIN           — Path to ruster binary (default: auto-detected from cargo)
 #   RUSTER_CONFIG        — Path to router.toml config (default: tests/containerlab/configs/ruster.toml)
+#   CLAB_TOPO_NAME       — Containerlab topology name (default: ruster-e2e)
 #
 # Usage:
 #   bash soak-test.sh                              # 30-min standalone
@@ -34,6 +35,8 @@ SOAK_DURATION_MIN="${SOAK_DURATION_MIN:-30}"
 SOAK_DURATION_SEC=$((SOAK_DURATION_MIN * 60))
 SOAK_MODE="${SOAK_MODE:-standalone}"
 SOAK_CHECK_INTERVAL="${SOAK_CHECK_INTERVAL:-60}"
+CLAB_TOPO_NAME="${CLAB_TOPO_NAME:-ruster-e2e}"
+export CLAB_TOPO_NAME
 
 # Output directory
 if [ -z "${SOAK_OUTPUT_DIR:-}" ]; then
@@ -89,9 +92,8 @@ cleanup() {
 
     # Destroy containerlab topology if in containerlab mode
     if [ "$SOAK_MODE" = "containerlab" ]; then
-        log "Destroying containerlab topology..."
-        cd "$PROJECT_ROOT/tests/containerlab" && \
-            sudo containerlab destroy --topo topology.yml 2>/dev/null || true
+        log "Destroying containerlab topology (name: ${CLAB_TOPO_NAME})..."
+        sudo containerlab destroy --name "$CLAB_TOPO_NAME" --cleanup 2>/dev/null || true
     fi
 
     log "Cleanup complete (exit code: $exit_code)"
@@ -207,10 +209,10 @@ deploy_containerlab() {
         return
     fi
 
-    log "Deploying containerlab topology..."
+    log "Deploying containerlab topology (name: ${CLAB_TOPO_NAME})..."
 
     cd "$PROJECT_ROOT/tests/containerlab"
-    if ! sudo containerlab deploy --topo topology.yml; then
+    if ! sudo containerlab deploy --topo topology.yml --name "$CLAB_TOPO_NAME"; then
         log_error "Failed to deploy containerlab topology"
         exit 1
     fi

--- a/tests/soak/traffic-gen.sh
+++ b/tests/soak/traffic-gen.sh
@@ -13,8 +13,9 @@
 #   containerlab  — Real traffic via containerlab nodes
 #
 # Environment variables (containerlab mode):
-#   CLAB_LAN_HOST   — Container name for lan-host (default: clab-ruster-e2e-lan-host)
-#   CLAB_WAN_HOST   — Container name for wan-host (default: clab-ruster-e2e-wan-host)
+#   CLAB_TOPO_NAME  — Containerlab topology name (default: ruster-e2e)
+#   CLAB_LAN_HOST   — Container name for lan-host (default: clab-${CLAB_TOPO_NAME}-lan-host)
+#   CLAB_WAN_HOST   — Container name for wan-host (default: clab-${CLAB_TOPO_NAME}-wan-host)
 #   TRAFFIC_STREAMS — Number of parallel ping streams (default: 4)
 
 set -uo pipefail
@@ -22,8 +23,9 @@ set -uo pipefail
 MODE="${1:-standalone}"
 DURATION_SEC="${2:-1800}"
 
-CLAB_LAN_HOST="${CLAB_LAN_HOST:-clab-ruster-e2e-lan-host}"
-CLAB_WAN_HOST="${CLAB_WAN_HOST:-clab-ruster-e2e-wan-host}"
+CLAB_TOPO_NAME="${CLAB_TOPO_NAME:-ruster-e2e}"
+CLAB_LAN_HOST="${CLAB_LAN_HOST:-clab-${CLAB_TOPO_NAME}-lan-host}"
+CLAB_WAN_HOST="${CLAB_WAN_HOST:-clab-${CLAB_TOPO_NAME}-wan-host}"
 TRAFFIC_STREAMS="${TRAFFIC_STREAMS:-4}"
 
 log() {


### PR DESCRIPTION
## Summary
- Introduce `CLAB_TOPO_NAME` env var for unique topology names per run
- CI uses `ruster-e2e-$GITHUB_RUN_ID` to avoid parallel job collision
- All test scripts (check-ruster, test-l2/l3/nat/fw) read `CLAB_TOPO_NAME` with fallback to `ruster-e2e`
- Makefile `clab-deploy`/`clab-destroy` pass `--name` flag
- Soak test scripts propagate the name
- Full backward compatibility when env var is not set

Closes #164

## Test plan
- [x] `scripts/rfc-deviation-lint.sh` passes
- [x] All scripts reference `CLAB_TOPO_NAME` consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)