### PR TITLE
fix(ci): remove sudo from containerlab commands

### DIFF
--- a/.github/workflows/e2e-baseline.yml
+++ b/.github/workflows/e2e-baseline.yml
@@ -38,7 +38,7 @@ jobs:
         run: cargo build --release
 
       - name: Deploy containerlab topology
-        run: sudo containerlab deploy --topo tests/containerlab/topology.yml --name "$CLAB_TOPO_NAME"
+        run: containerlab deploy --topo tests/containerlab/topology.yml --name "$CLAB_TOPO_NAME"
 
       - name: Verify ruster is running
         run: bash tests/containerlab/scripts/check-ruster.sh
@@ -60,8 +60,8 @@ jobs:
           done
 
           echo "=== Topology inspect ==="
-          sudo containerlab inspect --name "$CLAB_TOPO_NAME" > "${LOG_DIR}/topology-inspect.txt" 2>&1 || true
-          sudo containerlab inspect --name "$CLAB_TOPO_NAME" || true
+          containerlab inspect --name "$CLAB_TOPO_NAME" > "${LOG_DIR}/topology-inspect.txt" 2>&1 || true
+          containerlab inspect --name "$CLAB_TOPO_NAME" || true
 
           echo "=== Docker ps ==="
           docker ps -a > "${LOG_DIR}/docker-ps.txt" 2>&1 || true
@@ -98,4 +98,4 @@ jobs:
 
       - name: Destroy topology
         if: always()
-        run: sudo containerlab destroy --name "$CLAB_TOPO_NAME" --cleanup
+        run: containerlab destroy --name "$CLAB_TOPO_NAME" --cleanup

--- a/.github/workflows/e2e-strict.yml
+++ b/.github/workflows/e2e-strict.yml
@@ -41,7 +41,7 @@ jobs:
         run: cargo build --release
 
       - name: Deploy containerlab topology
-        run: sudo containerlab deploy --topo tests/containerlab/topology.yml --name "$CLAB_TOPO_NAME"
+        run: containerlab deploy --topo tests/containerlab/topology.yml --name "$CLAB_TOPO_NAME"
 
       - name: Verify ruster is running
         run: bash tests/containerlab/scripts/check-ruster.sh
@@ -72,4 +72,4 @@ jobs:
 
       - name: Destroy topology
         if: always()
-        run: sudo containerlab destroy --name "$CLAB_TOPO_NAME" --cleanup
+        run: containerlab destroy --name "$CLAB_TOPO_NAME" --cleanup

--- a/.github/workflows/runner-health.yml
+++ b/.github/workflows/runner-health.yml
@@ -77,13 +77,13 @@ jobs:
           sed -i 's/^          //' "$TOPO_FILE"
 
           echo "=== Deploy smoke topology ==="
-          sudo containerlab deploy --topo "$TOPO_FILE"
+          containerlab deploy --topo "$TOPO_FILE"
 
           echo "=== Verify container running ==="
           docker ps --filter name=clab-health-check
 
           echo "=== Destroy smoke topology ==="
-          sudo containerlab destroy --topo "$TOPO_FILE" --cleanup
+          containerlab destroy --topo "$TOPO_FILE" --cleanup
 
           rm -f "$TOPO_FILE"
           echo "Smoke test passed."


### PR DESCRIPTION
## Summary

- `e2e-baseline.yml`、`e2e-strict.yml`、`runner-health.yml` の全 `sudo containerlab` を `containerlab` に変更
- containerlab は sudo なしで動作するため不要な権限昇格を除去

## Test plan

- [ ] `runner-health.yml` を `workflow_dispatch` で手動実行して containerlab の deploy/destroy が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)