### PR TITLE
refactor(ci): split E2E into baseline and strict workflows (#153)

### DIFF
--- a/.github/workflows/e2e-baseline.yml
+++ b/.github/workflows/e2e-baseline.yml
@@ -1,4 +1,11 @@
-name: Integration Tests (self-hosted)
+# E2E Baseline — Required CI gate for v0.1
+#
+# Validates L2 (ARP, MAC forwarding) and L3 (IP routing) connectivity
+# using containerlab topology. This job MUST pass for PRs to merge.
+#
+# See docs/ci-gates.md for gate definitions and promotion process.
+
+name: E2E Baseline (L2/L3 — required)
 
 on:
   push:
@@ -11,15 +18,12 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # ── v0.1 gate: ruster liveness + L2/L3 connectivity ─────────
-  # This job validates what v0.1 (MockPacketIo) can actually verify:
-  # process startup, L2 ARP/MAC, L3 routing via kernel.
-  containerlab-e2e:
-    name: Containerlab E2E (v0.1 gate)
+  containerlab-e2e-baseline:
+    name: E2E Baseline (L2 + L3)
     runs-on: [self-hosted, linux, kvm]
     timeout-minutes: 30
     env:
-      CLAB_TOPO_NAME: ruster-e2e-${{ github.run_id }}
+      CLAB_TOPO_NAME: ruster-e2e-baseline-${{ github.run_id }}
 
     steps:
       - uses: actions/checkout@v4
@@ -88,66 +92,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-logs-${{ github.run_id }}
-          path: /tmp/${{ env.CLAB_TOPO_NAME }}-logs/
-          retention-days: 7
-
-      - name: Destroy topology
-        if: always()
-        run: sudo containerlab destroy --name "$CLAB_TOPO_NAME" --cleanup
-
-  # ── NAT/FW strict: real dataplane required ───────────────────
-  # These tests require ruster's dataplane to handle real packets.
-  # In v0.1 (MockPacketIo), these are expected to FAIL.
-  # This job is non-blocking (continue-on-error) so it does not
-  # break CI, but still runs to track readiness for v0.2+.
-  containerlab-e2e-strict:
-    name: Containerlab E2E (NAT/FW strict — expected-fail in v0.1)
-    runs-on: [self-hosted, linux, kvm]
-    timeout-minutes: 30
-    continue-on-error: true
-    env:
-      CLAB_TOPO_NAME: ruster-e2e-strict-${{ github.run_id }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo registry & build
-        uses: Swatinem/rust-cache@v2
-
-      - name: Build release binary
-        run: cargo build --release
-
-      - name: Deploy containerlab topology
-        run: sudo containerlab deploy --topo tests/containerlab/topology.yml --name "$CLAB_TOPO_NAME"
-
-      - name: Verify ruster is running
-        run: bash tests/containerlab/scripts/check-ruster.sh
-
-      - name: Run E2E tests (NAT + FW strict)
-        run: E2E_SUITES=nat,fw bash tests/containerlab/scripts/run-all.sh
-
-      - name: Collect logs on failure
-        if: failure()
-        run: |
-          LOG_DIR="/tmp/${CLAB_TOPO_NAME}-logs"
-          mkdir -p "$LOG_DIR"
-
-          for node in ruster lan-host wan-host; do
-            docker logs "clab-${CLAB_TOPO_NAME}-${node}" > "${LOG_DIR}/${node}.log" 2>&1 || true
-          done
-
-          docker exec "clab-${CLAB_TOPO_NAME}-ruster" cat /var/log/ruster.log > "${LOG_DIR}/ruster-app.log" 2>&1 || true
-          docker ps -a > "${LOG_DIR}/docker-ps.txt" 2>&1 || true
-
-      - name: Upload logs artifact
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: e2e-strict-logs-${{ github.run_id }}
+          name: e2e-baseline-logs-${{ github.run_id }}
           path: /tmp/${{ env.CLAB_TOPO_NAME }}-logs/
           retention-days: 7
 

--- a/.github/workflows/e2e-strict.yml
+++ b/.github/workflows/e2e-strict.yml
@@ -1,0 +1,75 @@
+# E2E Strict — Informational CI for NAT/FW validation
+#
+# Runs NAT and firewall E2E tests against the containerlab topology.
+# These tests require a real dataplane (not MockPacketIo), so they are
+# EXPECTED TO FAIL in v0.1. This workflow is non-blocking and exists
+# to track readiness for v0.2+.
+#
+# See docs/ci-gates.md for gate definitions and promotion process.
+
+name: E2E Strict (NAT/FW — informational)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  containerlab-e2e-strict:
+    name: E2E Strict (NAT + FW — expected-fail in v0.1)
+    runs-on: [self-hosted, linux, kvm]
+    timeout-minutes: 30
+    continue-on-error: true
+    env:
+      CLAB_TOPO_NAME: ruster-e2e-strict-${{ github.run_id }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry & build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: cargo build --release
+
+      - name: Deploy containerlab topology
+        run: sudo containerlab deploy --topo tests/containerlab/topology.yml --name "$CLAB_TOPO_NAME"
+
+      - name: Verify ruster is running
+        run: bash tests/containerlab/scripts/check-ruster.sh
+
+      - name: Run E2E tests (NAT + FW strict)
+        run: E2E_SUITES=nat,fw bash tests/containerlab/scripts/run-all.sh
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          LOG_DIR="/tmp/${CLAB_TOPO_NAME}-logs"
+          mkdir -p "$LOG_DIR"
+
+          for node in ruster lan-host wan-host; do
+            docker logs "clab-${CLAB_TOPO_NAME}-${node}" > "${LOG_DIR}/${node}.log" 2>&1 || true
+          done
+
+          docker exec "clab-${CLAB_TOPO_NAME}-ruster" cat /var/log/ruster.log > "${LOG_DIR}/ruster-app.log" 2>&1 || true
+          docker ps -a > "${LOG_DIR}/docker-ps.txt" 2>&1 || true
+
+      - name: Upload logs artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-strict-logs-${{ github.run_id }}
+          path: /tmp/${{ env.CLAB_TOPO_NAME }}-logs/
+          retention-days: 7
+
+      - name: Destroy topology
+        if: always()
+        run: sudo containerlab destroy --name "$CLAB_TOPO_NAME" --cleanup

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -1,0 +1,115 @@
+# CI Gate Definitions
+
+This document describes the CI gates for the ruster project, their purpose,
+and the process for promoting informational gates to required status.
+
+---
+
+## Overview
+
+ruster uses two E2E workflow files to separate **required** gates (must pass
+to merge) from **informational** gates (expected to fail during early
+development). Both run on every push to `main` and on pull requests targeting
+`main`.
+
+| Workflow file | Name | Status | Suites |
+|---------------|------|--------|--------|
+| `e2e-baseline.yml` | E2E Baseline (L2/L3 -- required) | **Required** | `l2`, `l3` |
+| `e2e-strict.yml` | E2E Strict (NAT/FW -- informational) | Informational | `nat`, `fw` |
+
+In addition to E2E, the following workflows also run:
+
+| Workflow file | Name | Status |
+|---------------|------|--------|
+| `ci.yml` | CI (build, test, lint, fmt) | **Required** |
+| `rfc-check.yml` | RFC-DEVIATION lint | **Required** |
+| `runner-health.yml` | Self-hosted runner health check | Informational |
+
+---
+
+## Gate Details
+
+### E2E Baseline (`e2e-baseline.yml`) -- REQUIRED
+
+**What it checks:**
+
+- L2 connectivity: ARP resolution, MAC forwarding between LAN and WAN hosts
+  through the ruster node.
+- L3 connectivity: IP routing, ICMP reachability across subnets via kernel
+  forwarding configured by ruster.
+
+**Why it is required:**
+
+These tests validate the core v0.1 functionality -- process startup and basic
+L2/L3 packet forwarding. Failures here indicate a regression in fundamental
+router behavior.
+
+**Topology:** containerlab with `ruster`, `lan-host`, `wan-host` nodes.
+
+**Environment variable:** `CLAB_TOPO_NAME=ruster-e2e-baseline-${{ github.run_id }}`
+ensures unique topology names for concurrent runs.
+
+### E2E Strict (`e2e-strict.yml`) -- INFORMATIONAL
+
+**What it checks:**
+
+- NAT: Source NAT (SNAT/masquerade) for LAN-to-WAN traffic, correct
+  translation and de-translation of addresses/ports.
+- FW: Stateful firewall rules, connection tracking, default-deny policies.
+
+**Why it is informational (expected-fail in v0.1):**
+
+v0.1 uses `MockPacketIo` for the dataplane, which does not perform real
+packet manipulation. NAT and firewall require a real dataplane to rewrite
+headers and track connections. These tests are expected to fail until the
+dataplane is implemented with real packet I/O (targeted for v0.2+).
+
+The workflow uses `continue-on-error: true` at the job level so failures
+do not block PR merges or mark the overall CI status as failed.
+
+**Environment variable:** `CLAB_TOPO_NAME=ruster-e2e-strict-${{ github.run_id }}`
+ensures unique topology names for concurrent runs.
+
+**Current expected-fail status:**
+
+- `nat` suite: Expected to fail (MockPacketIo cannot rewrite packet headers)
+- `fw` suite: Expected to fail (MockPacketIo cannot enforce firewall rules)
+
+---
+
+## Promoting Strict Tests to Required
+
+When the real dataplane is implemented and NAT/FW tests pass reliably, follow
+these steps to promote the strict gate to required:
+
+1. **Verify stability.** Confirm that `e2e-strict.yml` passes consistently
+   on `main` for at least 5 consecutive runs.
+
+2. **Remove `continue-on-error`.** In `e2e-strict.yml`, delete the
+   `continue-on-error: true` line from the job definition.
+
+3. **Add to branch protection.** In the GitHub repository settings under
+   *Branches > Branch protection rules > main*, add the strict job name
+   (`E2E Strict (NAT + FW -- expected-fail in v0.1)`) to the list of
+   required status checks.
+
+4. **Update this document.** Change the strict gate status from
+   "Informational" to "Required" in the table above and remove the
+   expected-fail notes.
+
+5. **Rename the workflow.** Update the `name` fields to remove
+   "expected-fail" and "informational" labels. Suggested:
+   - Workflow name: `E2E Strict (NAT/FW -- required)`
+   - Job name: `E2E Strict (NAT + FW)`
+
+---
+
+## Topology Naming
+
+Both workflows use the `CLAB_TOPO_NAME` environment variable with a
+`github.run_id` suffix to ensure unique containerlab topology names. This
+prevents collisions when multiple CI runs execute concurrently on the same
+self-hosted runner.
+
+- Baseline: `ruster-e2e-baseline-<run_id>`
+- Strict: `ruster-e2e-strict-<run_id>`


### PR DESCRIPTION
## Summary
- Split `integration-test.yml` into two separate workflows:
  - `e2e-baseline.yml` — required gate (L2+L3), must pass for merging
  - `e2e-strict.yml` — informational (NAT+FW), `continue-on-error: true`
- Remove old combined `integration-test.yml`
- Add `docs/ci-gates.md` documenting all CI gates, expected-fail status, and promotion process
- Both workflows use `CLAB_TOPO_NAME` for unique topology names

Closes #153

## Test plan
- [x] `scripts/rfc-deviation-lint.sh` passes
- [x] Workflow YAML syntax is valid
- [x] `docs/ci-gates.md` covers all gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)