### PR TITLE
feat(dataplane): add AF_PACKET real packet I/O and L3 forwarding

### DIFF
--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -107,6 +107,8 @@ pub struct InterfaceConfig {
     pub ipv4_addrs: Vec<String>,
     pub zone: InterfaceZone,
     pub l2_domain: String,
+    #[serde(default)]
+    pub linux_if: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/dataplane/examples/bench_pipeline.rs
+++ b/crates/dataplane/examples/bench_pipeline.rs
@@ -71,6 +71,7 @@ fn make_interfaces() -> Vec<InterfaceConfig> {
             ipv4_addrs: vec!["10.0.0.2/24".to_string()],
             zone: InterfaceZone::Wan,
             l2_domain: "br0".to_string(),
+            linux_if: None,
         },
         InterfaceConfig {
             name: "lan0".to_string(),
@@ -82,6 +83,7 @@ fn make_interfaces() -> Vec<InterfaceConfig> {
             ipv4_addrs: vec!["192.168.1.1/24".to_string()],
             zone: InterfaceZone::Lan,
             l2_domain: "br0".to_string(),
+            linux_if: None,
         },
         InterfaceConfig {
             name: "lan1".to_string(),
@@ -93,6 +95,7 @@ fn make_interfaces() -> Vec<InterfaceConfig> {
             ipv4_addrs: vec!["192.168.2.1/24".to_string()],
             zone: InterfaceZone::Lan,
             l2_domain: "br0".to_string(),
+            linux_if: None,
         },
     ]
 }

--- a/crates/dataplane/src/afpacket.rs
+++ b/crates/dataplane/src/afpacket.rs
@@ -1,0 +1,279 @@
+//! AF_PACKET raw socket I/O backend for Linux.
+//!
+//! Provides real packet I/O using Linux AF_PACKET raw sockets.
+//! Each interface gets its own socket bound to a specific interface
+//! via `bind()` with `sockaddr_ll`.
+//! Sockets are set to non-blocking mode.
+//!
+//! This module is only compiled on Linux (`cfg(target_os = "linux")`).
+
+use std::collections::HashMap;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+
+use crate::io::{IoError, PacketIo, RawPacket};
+
+// ── Linux constants ──────────────────────────────────────────────────
+
+const AF_PACKET: i32 = 17;
+const SOCK_RAW: i32 = 3;
+const ETH_P_ALL: i32 = 0x0003;
+const SOL_PACKET: i32 = 263;
+const PACKET_IGNORE_OUTGOING: i32 = 23;
+const O_NONBLOCK: i32 = 2048;
+const F_GETFL: i32 = 3;
+const F_SETFL: i32 = 4;
+const MSG_DONTWAIT: i32 = 0x40;
+
+/// Maximum Ethernet frame size we'll receive.
+const MAX_FRAME_SIZE: usize = 9216;
+
+// ── Raw libc FFI ─────────────────────────────────────────────────────
+
+extern "C" {
+    fn socket(domain: i32, ty: i32, protocol: i32) -> i32;
+    fn bind(sockfd: i32, addr: *const SockaddrLl, addrlen: u32) -> i32;
+    fn setsockopt(
+        sockfd: i32,
+        level: i32,
+        optname: i32,
+        optval: *const std::ffi::c_void,
+        optlen: u32,
+    ) -> i32;
+    fn recv(sockfd: i32, buf: *mut u8, len: usize, flags: i32) -> isize;
+    fn sendto(
+        sockfd: i32,
+        buf: *const u8,
+        len: usize,
+        flags: i32,
+        dest_addr: *const SockaddrLl,
+        addrlen: u32,
+    ) -> isize;
+    fn fcntl(fd: i32, cmd: i32, ...) -> i32;
+    fn if_nametoindex(ifname: *const u8) -> u32;
+}
+
+// ── sockaddr_ll ──────────────────────────────────────────────────────
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct SockaddrLl {
+    sll_family: u16,
+    sll_protocol: u16,
+    sll_ifindex: i32,
+    sll_hatype: u16,
+    sll_pkttype: u8,
+    sll_halen: u8,
+    sll_addr: [u8; 8],
+}
+
+impl SockaddrLl {
+    fn new(ifindex: i32, dst_mac: &[u8]) -> Self {
+        let mut addr = Self {
+            sll_family: AF_PACKET as u16,
+            sll_protocol: (ETH_P_ALL as u16).to_be(),
+            sll_ifindex: ifindex,
+            sll_hatype: 0,
+            sll_pkttype: 0,
+            sll_halen: 6,
+            sll_addr: [0; 8],
+        };
+        if dst_mac.len() >= 6 {
+            addr.sll_addr[..6].copy_from_slice(&dst_mac[..6]);
+        }
+        addr
+    }
+
+    /// Create a sockaddr_ll for binding (no MAC address needed).
+    fn for_bind(ifindex: i32) -> Self {
+        Self {
+            sll_family: AF_PACKET as u16,
+            sll_protocol: (ETH_P_ALL as u16).to_be(),
+            sll_ifindex: ifindex,
+            sll_hatype: 0,
+            sll_pkttype: 0,
+            sll_halen: 0,
+            sll_addr: [0; 8],
+        }
+    }
+}
+
+// ── IfSocket ─────────────────────────────────────────────────────────
+
+/// Per-interface socket state.
+struct IfSocket {
+    fd: OwnedFd,
+    ifindex: i32,
+}
+
+// ── AfPacketIo ───────────────────────────────────────────────────────
+
+/// AF_PACKET raw socket I/O backend.
+///
+/// Creates one raw socket per interface, bound to the Linux device via
+/// `bind()` with `sockaddr_ll`. Sockets are set to non-blocking mode.
+pub struct AfPacketIo {
+    sockets: HashMap<String, IfSocket>,
+    rx_ifaces: Vec<String>,
+}
+
+impl AfPacketIo {
+    /// Create a new AF_PACKET I/O backend.
+    ///
+    /// `iface_map` is a list of `(logical_name, linux_device_name)` pairs.
+    ///
+    /// # Errors
+    ///
+    /// Returns `IoError::TxFailed` if socket creation or binding fails
+    /// (typically requires `CAP_NET_RAW` or root).
+    pub fn new(iface_map: &[(String, String)]) -> Result<Self, IoError> {
+        let mut sockets = HashMap::new();
+        let mut rx_ifaces = Vec::new();
+
+        for (logical_name, linux_name) in iface_map {
+            // Get ifindex first (needed for bind).
+            let mut name_buf = Vec::with_capacity(linux_name.len() + 1);
+            name_buf.extend_from_slice(linux_name.as_bytes());
+            name_buf.push(0); // NUL terminator
+            let ifidx = unsafe { if_nametoindex(name_buf.as_ptr()) };
+            if ifidx == 0 {
+                return Err(IoError::TxFailed(format!(
+                    "if_nametoindex({}) for {}: {}",
+                    linux_name,
+                    logical_name,
+                    std::io::Error::last_os_error()
+                )));
+            }
+
+            // Create AF_PACKET, SOCK_RAW, ETH_P_ALL socket.
+            let raw_fd = unsafe { socket(AF_PACKET, SOCK_RAW, (ETH_P_ALL as u16).to_be() as i32) };
+            if raw_fd < 0 {
+                return Err(IoError::TxFailed(format!(
+                    "socket(AF_PACKET) for {}: errno={}",
+                    linux_name,
+                    std::io::Error::last_os_error()
+                )));
+            }
+            // SAFETY: socket() returned a valid fd.
+            let fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+
+            // Set non-blocking mode.
+            unsafe {
+                let flags = fcntl(fd.as_raw_fd(), F_GETFL);
+                fcntl(fd.as_raw_fd(), F_SETFL, flags | O_NONBLOCK);
+            }
+
+            // Bind to the specific interface using sockaddr_ll.
+            // This is the canonical way to restrict AF_PACKET to one device.
+            let bind_addr = SockaddrLl::for_bind(ifidx as i32);
+            let ret = unsafe {
+                bind(
+                    fd.as_raw_fd(),
+                    &bind_addr,
+                    std::mem::size_of::<SockaddrLl>() as u32,
+                )
+            };
+            if ret < 0 {
+                return Err(IoError::TxFailed(format!(
+                    "bind(AF_PACKET) to {} for {}: {}",
+                    linux_name,
+                    logical_name,
+                    std::io::Error::last_os_error()
+                )));
+            }
+
+            // PACKET_IGNORE_OUTGOING (Linux 4.20+): don't deliver our own
+            // transmitted packets back to the RX path. Ignore errors on
+            // older kernels.
+            unsafe {
+                let val: i32 = 1;
+                setsockopt(
+                    fd.as_raw_fd(),
+                    SOL_PACKET,
+                    PACKET_IGNORE_OUTGOING,
+                    &val as *const i32 as *const std::ffi::c_void,
+                    std::mem::size_of::<i32>() as u32,
+                );
+            }
+
+            sockets.insert(
+                logical_name.clone(),
+                IfSocket {
+                    fd,
+                    ifindex: ifidx as i32,
+                },
+            );
+            rx_ifaces.push(logical_name.clone());
+        }
+
+        Ok(Self { sockets, rx_ifaces })
+    }
+}
+
+// SAFETY: The OwnedFd handles are not shared across threads without
+// synchronization, and the HashMap is only read (never modified) after
+// construction. The run loop calls rx()/tx() from a single thread.
+unsafe impl Send for AfPacketIo {}
+unsafe impl Sync for AfPacketIo {}
+
+impl PacketIo for AfPacketIo {
+    fn rx(&self) -> Vec<RawPacket> {
+        let mut batch = Vec::new();
+        let mut buf = [0u8; MAX_FRAME_SIZE];
+
+        for iface_name in &self.rx_ifaces {
+            let if_sock = match self.sockets.get(iface_name) {
+                Some(s) => s,
+                None => continue,
+            };
+
+            let n = unsafe {
+                recv(
+                    if_sock.fd.as_raw_fd(),
+                    buf.as_mut_ptr(),
+                    buf.len(),
+                    MSG_DONTWAIT,
+                )
+            };
+
+            if n > 0 {
+                batch.push(RawPacket {
+                    ingress_iface: iface_name.clone(),
+                    data: buf[..n as usize].to_vec(),
+                });
+            }
+            // n <= 0: EAGAIN/EWOULDBLOCK or error, skip silently.
+        }
+
+        batch
+    }
+
+    fn tx(&self, iface: &str, packet: &RawPacket) -> Result<(), IoError> {
+        let if_sock = self
+            .sockets
+            .get(iface)
+            .ok_or_else(|| IoError::InterfaceNotFound(iface.to_string()))?;
+
+        let addr = SockaddrLl::new(if_sock.ifindex, &packet.data);
+
+        let n = unsafe {
+            sendto(
+                if_sock.fd.as_raw_fd(),
+                packet.data.as_ptr(),
+                packet.data.len(),
+                0,
+                &addr,
+                std::mem::size_of::<SockaddrLl>() as u32,
+            )
+        };
+
+        if n < 0 {
+            Err(IoError::TxFailed(format!(
+                "sendto on {}: {}",
+                iface,
+                std::io::Error::last_os_error()
+            )))
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/crates/dataplane/src/arp/mod.rs
+++ b/crates/dataplane/src/arp/mod.rs
@@ -216,6 +216,90 @@ impl ArpEngine {
         }
     }
 
+    /// Pre-populate ARP caches from the kernel's neighbor table (`/proc/net/arp`).
+    ///
+    /// `linux_to_logical` maps Linux device names (e.g. "eth1") to logical
+    /// interface names (e.g. "lan0") used as cache keys. This is used at
+    /// startup so that ruster can immediately forward packets to directly
+    /// connected hosts without waiting for ARP resolution.
+    ///
+    /// Returns the number of entries loaded.
+    #[cfg(target_os = "linux")]
+    pub fn load_kernel_arp(
+        &mut self,
+        linux_to_logical: &std::collections::HashMap<String, String>,
+    ) -> usize {
+        let content = match std::fs::read_to_string("/proc/net/arp") {
+            Ok(c) => c,
+            Err(_) => return 0,
+        };
+        let mut loaded = 0;
+        // /proc/net/arp format:
+        // IP address       HW type     Flags       HW address            Mask     Device
+        // 192.168.1.100    0x1         0x2         aa:bb:cc:dd:ee:ff     *        eth1
+        for line in content.lines().skip(1) {
+            let fields: Vec<&str> = line.split_whitespace().collect();
+            if fields.len() < 6 {
+                continue;
+            }
+            let ip_str = fields[0];
+            let flags = fields[2];
+            let mac_str = fields[3];
+            let device = fields[5];
+
+            // Skip incomplete entries (flags 0x0 means incomplete).
+            if flags == "0x0" {
+                continue;
+            }
+
+            let ip = match parse_ipv4_addr(ip_str) {
+                Some(ip) => ip,
+                None => continue,
+            };
+            let mac = parse_mac(mac_str);
+            if mac == [0; 6] {
+                continue;
+            }
+
+            // Map Linux device name to logical interface name.
+            let logical_name = linux_to_logical
+                .get(device)
+                .map(|s| s.as_str())
+                .unwrap_or(device);
+
+            if let Some(cache) = self.caches.get_mut(logical_name) {
+                cache.insert(ip, mac);
+                loaded += 1;
+            }
+        }
+        loaded
+    }
+
+    /// Pre-populate ARP caches from the kernel's neighbor table.
+    ///
+    /// On non-Linux platforms this is a no-op.
+    #[cfg(not(target_os = "linux"))]
+    pub fn load_kernel_arp(
+        &mut self,
+        _linux_to_logical: &std::collections::HashMap<String, String>,
+    ) -> usize {
+        0
+    }
+
+    /// Insert an ARP entry directly into the cache for a given interface.
+    ///
+    /// This is used for pre-populating the ARP cache (e.g. from the kernel
+    /// neighbor table at startup, or in tests). Returns `true` if the
+    /// interface was found and the entry was inserted.
+    pub fn insert(&mut self, ifname: &str, ip: [u8; 4], mac: [u8; 6]) -> bool {
+        if let Some(cache) = self.caches.get_mut(ifname) {
+            cache.insert(ip, mac);
+            true
+        } else {
+            false
+        }
+    }
+
     /// Run aging on all per-interface ARP caches.
     ///
     /// Returns the total number of entries removed across all interfaces.
@@ -375,6 +459,7 @@ mod tests {
             ipv4_addrs: vec!["192.168.1.1/24".to_string()],
             zone: InterfaceZone::Lan,
             l2_domain: "br0".to_string(),
+            linux_if: None,
         }]
     }
 

--- a/crates/dataplane/src/lib.rs
+++ b/crates/dataplane/src/lib.rs
@@ -8,7 +8,11 @@ pub mod l2;
 pub mod nat;
 pub mod packet;
 pub mod pipeline;
+pub mod rewrite;
 pub mod routing;
+
+#[cfg(target_os = "linux")]
+pub mod afpacket;
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -42,7 +46,10 @@ pub struct Dataplane {
     /// `&mut self` (for MAC learning), while the run loop takes `&self`.
     pub l2: Mutex<l2::L2Engine>,
     /// ARP resolution engine (per-interface ARP caches).
-    pub arp: arp::ArpEngine,
+    ///
+    /// Wrapped in a `Mutex` because [`arp::ArpEngine::resolve`] requires
+    /// `&mut self`, while the run loop takes `&self`.
+    pub arp: Mutex<arp::ArpEngine>,
     /// L3 IPv4 forwarding engine (static routing, LPM).
     pub l3: routing::L3Engine,
     /// NAT44 engine (NAPT, port forwarding, hairpin).
@@ -53,6 +60,10 @@ pub struct Dataplane {
     pub conntrack: conntrack::ConntrackEngine,
     /// Zone resolver: maps interface names to firewall zones.
     pub zone_resolver: pipeline::ZoneResolver,
+    /// Per-interface MAC addresses for src MAC rewriting on egress.
+    iface_macs: std::collections::HashMap<String, [u8; 6]>,
+    /// Linux device name -> logical interface name mapping (for ARP refresh).
+    linux_to_logical: std::collections::HashMap<String, String>,
     /// Counter for TX errors encountered in the run loop.
     tx_errors: AtomicU64,
     /// Observability hub: per-interface and per-stage counters.
@@ -66,24 +77,54 @@ impl Dataplane {
     /// In v0.1 the DPDK backend is mocked, so no real NIC init happens.
     pub fn init(config: &RouterConfig) -> Result<Self, DataplaneError> {
         let l2 = l2::L2Engine::from_config(&config.l2);
-        let arp = arp::ArpEngine::from_config(&config.l2, &config.interfaces);
+        let mut arp = arp::ArpEngine::from_config(&config.l2, &config.interfaces);
         let l3 = routing::L3Engine::from_config(&config.routing, &config.interfaces)?;
         let nat = nat::NatEngine::from_config(&config.nat, &config.interfaces);
         let firewall = firewall::FirewallEngine::from_config(&config.firewall);
         let conntrack = conntrack::ConntrackEngine::from_nat_config(&config.nat);
         let zone_resolver = pipeline::ZoneResolver::from_config(&config.interfaces);
 
+        let iface_macs: std::collections::HashMap<String, [u8; 6]> = config
+            .interfaces
+            .iter()
+            .map(|iface| {
+                let mac = parse_mac_str(&iface.mac);
+                (iface.name.clone(), mac)
+            })
+            .collect();
+
+        // Build linux device -> logical name mapping for ARP cache pre-loading.
+        let linux_to_logical: std::collections::HashMap<String, String> = config
+            .interfaces
+            .iter()
+            .filter_map(|iface| {
+                iface
+                    .linux_if
+                    .as_ref()
+                    .map(|linux_name| (linux_name.clone(), iface.name.clone()))
+            })
+            .collect();
+
+        // Pre-populate ARP caches from the kernel's neighbor table so that
+        // directly connected hosts can be forwarded to immediately.
+        let arp_loaded = arp.load_kernel_arp(&linux_to_logical);
+        if arp_loaded > 0 {
+            println!("  ARP: loaded {} entries from kernel", arp_loaded);
+        }
+
         let iface_names: Vec<String> = config.interfaces.iter().map(|i| i.name.clone()).collect();
         let observer = Arc::new(ruster_observe::Observer::new(&iface_names));
 
         Ok(Self {
             l2: Mutex::new(l2),
-            arp,
+            arp: Mutex::new(arp),
             l3,
             nat,
             firewall,
             conntrack,
             zone_resolver,
+            iface_macs,
+            linux_to_logical,
             tx_errors: AtomicU64::new(0),
             observer,
         })
@@ -104,8 +145,16 @@ impl Dataplane {
         io: Box<dyn io::PacketIo>,
     ) -> Result<(), DataplaneError> {
         let mut last_stats = std::time::Instant::now();
+        let mut last_arp_refresh = std::time::Instant::now();
 
         while !shutdown.load(Ordering::Relaxed) {
+            // Periodically refresh ARP cache from the kernel neighbor table.
+            if last_arp_refresh.elapsed() >= Duration::from_secs(5) {
+                let mut arp_guard = self.arp.lock().unwrap();
+                arp_guard.load_kernel_arp(&self.linux_to_logical);
+                drop(arp_guard);
+                last_arp_refresh = std::time::Instant::now();
+            }
             let batch = io.rx();
             if batch.is_empty() {
                 std::thread::sleep(Duration::from_millis(1));
@@ -125,12 +174,79 @@ impl Dataplane {
                         &self.firewall,
                         &self.conntrack,
                         &self.zone_resolver,
+                        &self.iface_macs,
                     )
                 };
                 match result {
-                    pipeline::PipelineResult::Forward { egress_iface } => {
+                    pipeline::PipelineResult::Forward {
+                        egress_iface,
+                        new_ttl,
+                        next_hop,
+                    } => {
                         self.observer.inc_forwarded();
-                        match io.tx(&egress_iface, raw_pkt) {
+
+                        // Apply packet rewrites for L3 forwarding.
+                        let tx_data;
+                        let tx_pkt = if new_ttl.is_some() || next_hop.is_some() {
+                            let mut data = raw_pkt.data.clone();
+
+                            // 1. TTL + checksum
+                            if let Some(ttl) = new_ttl {
+                                rewrite::rewrite_ipv4_ttl(&mut data, ttl);
+                            }
+
+                            // 2. src MAC -> egress IF's MAC
+                            if let Some(mac) = self.iface_macs.get(&egress_iface) {
+                                rewrite::rewrite_src_mac(&mut data, mac);
+                            }
+
+                            // 3. dst MAC -> ARP resolve
+                            if let Some(nh) = next_hop {
+                                // Determine the IP to ARP-resolve:
+                                // - If next_hop != 0.0.0.0: resolve the next-hop gateway
+                                // - If next_hop == 0.0.0.0: directly connected, resolve
+                                //   the packet's destination IP
+                                let arp_target = if nh != [0, 0, 0, 0] {
+                                    nh
+                                } else {
+                                    // Extract dst IP from the IPv4 header (offset 30..34
+                                    // in an Ethernet+IPv4 frame: 14 eth + 16 dst offset)
+                                    if data.len() >= 34 {
+                                        [data[30], data[31], data[32], data[33]]
+                                    } else {
+                                        // Malformed, cannot extract dst IP
+                                        self.observer
+                                            .inc_drop_reason(ruster_observe::DropReason::L3NoRoute);
+                                        continue;
+                                    }
+                                };
+                                let arp_result = {
+                                    let mut arp_guard = self.arp.lock().unwrap();
+                                    arp_guard.resolve(arp_target, &egress_iface)
+                                };
+                                match arp_result {
+                                    arp::ArpAction::Forward { resolved_mac } => {
+                                        rewrite::rewrite_dst_mac(&mut data, &resolved_mac);
+                                    }
+                                    _ => {
+                                        // ARP unresolved -> drop
+                                        self.observer
+                                            .inc_drop_reason(ruster_observe::DropReason::L3NoRoute);
+                                        continue;
+                                    }
+                                }
+                            }
+
+                            tx_data = io::RawPacket {
+                                ingress_iface: raw_pkt.ingress_iface.clone(),
+                                data,
+                            };
+                            &tx_data
+                        } else {
+                            raw_pkt
+                        };
+
+                        match io.tx(&egress_iface, tx_pkt) {
                             Ok(()) => {
                                 self.observer
                                     .inc_tx(&egress_iface, raw_pkt.data.len() as u64);
@@ -197,6 +313,21 @@ impl Dataplane {
     pub fn tx_error_count(&self) -> u64 {
         self.tx_errors.load(Ordering::Relaxed)
     }
+}
+
+/// Parse a MAC address string (e.g. "00:11:22:33:44:55") into a 6-byte array.
+///
+/// Returns `[0; 6]` if the string cannot be parsed.
+fn parse_mac_str(mac_str: &str) -> [u8; 6] {
+    let parts: Vec<&str> = mac_str.split(':').collect();
+    if parts.len() != 6 {
+        return [0; 6];
+    }
+    let mut mac = [0u8; 6];
+    for (i, part) in parts.iter().enumerate() {
+        mac[i] = u8::from_str_radix(part, 16).unwrap_or(0);
+    }
+    mac
 }
 
 /// Map a pipeline [`pipeline::DropReason`] to an observe [`ruster_observe::DropReason`].
@@ -317,6 +448,17 @@ mod tests {
         config
     }
 
+    /// Pre-populate the ARP cache so that the default route's next hop
+    /// (203.0.113.1 via wan0) can be resolved. Without this, L3 forwarding
+    /// would drop packets waiting for ARP resolution.
+    fn prepopulate_arp(dp: &Dataplane) {
+        let mut arp_guard = dp.arp.lock().unwrap();
+        // Default route next_hop in example config: 203.0.113.1
+        let next_hop = [203, 0, 113, 1];
+        let fake_gw_mac = [0x00, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE];
+        arp_guard.insert("wan0", next_hop, fake_gw_mac);
+    }
+
     /// Build a minimal valid Ethernet+IPv4+UDP packet that the pipeline
     /// will route via the default route (wan0) in the example config.
     fn make_forwardable_packet() -> io::RawPacket {
@@ -376,6 +518,7 @@ mod tests {
     fn dataplane_run_counts_tx_errors() {
         let config = load_example_fw_disabled();
         let dp = Dataplane::init(&config).expect("init should succeed");
+        prepopulate_arp(&dp);
 
         let mock_io = io::MockPacketIo::new();
 
@@ -455,6 +598,7 @@ mod tests {
     fn observer_tx_counter_increments_on_successful_forward() {
         let config = load_example_fw_disabled();
         let dp = Dataplane::init(&config).expect("init should succeed");
+        prepopulate_arp(&dp);
 
         let mock_io = io::MockPacketIo::new();
         let pkt = make_forwardable_packet();
@@ -483,6 +627,7 @@ mod tests {
     fn observer_tx_drop_counter_increments_on_tx_failure() {
         let config = load_example_fw_disabled();
         let dp = Dataplane::init(&config).expect("init should succeed");
+        prepopulate_arp(&dp);
 
         let mock_io = io::MockPacketIo::new();
         mock_io.inject(make_forwardable_packet());
@@ -665,6 +810,7 @@ mod tests {
     fn observer_snapshot_after_mixed_traffic() {
         let config = load_example_fw_disabled();
         let dp = Dataplane::init(&config).expect("init should succeed");
+        prepopulate_arp(&dp);
 
         let mock_io = io::MockPacketIo::new();
 

--- a/crates/dataplane/src/nat/mod.rs
+++ b/crates/dataplane/src/nat/mod.rs
@@ -574,6 +574,7 @@ mod tests {
                 ipv4_addrs: vec!["10.0.0.2/24".to_string()],
                 zone: InterfaceZone::Wan,
                 l2_domain: "br0".to_string(),
+                linux_if: None,
             },
             InterfaceConfig {
                 name: "lan0".to_string(),
@@ -585,6 +586,7 @@ mod tests {
                 ipv4_addrs: vec!["192.168.1.1/24".to_string()],
                 zone: InterfaceZone::Lan,
                 l2_domain: "br0".to_string(),
+                linux_if: None,
             },
         ]
     }

--- a/crates/dataplane/src/pipeline.rs
+++ b/crates/dataplane/src/pipeline.rs
@@ -65,6 +65,10 @@ pub enum PipelineResult {
     Forward {
         /// Name of the egress interface.
         egress_iface: String,
+        /// New TTL after L3 decrement (Some for L3 forwarded packets, None for L2-only).
+        new_ttl: Option<u8>,
+        /// Next-hop IPv4 address (Some for L3 forwarded packets, None for L2-only).
+        next_hop: Option<[u8; 4]>,
     },
     /// Packet should be flooded to all listed interfaces (L2 unknown
     /// unicast or broadcast within a bridge domain).
@@ -133,6 +137,7 @@ pub fn process_packet(
     firewall: &FirewallEngine,
     conntrack: &ConntrackEngine,
     zone_resolver: &ZoneResolver,
+    iface_macs: &std::collections::HashMap<String, [u8; 6]>,
 ) -> PipelineResult {
     // Step 1: Parse raw bytes.
     let meta = match packet::parse_packet(&raw_pkt.data, &raw_pkt.ingress_iface) {
@@ -149,19 +154,27 @@ pub fn process_packet(
     if l2.is_bridged(&meta.in_ifname) {
         let l2_decision = l2.process(&meta);
 
-        // Check whether the packet is destined for one of the router's
-        // own IP addresses. If so, skip L2 forwarding and fall through
-        // to L3 processing (the MAC was already learned in `l2.process`).
-        let is_local = match &meta.l3 {
+        // Check whether the packet should be punted to L3 processing.
+        // This happens when either:
+        // - The destination IP is one of the router's own IPs (local delivery), OR
+        // - The destination MAC matches the router's MAC on the ingress interface
+        //   (transit routing — the host is using us as the default gateway).
+        let is_local_ip = match &meta.l3 {
             Some(L3Info::Ipv4(ipv4)) => l3.is_local_ip(&ipv4.dst_addr),
             _ => false,
         };
+        let is_router_mac = iface_macs
+            .get(&meta.in_ifname)
+            .is_some_and(|our_mac| meta.l2.dst_mac == *our_mac);
+        let is_local = is_local_ip || is_router_mac;
 
         if !is_local {
             // Pure L2 forwarding — do not enter L3.
             return match l2_decision {
                 L2Decision::Unicast { out_ifname } => PipelineResult::Forward {
                     egress_iface: out_ifname,
+                    new_ttl: None,
+                    next_hop: None,
                 },
                 L2Decision::Flood { out_ifnames } => PipelineResult::Flood {
                     egress_ifaces: out_ifnames,
@@ -181,8 +194,8 @@ pub fn process_packet(
     match l3_decision {
         L3Decision::Forward {
             out_ifname,
-            next_hop: _,
-            new_ttl: _,
+            next_hop,
+            new_ttl,
         } => {
             // Step 4: Firewall check on the forward chain.
             let src_zone = zone_resolver.resolve(&raw_pkt.ingress_iface);
@@ -194,6 +207,8 @@ pub fn process_packet(
             match verdict {
                 FwVerdict::Accept | FwVerdict::AcceptRule { .. } => PipelineResult::Forward {
                     egress_iface: out_ifname,
+                    new_ttl: Some(new_ttl),
+                    next_hop: Some(next_hop),
                 },
                 FwVerdict::Drop | FwVerdict::DropRule { .. } => PipelineResult::Drop {
                     reason: DropReason::FirewallDrop,
@@ -306,6 +321,7 @@ mod tests {
                 ipv4_addrs: vec!["10.0.0.2/24".to_string()],
                 zone: InterfaceZone::Wan,
                 l2_domain: "br0".to_string(),
+                linux_if: None,
             },
             InterfaceConfig {
                 name: "lan0".to_string(),
@@ -317,6 +333,7 @@ mod tests {
                 ipv4_addrs: vec!["192.168.1.1/24".to_string()],
                 zone: InterfaceZone::Lan,
                 l2_domain: "br0".to_string(),
+                linux_if: None,
             },
         ]
     }
@@ -443,10 +460,11 @@ mod tests {
         };
 
         let zr = make_zone_resolver();
+        let im = std::collections::HashMap::new();
         let mut l2 = make_l2_engine_empty();
-        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr);
+        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr, &im);
         match result {
-            PipelineResult::Forward { egress_iface } => {
+            PipelineResult::Forward { egress_iface, .. } => {
                 assert_eq!(egress_iface, "wan0");
             }
             other => panic!("expected Forward, got {:?}", other),
@@ -466,8 +484,9 @@ mod tests {
         };
 
         let zr = make_zone_resolver();
+        let im = std::collections::HashMap::new();
         let mut l2 = make_l2_engine_empty();
-        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr);
+        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr, &im);
         match result {
             PipelineResult::Drop { reason, .. } => {
                 assert_eq!(reason, DropReason::ParseError);
@@ -505,8 +524,9 @@ mod tests {
         };
 
         let zr = make_zone_resolver();
+        let im = std::collections::HashMap::new();
         let mut l2 = make_l2_engine_empty();
-        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr);
+        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr, &im);
         match result {
             PipelineResult::Drop { reason, .. } => {
                 assert_eq!(reason, DropReason::L3NoRoute);
@@ -535,8 +555,9 @@ mod tests {
         };
 
         let zr = make_zone_resolver();
+        let im = std::collections::HashMap::new();
         let mut l2 = make_l2_engine_empty();
-        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr);
+        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr, &im);
         match result {
             PipelineResult::Drop { reason, .. } => {
                 assert_eq!(reason, DropReason::L3TtlExpired);
@@ -565,8 +586,9 @@ mod tests {
         };
 
         let zr = make_zone_resolver();
+        let im = std::collections::HashMap::new();
         let mut l2 = make_l2_engine_empty();
-        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr);
+        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr, &im);
         assert!(matches!(result, PipelineResult::Consumed));
     }
 
@@ -590,8 +612,9 @@ mod tests {
         };
 
         let zr = make_zone_resolver();
+        let im = std::collections::HashMap::new();
         let mut l2 = make_l2_engine_empty();
-        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr);
+        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr, &im);
         match result {
             PipelineResult::Drop { reason, .. } => {
                 assert_eq!(reason, DropReason::FirewallDrop);
@@ -629,8 +652,9 @@ mod tests {
         };
 
         let zr = make_zone_resolver();
+        let im = std::collections::HashMap::new();
         let mut l2 = make_l2_engine_empty();
-        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr);
+        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr, &im);
         match result {
             PipelineResult::Drop { reason, .. } => {
                 assert_eq!(reason, DropReason::L3NotIpv4);
@@ -647,6 +671,7 @@ mod tests {
         let fw = make_fw_accept_all();
         let ct = make_conntrack();
         let zr = make_zone_resolver();
+        let im = std::collections::HashMap::new();
         let mut l2 = make_l2_engine_empty();
 
         let mut parse_errors = 0u64;
@@ -658,7 +683,7 @@ mod tests {
             ingress_iface: "eth0".to_string(),
             data: vec![0x00; 5],
         };
-        match process_packet(&short_pkt, &mut l2, &l3, &fw, &ct, &zr) {
+        match process_packet(&short_pkt, &mut l2, &l3, &fw, &ct, &zr, &im) {
             PipelineResult::Drop {
                 reason: DropReason::ParseError,
                 ..
@@ -672,7 +697,7 @@ mod tests {
             ingress_iface: "lan0".to_string(),
             data: ttl_data,
         };
-        match process_packet(&ttl_pkt, &mut l2, &l3, &fw, &ct, &zr) {
+        match process_packet(&ttl_pkt, &mut l2, &l3, &fw, &ct, &zr, &im) {
             PipelineResult::Drop {
                 reason: DropReason::L3TtlExpired,
                 ..
@@ -686,7 +711,7 @@ mod tests {
             ingress_iface: "lan0".to_string(),
             data: fwd_data,
         };
-        match process_packet(&fwd_pkt, &mut l2, &l3, &fw, &ct, &zr) {
+        match process_packet(&fwd_pkt, &mut l2, &l3, &fw, &ct, &zr, &im) {
             PipelineResult::Forward { .. } => forwards += 1,
             _ => {}
         }
@@ -709,6 +734,7 @@ mod tests {
         let l3 = make_l3_engine();
         let ct = make_conntrack();
         let zr = make_zone_resolver();
+        let im = std::collections::HashMap::new();
 
         // Firewall: only allow Lan->Wan forward, drop everything else.
         let fw = FirewallEngine::from_config(&FirewallConfig {
@@ -742,9 +768,9 @@ mod tests {
         };
 
         let mut l2 = make_l2_engine_empty();
-        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr);
+        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr, &im);
         match result {
-            PipelineResult::Forward { egress_iface } => {
+            PipelineResult::Forward { egress_iface, .. } => {
                 assert_eq!(egress_iface, "wan0");
             }
             other => panic!(
@@ -765,6 +791,7 @@ mod tests {
         let l3 = make_l3_engine();
         let ct = make_conntrack();
         let zr = make_zone_resolver();
+        let im = std::collections::HashMap::new();
 
         // Firewall: only allow Lan->Wan forward, drop everything else.
         let fw = FirewallEngine::from_config(&FirewallConfig {
@@ -799,7 +826,7 @@ mod tests {
         };
 
         let mut l2 = make_l2_engine_empty();
-        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr);
+        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr, &im);
         match result {
             PipelineResult::Drop { reason, .. } => {
                 assert_eq!(reason, DropReason::FirewallDrop);
@@ -827,6 +854,7 @@ mod tests {
         let fw = make_fw_accept_all();
         let ct = make_conntrack();
         let zr = make_zone_resolver();
+        let im = std::collections::HashMap::new();
 
         // TTL = 1 -> L3 drops with TtlExpired -> should generate ICMP.
         let data = make_ipv4_packet(
@@ -842,7 +870,7 @@ mod tests {
         };
 
         let mut l2 = make_l2_engine_empty();
-        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr);
+        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr, &im);
         match result {
             PipelineResult::Drop { reason, icmp_reply } => {
                 assert_eq!(reason, DropReason::L3TtlExpired);
@@ -877,6 +905,7 @@ mod tests {
         let fw = make_fw_accept_all();
         let ct = make_conntrack();
         let zr = make_zone_resolver();
+        let im = std::collections::HashMap::new();
 
         // Destination 8.8.8.8 has no matching route.
         let data = make_ipv4_packet(
@@ -892,7 +921,7 @@ mod tests {
         };
 
         let mut l2 = make_l2_engine_empty();
-        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr);
+        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr, &im);
         match result {
             PipelineResult::Drop { reason, icmp_reply } => {
                 assert_eq!(reason, DropReason::L3NoRoute);
@@ -914,6 +943,7 @@ mod tests {
         let fw = make_fw_accept_all();
         let ct = make_conntrack();
         let zr = make_zone_resolver();
+        let im = std::collections::HashMap::new();
 
         // Build an ICMP packet (protocol=1) with TTL=1.
         let mut pkt = Vec::new();
@@ -950,7 +980,7 @@ mod tests {
         };
 
         let mut l2 = make_l2_engine_empty();
-        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr);
+        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr, &im);
         match result {
             PipelineResult::Drop { reason, icmp_reply } => {
                 assert_eq!(reason, DropReason::L3TtlExpired);
@@ -969,6 +999,7 @@ mod tests {
         let fw = make_fw_accept_all();
         let ct = make_conntrack();
         let zr = make_zone_resolver();
+        let im = std::collections::HashMap::new();
 
         let raw_pkt = RawPacket {
             ingress_iface: "eth0".to_string(),
@@ -976,7 +1007,7 @@ mod tests {
         };
 
         let mut l2 = make_l2_engine_empty();
-        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr);
+        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr, &im);
         match result {
             PipelineResult::Drop { reason, icmp_reply } => {
                 assert_eq!(reason, DropReason::ParseError);
@@ -992,6 +1023,7 @@ mod tests {
         let fw = make_fw_drop_all();
         let ct = make_conntrack();
         let zr = make_zone_resolver();
+        let im = std::collections::HashMap::new();
 
         let data = make_ipv4_packet(
             [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
@@ -1006,7 +1038,7 @@ mod tests {
         };
 
         let mut l2 = make_l2_engine_empty();
-        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr);
+        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr, &im);
         match result {
             PipelineResult::Drop { reason, icmp_reply } => {
                 assert_eq!(reason, DropReason::FirewallDrop);
@@ -1022,6 +1054,7 @@ mod tests {
         let fw = make_fw_accept_all();
         let ct = make_conntrack();
         let zr = make_zone_resolver();
+        let im = std::collections::HashMap::new();
 
         // ARP packet.
         let mut data = Vec::new();
@@ -1044,7 +1077,7 @@ mod tests {
         };
 
         let mut l2 = make_l2_engine_empty();
-        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr);
+        let result = process_packet(&raw_pkt, &mut l2, &l3, &fw, &ct, &zr, &im);
         match result {
             PipelineResult::Drop { reason, icmp_reply } => {
                 assert_eq!(reason, DropReason::L3NotIpv4);
@@ -1093,6 +1126,7 @@ mod tests {
                 ipv4_addrs: vec!["192.168.1.1/24".to_string()],
                 zone: InterfaceZone::Lan,
                 l2_domain: "br0".to_string(),
+                linux_if: None,
             },
             InterfaceConfig {
                 name: "eth1".to_string(),
@@ -1104,6 +1138,7 @@ mod tests {
                 ipv4_addrs: vec![],
                 zone: InterfaceZone::Lan,
                 l2_domain: "br0".to_string(),
+                linux_if: None,
             },
             InterfaceConfig {
                 name: "eth2".to_string(),
@@ -1115,6 +1150,7 @@ mod tests {
                 ipv4_addrs: vec![],
                 zone: InterfaceZone::Lan,
                 l2_domain: "br0".to_string(),
+                linux_if: None,
             },
             InterfaceConfig {
                 name: "wan0".to_string(),
@@ -1126,6 +1162,7 @@ mod tests {
                 ipv4_addrs: vec!["10.0.0.2/24".to_string()],
                 zone: InterfaceZone::Wan,
                 l2_domain: "bd-wan".to_string(),
+                linux_if: None,
             },
         ];
         L3Engine::from_config(&routing, &ifaces).unwrap()
@@ -1158,6 +1195,7 @@ mod tests {
         let fw = make_fw_accept_all();
         let ct = make_conntrack();
         let zr = ZoneResolver::from_config(&[]);
+        let im = std::collections::HashMap::new();
 
         // Step 1: Learn MAC_HOST_B on eth1.
         let learn_pkt = make_l2_raw_packet(
@@ -1167,7 +1205,7 @@ mod tests {
             [192, 168, 1, 50],
             [192, 168, 1, 60],
         );
-        let _ = process_packet(&learn_pkt, &mut l2, &l3, &fw, &ct, &zr);
+        let _ = process_packet(&learn_pkt, &mut l2, &l3, &fw, &ct, &zr, &im);
 
         // Step 2: Send from MAC_HOST_A on eth0 to MAC_HOST_B -> unicast to eth1.
         let pkt = make_l2_raw_packet(
@@ -1177,10 +1215,10 @@ mod tests {
             [192, 168, 1, 60],
             [192, 168, 1, 50],
         );
-        let result = process_packet(&pkt, &mut l2, &l3, &fw, &ct, &zr);
+        let result = process_packet(&pkt, &mut l2, &l3, &fw, &ct, &zr, &im);
 
         match result {
-            PipelineResult::Forward { egress_iface } => {
+            PipelineResult::Forward { egress_iface, .. } => {
                 assert_eq!(egress_iface, "eth1");
             }
             other => panic!("expected Forward to eth1, got {:?}", other),
@@ -1195,6 +1233,7 @@ mod tests {
         let fw = make_fw_accept_all();
         let ct = make_conntrack();
         let zr = ZoneResolver::from_config(&[]);
+        let im = std::collections::HashMap::new();
 
         let pkt = make_l2_raw_packet(
             "eth0",
@@ -1203,7 +1242,7 @@ mod tests {
             [192, 168, 1, 60],
             [192, 168, 1, 50],
         );
-        let result = process_packet(&pkt, &mut l2, &l3, &fw, &ct, &zr);
+        let result = process_packet(&pkt, &mut l2, &l3, &fw, &ct, &zr, &im);
 
         match result {
             PipelineResult::Flood { egress_ifaces } => {
@@ -1227,6 +1266,7 @@ mod tests {
         let fw = make_fw_accept_all();
         let ct = make_conntrack();
         let zr = ZoneResolver::from_config(&[]);
+        let im = std::collections::HashMap::new();
 
         let pkt = make_l2_raw_packet(
             "eth0",
@@ -1235,7 +1275,7 @@ mod tests {
             [192, 168, 1, 60],
             [192, 168, 1, 255],
         );
-        let result = process_packet(&pkt, &mut l2, &l3, &fw, &ct, &zr);
+        let result = process_packet(&pkt, &mut l2, &l3, &fw, &ct, &zr, &im);
 
         match result {
             PipelineResult::Flood { egress_ifaces } => {
@@ -1261,6 +1301,7 @@ mod tests {
         let fw = make_fw_accept_all();
         let ct = make_conntrack();
         let zr = ZoneResolver::from_config(&[]);
+        let im = std::collections::HashMap::new();
 
         // Step 1: MAC_HOST_A arrives on eth0 (triggers learning).
         let learn_pkt = make_l2_raw_packet(
@@ -1270,7 +1311,7 @@ mod tests {
             [192, 168, 1, 60],
             [192, 168, 1, 50],
         );
-        let _ = process_packet(&learn_pkt, &mut l2, &l3, &fw, &ct, &zr);
+        let _ = process_packet(&learn_pkt, &mut l2, &l3, &fw, &ct, &zr, &im);
 
         // Step 2: Send to MAC_HOST_A from eth1 -> should unicast to eth0.
         let pkt = make_l2_raw_packet(
@@ -1280,10 +1321,10 @@ mod tests {
             [192, 168, 1, 50],
             [192, 168, 1, 60],
         );
-        let result = process_packet(&pkt, &mut l2, &l3, &fw, &ct, &zr);
+        let result = process_packet(&pkt, &mut l2, &l3, &fw, &ct, &zr, &im);
 
         match result {
-            PipelineResult::Forward { egress_iface } => {
+            PipelineResult::Forward { egress_iface, .. } => {
                 assert_eq!(egress_iface, "eth0");
             }
             other => panic!("expected Forward to eth0, got {:?}", other),
@@ -1300,6 +1341,7 @@ mod tests {
         let fw = make_fw_accept_all();
         let ct = make_conntrack();
         let zr = ZoneResolver::from_config(&[]);
+        let im = std::collections::HashMap::new();
 
         let pkt = make_l2_raw_packet(
             "eth0",
@@ -1308,7 +1350,7 @@ mod tests {
             [192, 168, 1, 60],
             [192, 168, 1, 1],
         );
-        let result = process_packet(&pkt, &mut l2, &l3, &fw, &ct, &zr);
+        let result = process_packet(&pkt, &mut l2, &l3, &fw, &ct, &zr, &im);
 
         // The packet's dst IP (192.168.1.1) is a local IP on eth0,
         // so L3 should handle it as LocalDelivery -> Consumed.
@@ -1328,6 +1370,7 @@ mod tests {
         let fw = make_fw_accept_all();
         let ct = make_conntrack();
         let zr = ZoneResolver::from_config(&[]);
+        let im = std::collections::HashMap::new();
 
         // wan0 is NOT in br0, so it skips L2 entirely.
         let pkt = make_l2_raw_packet(
@@ -1337,7 +1380,7 @@ mod tests {
             [10, 0, 0, 5],
             [192, 168, 1, 1], // local IP -> Consumed
         );
-        let result = process_packet(&pkt, &mut l2, &l3, &fw, &ct, &zr);
+        let result = process_packet(&pkt, &mut l2, &l3, &fw, &ct, &zr, &im);
 
         assert!(
             matches!(result, PipelineResult::Consumed),

--- a/crates/dataplane/src/rewrite.rs
+++ b/crates/dataplane/src/rewrite.rs
@@ -1,0 +1,189 @@
+//! Packet header rewrite functions for L3 forwarding.
+//!
+//! These pure functions modify raw packet bytes in place for:
+//! - IPv4 TTL decrement with incremental checksum update (RFC 1624)
+//! - Ethernet source MAC rewrite
+//! - Ethernet destination MAC rewrite
+//!
+//! RFC-REF: RFC 1624 Section 3
+//! "HC' = ~(~HC + ~m + m')"
+
+use crate::nat::checksum::incremental_checksum_update;
+
+/// Rewrite the IPv4 TTL field and update the IP header checksum incrementally.
+///
+/// Expects a full Ethernet frame (14-byte header + IPv4 payload).
+/// Returns `false` if the packet is too short to contain a valid IPv4 header.
+///
+/// RFC-REF: RFC 791 Section 3.2
+/// "The time-to-live is decremented at each point that the internet
+/// header is processed."
+pub fn rewrite_ipv4_ttl(data: &mut [u8], new_ttl: u8) -> bool {
+    // Ethernet header is 14 bytes; IPv4 TTL is at offset 8 within the IP header.
+    const ETH_HLEN: usize = 14;
+    const IPV4_TTL_OFFSET: usize = ETH_HLEN + 8;
+    const IPV4_CHECKSUM_OFFSET: usize = ETH_HLEN + 10;
+
+    if data.len() < ETH_HLEN + 20 {
+        return false;
+    }
+
+    let old_ttl = data[IPV4_TTL_OFFSET];
+
+    // The TTL occupies the high byte of a 16-bit word at offset 8.
+    // The word is [TTL, Protocol].
+    let old_word = u16::from_be_bytes([old_ttl, data[IPV4_TTL_OFFSET + 1]]);
+    let new_word = u16::from_be_bytes([new_ttl, data[IPV4_TTL_OFFSET + 1]]);
+
+    let old_checksum =
+        u16::from_be_bytes([data[IPV4_CHECKSUM_OFFSET], data[IPV4_CHECKSUM_OFFSET + 1]]);
+    let new_checksum = incremental_checksum_update(old_checksum, old_word, new_word);
+
+    data[IPV4_TTL_OFFSET] = new_ttl;
+    let cksum_bytes = new_checksum.to_be_bytes();
+    data[IPV4_CHECKSUM_OFFSET] = cksum_bytes[0];
+    data[IPV4_CHECKSUM_OFFSET + 1] = cksum_bytes[1];
+
+    true
+}
+
+/// Rewrite the Ethernet source MAC address (bytes 6..12).
+pub fn rewrite_src_mac(data: &mut [u8], mac: &[u8; 6]) {
+    if data.len() >= 14 {
+        data[6..12].copy_from_slice(mac);
+    }
+}
+
+/// Rewrite the Ethernet destination MAC address (bytes 0..6).
+pub fn rewrite_dst_mac(data: &mut [u8], mac: &[u8; 6]) {
+    if data.len() >= 14 {
+        data[0..6].copy_from_slice(mac);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Compute a full IPv4 header checksum from scratch for verification.
+    fn compute_ipv4_checksum(hdr: &[u8]) -> u16 {
+        let mut sum: u32 = 0;
+        for i in (0..hdr.len()).step_by(2) {
+            let word = if i + 1 < hdr.len() {
+                u16::from_be_bytes([hdr[i], hdr[i + 1]])
+            } else {
+                u16::from_be_bytes([hdr[i], 0])
+            };
+            sum += word as u32;
+        }
+        while (sum >> 16) != 0 {
+            sum = (sum & 0xFFFF) + (sum >> 16);
+        }
+        !(sum as u16)
+    }
+
+    /// Build a minimal Ethernet + IPv4 + UDP packet.
+    fn make_test_packet(ttl: u8) -> Vec<u8> {
+        let mut pkt = Vec::new();
+        // Ethernet header (14 bytes)
+        pkt.extend_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]); // dst MAC
+        pkt.extend_from_slice(&[0x11, 0x22, 0x33, 0x44, 0x55, 0x66]); // src MAC
+        pkt.extend_from_slice(&[0x08, 0x00]); // EtherType: IPv4
+
+        // IPv4 header (20 bytes)
+        let ipv4_start = pkt.len();
+        pkt.push(0x45); // version=4, IHL=5
+        pkt.push(0x00); // DSCP/ECN
+        let total_len: u16 = 20 + 8;
+        pkt.extend_from_slice(&total_len.to_be_bytes());
+        pkt.extend_from_slice(&[0x00, 0x01]); // identification
+        pkt.extend_from_slice(&[0x40, 0x00]); // flags: DF
+        pkt.push(ttl);
+        pkt.push(17); // protocol: UDP
+        pkt.extend_from_slice(&[0x00, 0x00]); // checksum placeholder
+        pkt.extend_from_slice(&[192, 168, 1, 100]); // src IP
+        pkt.extend_from_slice(&[8, 8, 8, 8]); // dst IP
+
+        // Compute and set IPv4 checksum
+        let cksum = compute_ipv4_checksum(&pkt[ipv4_start..ipv4_start + 20]);
+        pkt[ipv4_start + 10] = (cksum >> 8) as u8;
+        pkt[ipv4_start + 11] = (cksum & 0xFF) as u8;
+
+        // Minimal UDP header (8 bytes)
+        pkt.extend_from_slice(&[0x00, 0x50]); // src port: 80
+        pkt.extend_from_slice(&[0x00, 0x51]); // dst port: 81
+        pkt.extend_from_slice(&[0x00, 0x08]); // length: 8
+        pkt.extend_from_slice(&[0x00, 0x00]); // checksum: 0
+
+        pkt
+    }
+
+    #[test]
+    fn rewrite_ttl_decrements_and_updates_checksum() {
+        let mut pkt = make_test_packet(64);
+
+        // Verify the original checksum is valid.
+        assert_eq!(compute_ipv4_checksum(&pkt[14..34]), 0);
+
+        // Rewrite TTL from 64 to 63.
+        assert!(rewrite_ipv4_ttl(&mut pkt, 63));
+        assert_eq!(pkt[14 + 8], 63, "TTL should be 63");
+
+        // Verify the updated checksum is still valid.
+        assert_eq!(
+            compute_ipv4_checksum(&pkt[14..34]),
+            0,
+            "checksum must be valid after TTL rewrite"
+        );
+    }
+
+    #[test]
+    fn rewrite_ttl_to_one() {
+        let mut pkt = make_test_packet(2);
+        assert!(rewrite_ipv4_ttl(&mut pkt, 1));
+        assert_eq!(pkt[14 + 8], 1);
+        assert_eq!(compute_ipv4_checksum(&pkt[14..34]), 0);
+    }
+
+    #[test]
+    fn rewrite_ttl_large_change() {
+        let mut pkt = make_test_packet(255);
+        assert!(rewrite_ipv4_ttl(&mut pkt, 1));
+        assert_eq!(pkt[14 + 8], 1);
+        assert_eq!(compute_ipv4_checksum(&pkt[14..34]), 0);
+    }
+
+    #[test]
+    fn rewrite_ttl_too_short_packet() {
+        let mut pkt = vec![0u8; 20]; // Too short for Ethernet + IPv4
+        assert!(!rewrite_ipv4_ttl(&mut pkt, 63));
+    }
+
+    #[test]
+    fn rewrite_src_mac_changes_bytes() {
+        let mut pkt = make_test_packet(64);
+        let new_mac = [0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01];
+        rewrite_src_mac(&mut pkt, &new_mac);
+        assert_eq!(&pkt[6..12], &new_mac);
+        // dst MAC should be unchanged.
+        assert_eq!(&pkt[0..6], &[0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]);
+    }
+
+    #[test]
+    fn rewrite_dst_mac_changes_bytes() {
+        let mut pkt = make_test_packet(64);
+        let new_mac = [0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x02];
+        rewrite_dst_mac(&mut pkt, &new_mac);
+        assert_eq!(&pkt[0..6], &new_mac);
+        // src MAC should be unchanged.
+        assert_eq!(&pkt[6..12], &[0x11, 0x22, 0x33, 0x44, 0x55, 0x66]);
+    }
+
+    #[test]
+    fn rewrite_mac_too_short_packet() {
+        let mut pkt = vec![0u8; 10]; // Too short for Ethernet header
+                                     // Should not panic.
+        rewrite_src_mac(&mut pkt, &[0xFF; 6]);
+        rewrite_dst_mac(&mut pkt, &[0xFF; 6]);
+    }
+}

--- a/crates/dataplane/src/routing/mod.rs
+++ b/crates/dataplane/src/routing/mod.rs
@@ -319,6 +319,7 @@ mod tests {
                 ipv4_addrs: vec!["10.0.0.2/24".to_string()],
                 zone: InterfaceZone::Wan,
                 l2_domain: "br0".to_string(),
+                linux_if: None,
             },
             InterfaceConfig {
                 name: "lan0".to_string(),
@@ -330,6 +331,7 @@ mod tests {
                 ipv4_addrs: vec!["192.168.1.1/24".to_string()],
                 zone: InterfaceZone::Lan,
                 l2_domain: "br0".to_string(),
+                linux_if: None,
             },
         ]
     }

--- a/crates/dataplane/tests/e2e_scenarios.rs
+++ b/crates/dataplane/tests/e2e_scenarios.rs
@@ -80,6 +80,7 @@ fn make_home_router_config() -> (
             ipv4_addrs: vec!["10.0.0.2/24".to_string()],
             zone: InterfaceZone::Wan,
             l2_domain: "".to_string(),
+            linux_if: None,
         },
         InterfaceConfig {
             name: "eth1".to_string(),
@@ -91,6 +92,7 @@ fn make_home_router_config() -> (
             ipv4_addrs: vec!["192.168.1.1/24".to_string()],
             zone: InterfaceZone::Lan,
             l2_domain: "br0".to_string(),
+            linux_if: None,
         },
         InterfaceConfig {
             name: "eth2".to_string(),
@@ -102,6 +104,7 @@ fn make_home_router_config() -> (
             ipv4_addrs: vec![],
             zone: InterfaceZone::Lan,
             l2_domain: "br0".to_string(),
+            linux_if: None,
         },
     ];
 

--- a/crates/main/src/main.rs
+++ b/crates/main/src/main.rs
@@ -105,10 +105,37 @@ fn main() {
 
     println!("\nruster: running (press Ctrl+C to stop)");
 
-    // Enter the dataplane run loop (blocks until shutdown).
-    // v0.1: no real NIC I/O — use a mock backend that produces no packets.
-    let mock_io = ruster_dataplane::io::MockPacketIo::new();
-    if let Err(e) = dataplane.run(shutdown, Box::new(mock_io)) {
+    // Select I/O backend based on config.
+    let io: Box<dyn ruster_dataplane::io::PacketIo> = match config.dataplane.backend.as_str() {
+        #[cfg(target_os = "linux")]
+        "afpacket" => {
+            let iface_map: Vec<(String, String)> = config
+                .interfaces
+                .iter()
+                .filter(|i| i.admin_up)
+                .map(|i| {
+                    let linux_name = i.linux_if.clone().unwrap_or_else(|| i.name.clone());
+                    (i.name.clone(), linux_name)
+                })
+                .collect();
+            match ruster_dataplane::afpacket::AfPacketIo::new(&iface_map) {
+                Ok(io) => {
+                    println!("  Backend: AF_PACKET ({} interfaces)", iface_map.len());
+                    Box::new(io)
+                }
+                Err(e) => {
+                    eprintln!("Error: AF_PACKET init failed: {}", e);
+                    process::exit(1);
+                }
+            }
+        }
+        _ => {
+            println!("  Backend: mock (no real I/O)");
+            Box::new(ruster_dataplane::io::MockPacketIo::new())
+        }
+    };
+
+    if let Err(e) = dataplane.run(shutdown, io) {
         eprintln!("Error: dataplane run failed: {}", e);
         process::exit(1);
     }

--- a/router.toml.example
+++ b/router.toml.example
@@ -19,6 +19,7 @@ mac = "02:00:00:00:10:01"
 ipv4_addrs = ["203.0.113.2/24"]
 zone = "wan"
 l2_domain = "bd-wan"
+# linux_if = "eth1"  # optional: map to Linux device name (for afpacket backend)
 
 [[interfaces]]
 name = "lan0"
@@ -30,6 +31,7 @@ mac = "02:00:00:00:20:01"
 ipv4_addrs = ["192.168.10.1/24"]
 zone = "lan"
 l2_domain = "bd-lan"
+# linux_if = "eth2"
 
 [[interfaces]]
 name = "lan1"

--- a/tests/containerlab/configs/ruster.toml
+++ b/tests/containerlab/configs/ruster.toml
@@ -10,7 +10,7 @@ schema = "ruster/v0.1"
 hostname = "ruster-e2e"
 
 [dataplane]
-backend = "dpdk"
+backend = "afpacket"
 lcore_list = "0-1"
 memory_mb = 512
 rx_queue_size = 256
@@ -26,6 +26,7 @@ mac = "02:00:00:00:01:01"
 ipv4_addrs = ["192.168.1.1/24"]
 zone = "lan"
 l2_domain = "bd-lan"
+linux_if = "eth1"
 
 [[interfaces]]
 name = "wan0"
@@ -37,6 +38,7 @@ mac = "02:00:00:00:02:01"
 ipv4_addrs = ["10.0.0.1/24"]
 zone = "wan"
 l2_domain = "bd-wan"
+linux_if = "eth2"
 
 [l2]
 mac_table_max_entries = 4096
@@ -50,6 +52,10 @@ bridge_domains = [
 
 [routing]
 ipv4_static_routes = [
+  # Directly connected subnets (L3Engine does not auto-generate these)
+  { prefix = "192.168.1.0/24", next_hop = "0.0.0.0", out_if = "lan0", metric = 1 },
+  { prefix = "10.0.0.0/24", next_hop = "0.0.0.0", out_if = "wan0", metric = 1 },
+  # Default route for internet-bound traffic
   { prefix = "0.0.0.0/0", next_hop = "10.0.0.100", out_if = "wan0", metric = 10 }
 ]
 
@@ -73,6 +79,7 @@ default_output = "accept"
 allow_established_related = true
 rules = [
   { name = "allow-lan-to-wan", chain = "forward", action = "accept", proto = "any", src_zone = "lan", dst_zone = "wan", state = ["new", "established", "related"] },
+  { name = "allow-wan-to-lan", chain = "forward", action = "accept", proto = "any", src_zone = "wan", dst_zone = "lan", state = ["new", "established", "related"] },
   { name = "allow-lan-input-icmp", chain = "input", action = "accept", proto = "icmp", src_zone = "lan", dst_zone = "any", state = ["new"] },
   { name = "block-wan-input", chain = "input", action = "drop", proto = "any", src_zone = "wan", dst_zone = "any", state = ["new"] }
 ]

--- a/tests/containerlab/scripts/check-ruster.sh
+++ b/tests/containerlab/scripts/check-ruster.sh
@@ -9,11 +9,11 @@
 #   0 — ruster is running and healthy
 #   1 — ruster is NOT running or failed to start
 #
-# Note (v0.1): ruster uses MockPacketIo and does not perform real NIC I/O.
-# Kernel IP forwarding handles actual packet forwarding in the E2E topology.
-# This check gates on ruster *process liveness* to ensure the binary is
-# functional and doesn't crash on startup. Future versions with real
-# dataplane I/O will additionally verify that forwarding goes through ruster.
+# ruster uses AF_PACKET raw sockets for real packet I/O.
+# Kernel IP forwarding is disabled (ip_forward=0) so that ruster
+# performs all packet forwarding. This check gates on:
+#   1. ruster process liveness
+#   2. kernel ip_forward=0 (ensures tests are valid)
 
 set -uo pipefail
 
@@ -89,9 +89,17 @@ for attempt in $(seq 1 "${MAX_RETRIES}"); do
             info "WARNING: /var/log/ruster.log not found yet (process may still be starting)"
         fi
 
+        # Verify kernel forwarding is disabled (ruster handles forwarding).
+        KERNEL_FWD=$(docker exec "${CONTAINER}" cat /proc/sys/net/ipv4/ip_forward 2>/dev/null || echo "unknown")
+        if [ "${KERNEL_FWD}" = "0" ]; then
+            info "Kernel ip_forward=0 (ruster handles forwarding)"
+        else
+            error "kernel ip_forward=${KERNEL_FWD} — expected 0; E2E tests may be invalid"
+            exit 1
+        fi
+
         echo ""
-        info "PASSED: ruster is running in ${CONTAINER}"
-        info "NOTE (v0.1): Kernel forwarding is active. ruster process liveness is the E2E gate."
+        info "PASSED: ruster is running in ${CONTAINER} with kernel forwarding disabled"
         exit 0
     fi
 

--- a/tests/containerlab/scripts/test-l3.sh
+++ b/tests/containerlab/scripts/test-l3.sh
@@ -115,6 +115,48 @@ else
     report "traceroute-hop" "FAIL"
 fi
 
+# Test 6: TTL decrement — verify ruster (not kernel) is forwarding
+# If ruster is forwarding, TTL should be decremented by 1 (64 -> 63).
+echo ""
+echo "-- Test 6: TTL decrement (lan-host -> wan-host, verify TTL=63) --"
+# Use ping with TTL=64 and check received TTL on wan-host via tcpdump.
+# Start a background tcpdump on wan-host to capture ICMP echo requests.
+TTL_OK=false
+if run_on wan-host which tcpdump > /dev/null 2>&1 || \
+   run_on wan-host bash -c "apt-get update -qq && apt-get install -y -qq tcpdump" > /dev/null 2>&1; then
+    # Capture one ICMP echo request on wan-host in background.
+    run_on wan-host bash -c "tcpdump -c 1 -n -v 'icmp and icmp[icmptype] == 8' -i eth1 > /tmp/ttl_cap.txt 2>&1 &"
+    sleep 1
+    # Send a single ping from lan-host to wan-host with explicit TTL=64.
+    run_on lan-host ping -c 1 -W 5 -t 64 10.0.0.100 > /dev/null 2>&1 || true
+    sleep 2
+    # Read the capture and check TTL.
+    TTL_CAP=$(run_on wan-host cat /tmp/ttl_cap.txt 2>/dev/null || echo "")
+    echo "  tcpdump output:"
+    echo "$TTL_CAP" | sed 's/^/    /'
+    if echo "$TTL_CAP" | grep -q "ttl 63"; then
+        TTL_OK=true
+        report "ttl-decrement" "PASS"
+    else
+        echo "  Expected ttl 63 (64 - 1 hop through ruster)"
+        report "ttl-decrement" "FAIL"
+    fi
+else
+    echo "  Skipping: tcpdump not available and could not install"
+    report "ttl-decrement" "FAIL"
+fi
+
+# Test 7: Verify kernel forwarding is disabled
+echo ""
+echo "-- Test 7: Kernel ip_forward=0 (ruster does the forwarding) --"
+KERNEL_FWD=$(run_on ruster cat /proc/sys/net/ipv4/ip_forward 2>/dev/null || echo "unknown")
+if [ "$KERNEL_FWD" = "0" ]; then
+    report "kernel-fwd-disabled" "PASS"
+else
+    echo "  ip_forward=${KERNEL_FWD}, expected 0"
+    report "kernel-fwd-disabled" "FAIL"
+fi
+
 # ── Summary ───────────────────────────────────────────
 
 echo ""

--- a/tests/containerlab/topology.yml
+++ b/tests/containerlab/topology.yml
@@ -23,27 +23,41 @@ topology:
         - ../../target/release/ruster:/usr/local/bin/ruster:ro
         - ./configs/ruster.toml:/etc/ruster/router.toml:ro
       exec:
+        # Install networking tools (bookworm-slim lacks iproute2/procps)
+        - bash -c "apt-get update -qq && apt-get install -y -qq iproute2 procps iputils-ping > /dev/null 2>&1"
+        # Set MAC addresses to match config (required for kernel ARP replies)
+        - ip link set eth1 address 02:00:00:00:01:01
+        - ip link set eth2 address 02:00:00:00:02:01
         - ip addr add 192.168.1.1/24 dev eth1
         - ip addr add 10.0.0.1/24 dev eth2
-        - sysctl -w net.ipv4.ip_forward=1
-        # Start ruster process in background.
-        # v0.1 uses MockPacketIo so kernel forwarding remains enabled;
-        # the E2E gate is ruster process liveness, not dataplane bypass.
+        # Disable kernel forwarding — ruster handles packet forwarding
+        - sysctl -w net.ipv4.ip_forward=0
+        # Start ruster process in background (AF_PACKET backend).
         - bash -c "nohup /usr/local/bin/ruster --config /etc/ruster/router.toml > /var/log/ruster.log 2>&1 &"
 
     lan-host:
       kind: linux
       image: debian:bookworm-slim
       exec:
+        - bash -c "apt-get update -qq && apt-get install -y -qq iproute2 iputils-ping > /dev/null 2>&1"
         - ip addr add 192.168.1.100/24 dev eth1
+        # Replace Docker's default route with one through ruster
+        - bash -c "ip route del default 2>/dev/null || true"
         - ip route add default via 192.168.1.1
+        # ARP warmup: let kernel resolve ruster's MAC before tests run
+        - bash -c "sleep 3 && ping -c 1 -W 2 192.168.1.1 || true"
 
     wan-host:
       kind: linux
       image: debian:bookworm-slim
       exec:
+        - bash -c "apt-get update -qq && apt-get install -y -qq iproute2 iputils-ping > /dev/null 2>&1"
         - ip addr add 10.0.0.100/24 dev eth1
-        - ip route add 192.168.1.0/24 via 10.0.0.1
+        # Replace Docker's default route with one through ruster (for return traffic)
+        - bash -c "ip route del default 2>/dev/null || true"
+        - ip route add default via 10.0.0.1
+        # ARP warmup: let kernel resolve ruster's MAC before tests run
+        - bash -c "sleep 3 && ping -c 1 -W 2 10.0.0.1 || true"
 
   links:
     - endpoints: ["ruster:eth1", "lan-host:eth1"]


### PR DESCRIPTION
## Summary

- Add `AfPacketIo` backend using Linux AF_PACKET raw sockets so ruster actually forwards packets (replaces `MockPacketIo`)
- Add packet rewrite module (TTL decrement, src/dst MAC rewriting) and wire into the forwarding run loop
- Fix pipeline L2/L3 punt decision, ARP resolution for directly connected routes, and containerlab topology issues
- E2E verified: L2 4/4 + L3 7/7 PASS with `ip_forward=0` (kernel forwarding disabled, ruster handles everything)

## Changes

| Area | Detail |
|------|--------|
| `afpacket.rs` | Per-interface AF_PACKET SOCK_RAW sockets, bound via `bind(sockaddr_ll)`, `PACKET_IGNORE_OUTGOING` |
| `rewrite.rs` | `rewrite_ipv4_ttl`, `rewrite_src_mac`, `rewrite_dst_mac` pure functions |
| `pipeline.rs` | `PipelineResult::Forward` extended with `new_ttl`/`next_hop`; `is_router_mac` check for transit routing punt |
| `lib.rs` | Packet rewrite in run loop, ARP cache pre-load from `/proc/net/arp` with 5s periodic refresh, directly connected route ARP resolution |
| `model.rs` | `linux_if: Option<String>` field on `InterfaceConfig` |
| `main.rs` | Backend selection: `"afpacket"` → `AfPacketIo`, else `MockPacketIo` |
| `topology.yml` | Delete Docker default route, install `iputils-ping` on ruster, `sleep 3` warmup |
| `ruster.toml` | Add connected routes (192.168.1.0/24, 10.0.0.0/24), add `allow-wan-to-lan` FW rule |
| `test-l3.sh` | Test 6: TTL decrement (ttl=63), Test 7: kernel `ip_forward=0` verification |

## Test plan

- [x] `cargo test --workspace` — all unit tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] containerlab E2E: L2 4/4 PASS, L3 7/7 PASS
- [x] TTL=63 confirmed via tcpdump (proves ruster, not kernel, is forwarding)
- [x] traceroute shows ruster (192.168.1.1) as intermediate hop

🤖 Generated with [Claude Code](https://claude.com/claude-code)