### PR TITLE
feat(test): strict containerlab topology with kernel bypass elimination

### DIFF
--- a/.github/workflows/e2e-strict.yml
+++ b/.github/workflows/e2e-strict.yml
@@ -1,13 +1,16 @@
-# E2E Strict — Informational CI for NAT/FW validation
+# E2E Strict — Informational CI for dataplane-only forwarding validation
 #
-# Runs NAT and firewall E2E tests against the containerlab topology.
-# These tests require a real dataplane (not MockPacketIo), so they are
-# EXPECTED TO FAIL in v0.1. This workflow is non-blocking and exists
-# to track readiness for v0.2+.
+# Deploys a strict containerlab topology where kernel ip_forward=0 on all
+# nodes. Traffic can ONLY pass through the ruster dataplane. The test
+# validates:
+#   Phase 1: Without ruster → ping fails (no kernel bypass)
+#   Phase 2: With ruster    → ping succeeds (dataplane forwarding)
+#   Phase 3: Without ruster → ping fails again (confirms ruster was forwarding)
 #
-# See docs/ci-gates.md for gate definitions and promotion process.
+# This workflow is non-blocking (continue-on-error: true) and exists to
+# track dataplane readiness. See docs/ci-gates.md for gate definitions.
 
-name: E2E Strict (NAT/FW — informational)
+name: E2E Strict (dataplane-only — informational)
 
 on:
   push:
@@ -21,7 +24,7 @@ env:
 
 jobs:
   containerlab-e2e-strict:
-    name: E2E Strict (NAT + FW — expected-fail in v0.1)
+    name: E2E Strict (dataplane-only forwarding)
     runs-on: [self-hosted, linux, kvm]
     timeout-minutes: 30
     continue-on-error: true
@@ -40,29 +43,25 @@ jobs:
       - name: Build release binary
         run: cargo build --release
 
-      - name: Deploy containerlab topology
-        run: containerlab deploy --topo tests/containerlab/topology.yml --name "$CLAB_TOPO_NAME"
+      - name: Deploy strict containerlab topology
+        run: containerlab deploy --topo tests/containerlab/configs/strict.clab.yml --name "$CLAB_TOPO_NAME"
 
-      - name: Verify ruster is running
-        run: bash tests/containerlab/scripts/check-ruster.sh
+      - name: Wait for topology to settle
+        run: sleep 10
 
-      - name: Run E2E tests (NAT + FW strict)
-        run: E2E_SUITES=nat,fw bash tests/containerlab/scripts/run-all.sh
+      - name: Run strict setup (harden topology)
+        run: bash tests/containerlab/scripts/strict-setup.sh
 
-      - name: Collect logs on failure
+      - name: Run strict E2E tests (3-phase)
+        run: bash tests/containerlab/scripts/strict-test.sh
+
+      - name: Collect diagnostics on failure
         if: failure()
         run: |
-          LOG_DIR="/tmp/${CLAB_TOPO_NAME}-logs"
-          mkdir -p "$LOG_DIR"
+          export STRICT_LOG_DIR="/tmp/${CLAB_TOPO_NAME}-logs"
+          bash tests/containerlab/scripts/strict-diagnose.sh || true
 
-          for node in ruster lan-host wan-host; do
-            docker logs "clab-${CLAB_TOPO_NAME}-${node}" > "${LOG_DIR}/${node}.log" 2>&1 || true
-          done
-
-          docker exec "clab-${CLAB_TOPO_NAME}-ruster" cat /var/log/ruster.log > "${LOG_DIR}/ruster-app.log" 2>&1 || true
-          docker ps -a > "${LOG_DIR}/docker-ps.txt" 2>&1 || true
-
-      - name: Upload logs artifact
+      - name: Upload diagnostic logs
         if: failure()
         uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 .PHONY: worktree-start worktree-clean worktree-list
 .PHONY: team-start team-stop
 .PHONY: clab-deploy clab-test clab-destroy clab-e2e
+.PHONY: clab-strict-deploy clab-strict-test clab-strict-destroy clab-strict-e2e
 .PHONY: soak-test soak-test-short
 .PHONY: rfc-check rfc-registry
 
@@ -99,6 +100,27 @@ clab-destroy:
 	cd tests/containerlab && sudo containerlab destroy --name $(CLAB_TOPO_NAME) --cleanup
 
 clab-e2e: clab-test clab-destroy
+
+# ── Containerlab E2E Strict ──────────────────────────
+# Strict topology: kernel ip_forward=0 on all nodes.
+# Traffic only passes through the ruster dataplane.
+# Use CLAB_STRICT_NAME to override topology name.
+
+CLAB_STRICT_NAME ?= ruster-e2e-strict
+export CLAB_STRICT_NAME
+
+clab-strict-deploy:
+	cd tests/containerlab && sudo containerlab deploy --topo configs/strict.clab.yml --name $(CLAB_STRICT_NAME)
+	sleep 10
+	cd tests/containerlab && CLAB_TOPO_NAME=$(CLAB_STRICT_NAME) bash scripts/strict-setup.sh
+
+clab-strict-test: clab-strict-deploy
+	cd tests/containerlab && CLAB_TOPO_NAME=$(CLAB_STRICT_NAME) bash scripts/strict-test.sh
+
+clab-strict-destroy:
+	cd tests/containerlab && sudo containerlab destroy --name $(CLAB_STRICT_NAME) --cleanup
+
+clab-strict-e2e: clab-strict-test clab-strict-destroy
 
 # ── Soak Tests ────────────────────────────────────────
 

--- a/tests/containerlab/configs/strict.clab.yml
+++ b/tests/containerlab/configs/strict.clab.yml
@@ -1,0 +1,87 @@
+# ruster E2E strict test topology — containerlab (Linux kind)
+#
+# 3-node topology (same as baseline):
+#   lan-host  <--eth1-- ruster --eth2-->  wan-host
+#
+# STRICT MODE:
+#   - kernel ip_forward=0 on ALL nodes (client, server, ruster)
+#   - All kernel routes that might bypass ruster are flushed
+#   - ruster is NOT started automatically — the test script controls it
+#   - Traffic can ONLY pass when ruster dataplane is running
+#
+# This topology validates that ruster is the sole forwarding entity.
+# When ruster is stopped, no traffic should flow between lan-host and wan-host.
+#
+# Prerequisites:
+#   - Linux host with Docker
+#   - containerlab installed (https://containerlab.dev)
+#   - ruster binary built: cargo build --release
+#
+# Usage:
+#   sudo containerlab deploy --topo configs/strict.clab.yml --name <name>
+#   bash scripts/strict-test.sh
+#   sudo containerlab destroy --name <name> --cleanup
+
+name: ruster-e2e-strict
+
+topology:
+  nodes:
+    ruster:
+      kind: linux
+      image: debian:bookworm-slim
+      binds:
+        - ../../target/release/ruster:/usr/local/bin/ruster:ro
+        - ./configs/ruster.toml:/etc/ruster/router.toml:ro
+      exec:
+        # Install networking tools (bookworm-slim lacks iproute2/procps)
+        - bash -c "apt-get update -qq && apt-get install -y -qq iproute2 procps iputils-ping > /dev/null 2>&1"
+        # Set MAC addresses to match config (required for kernel ARP replies)
+        - ip link set eth1 address 02:00:00:00:01:01
+        - ip link set eth2 address 02:00:00:00:02:01
+        - ip addr add 192.168.1.1/24 dev eth1
+        - ip addr add 10.0.0.1/24 dev eth2
+        # STRICT: Disable kernel forwarding — only ruster handles forwarding
+        - sysctl -w net.ipv4.ip_forward=0
+        # STRICT: Flush any kernel routes that could bypass ruster
+        # Keep only directly-connected subnet routes (required for ARP)
+        - bash -c "ip route flush proto boot 2>/dev/null || true"
+        - bash -c "ip route flush proto static 2>/dev/null || true"
+        # STRICT: Do NOT start ruster here — strict-test.sh controls lifecycle
+
+    lan-host:
+      kind: linux
+      image: debian:bookworm-slim
+      exec:
+        - bash -c "apt-get update -qq && apt-get install -y -qq iproute2 iputils-ping > /dev/null 2>&1"
+        - ip addr add 192.168.1.100/24 dev eth1
+        # STRICT: Disable kernel forwarding on client too
+        - sysctl -w net.ipv4.ip_forward=0
+        # Replace Docker's default route with one through ruster
+        - bash -c "ip route del default 2>/dev/null || true"
+        - ip route add default via 192.168.1.1
+        # Flush any extra routes that might bypass ruster
+        - bash -c "ip route flush proto boot 2>/dev/null || true"
+        - bash -c "ip route flush proto static 2>/dev/null || true"
+        # Re-add default via ruster (in case flush removed it)
+        - bash -c "ip route replace default via 192.168.1.1 || true"
+
+    wan-host:
+      kind: linux
+      image: debian:bookworm-slim
+      exec:
+        - bash -c "apt-get update -qq && apt-get install -y -qq iproute2 iputils-ping > /dev/null 2>&1"
+        - ip addr add 10.0.0.100/24 dev eth1
+        # STRICT: Disable kernel forwarding on server too
+        - sysctl -w net.ipv4.ip_forward=0
+        # Replace Docker's default route with one through ruster
+        - bash -c "ip route del default 2>/dev/null || true"
+        - ip route add default via 10.0.0.1
+        # Flush any extra routes that might bypass ruster
+        - bash -c "ip route flush proto boot 2>/dev/null || true"
+        - bash -c "ip route flush proto static 2>/dev/null || true"
+        # Re-add default via ruster (in case flush removed it)
+        - bash -c "ip route replace default via 10.0.0.1 || true"
+
+  links:
+    - endpoints: ["ruster:eth1", "lan-host:eth1"]
+    - endpoints: ["ruster:eth2", "wan-host:eth1"]

--- a/tests/containerlab/scripts/strict-diagnose.sh
+++ b/tests/containerlab/scripts/strict-diagnose.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+# strict-diagnose.sh — Collect diagnostic logs from all strict topology nodes
+#
+# Gathers networking state, ruster logs, and process information from all
+# nodes in the strict topology. Output is saved to a timestamped directory.
+#
+# Environment variables:
+#   CLAB_TOPO_NAME  — Containerlab topology name (default: ruster-e2e-strict)
+#   STRICT_LOG_DIR  — Override output directory (default: /tmp/ruster-strict-diag-<timestamp>)
+#
+# Usage:
+#   bash scripts/strict-diagnose.sh
+#
+# Output:
+#   Diagnostic files are saved to $STRICT_LOG_DIR/ with one file per node
+#   plus a summary file.
+
+set -uo pipefail
+
+TOPO_NAME="${CLAB_TOPO_NAME:-ruster-e2e-strict}"
+PREFIX="clab-${TOPO_NAME}"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+LOG_DIR="${STRICT_LOG_DIR:-/tmp/ruster-strict-diag-${TIMESTAMP}}"
+
+# ── Helpers ───────────────────────────────────────────
+
+info()  { echo "[strict-diagnose] $*"; }
+error() { echo "[strict-diagnose] ERROR: $*" >&2; }
+
+run_on() {
+    local node="$1"; shift
+    docker exec "${PREFIX}-${node}" "$@" 2>&1 || echo "(command failed)"
+}
+
+# ── Create output directory ──────────────────────────
+
+mkdir -p "$LOG_DIR"
+info "Collecting diagnostics to: ${LOG_DIR}"
+
+# ── Collect from each node ───────────────────────────
+
+NODES=("ruster" "lan-host" "wan-host")
+
+for node in "${NODES[@]}"; do
+    NODE_LOG="${LOG_DIR}/${node}.log"
+    info "Collecting from ${node}..."
+
+    {
+        echo "========================================"
+        echo "  Diagnostics: ${node}"
+        echo "  Timestamp: $(date -Iseconds)"
+        echo "  Container: ${PREFIX}-${node}"
+        echo "========================================"
+        echo ""
+
+        echo "--- Container state ---"
+        docker inspect --format '{{.State.Status}}' "${PREFIX}-${node}" 2>&1 || echo "(not found)"
+        echo ""
+
+        echo "--- sysctl net.ipv4.ip_forward ---"
+        run_on "$node" cat /proc/sys/net/ipv4/ip_forward
+        echo ""
+
+        echo "--- ip addr show ---"
+        run_on "$node" ip addr show
+        echo ""
+
+        echo "--- ip route show ---"
+        run_on "$node" ip route show
+        echo ""
+
+        echo "--- ip neigh show (ARP table) ---"
+        run_on "$node" ip neigh show
+        echo ""
+
+        echo "--- iptables -L -n -v ---"
+        run_on "$node" iptables -L -n -v
+        echo ""
+
+        echo "--- iptables -t nat -L -n -v ---"
+        run_on "$node" iptables -t nat -L -n -v
+        echo ""
+
+        echo "--- Process list ---"
+        run_on "$node" ps aux
+        echo ""
+
+    } > "$NODE_LOG" 2>&1
+
+    info "  Saved: ${NODE_LOG}"
+done
+
+# ── Collect ruster-specific logs ─────────────────────
+
+RUSTER_LOG="${LOG_DIR}/ruster-app.log"
+info "Collecting ruster application log..."
+
+{
+    echo "========================================"
+    echo "  ruster application log"
+    echo "  Timestamp: $(date -Iseconds)"
+    echo "========================================"
+    echo ""
+    run_on ruster cat /var/log/ruster.log
+} > "$RUSTER_LOG" 2>&1
+
+info "  Saved: ${RUSTER_LOG}"
+
+# ── Collect docker logs ──────────────────────────────
+
+for node in "${NODES[@]}"; do
+    DOCKER_LOG="${LOG_DIR}/${node}-docker.log"
+    docker logs "${PREFIX}-${node}" > "$DOCKER_LOG" 2>&1 || true
+    info "  Docker logs: ${DOCKER_LOG}"
+done
+
+# ── Collect docker ps ────────────────────────────────
+
+DOCKER_PS="${LOG_DIR}/docker-ps.txt"
+docker ps -a > "$DOCKER_PS" 2>&1 || true
+info "  Docker ps: ${DOCKER_PS}"
+
+# ── Summary ──────────────────────────────────────────
+
+SUMMARY="${LOG_DIR}/summary.txt"
+{
+    echo "========================================"
+    echo "  Strict Diagnostic Summary"
+    echo "  Timestamp: $(date -Iseconds)"
+    echo "  Topology: ${TOPO_NAME}"
+    echo "========================================"
+    echo ""
+
+    echo "--- ip_forward status ---"
+    for node in "${NODES[@]}"; do
+        fwd=$(run_on "$node" cat /proc/sys/net/ipv4/ip_forward 2>/dev/null || echo "unknown")
+        echo "  ${node}: ip_forward=${fwd}"
+    done
+    echo ""
+
+    echo "--- ruster process ---"
+    if docker exec "${PREFIX}-ruster" pgrep -x ruster > /dev/null 2>&1; then
+        pid=$(docker exec "${PREFIX}-ruster" pgrep -x ruster 2>/dev/null)
+        echo "  ruster is running (PID: ${pid})"
+    else
+        echo "  ruster is NOT running"
+    fi
+    echo ""
+
+    echo "--- Routing tables ---"
+    for node in "${NODES[@]}"; do
+        echo "  [${node}]"
+        run_on "$node" ip route show 2>/dev/null | sed 's/^/    /'
+        echo ""
+    done
+
+    echo "--- ARP tables ---"
+    for node in "${NODES[@]}"; do
+        echo "  [${node}]"
+        run_on "$node" ip neigh show 2>/dev/null | sed 's/^/    /'
+        echo ""
+    done
+
+} > "$SUMMARY" 2>&1
+
+info "  Summary: ${SUMMARY}"
+info ""
+info "Diagnostic collection complete."
+info "Files saved to: ${LOG_DIR}"
+ls -la "$LOG_DIR" | sed 's/^/  /'

--- a/tests/containerlab/scripts/strict-setup.sh
+++ b/tests/containerlab/scripts/strict-setup.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# strict-setup.sh — Post-deploy hardening for the strict E2E topology
+#
+# Ensures that kernel IP forwarding is disabled on all nodes and that
+# no bypass routes exist. This script is idempotent and can be run
+# multiple times safely.
+#
+# Environment variables:
+#   CLAB_TOPO_NAME  — Containerlab topology name (default: ruster-e2e-strict)
+#
+# Usage:
+#   bash scripts/strict-setup.sh
+
+set -euo pipefail
+
+TOPO_NAME="${CLAB_TOPO_NAME:-ruster-e2e-strict}"
+PREFIX="clab-${TOPO_NAME}"
+
+# ── Helpers ───────────────────────────────────────────
+
+info()  { echo "[strict-setup] $*"; }
+error() { echo "[strict-setup] ERROR: $*" >&2; }
+
+run_on() {
+    local node="$1"; shift
+    docker exec "${PREFIX}-${node}" "$@"
+}
+
+# ── Step 1: Disable kernel forwarding on all nodes ───
+
+info "Disabling kernel ip_forward on all nodes..."
+
+for node in ruster lan-host wan-host; do
+    current=$(run_on "$node" cat /proc/sys/net/ipv4/ip_forward 2>/dev/null || echo "unknown")
+    if [ "$current" = "0" ]; then
+        info "  ${node}: ip_forward already 0"
+    else
+        run_on "$node" sysctl -w net.ipv4.ip_forward=0 > /dev/null 2>&1
+        info "  ${node}: ip_forward set to 0 (was ${current})"
+    fi
+done
+
+# ── Step 2: Flush kernel bypass routes on ruster ─────
+
+info "Flushing kernel bypass routes on ruster..."
+
+# Remove any default routes on ruster that the kernel might use
+run_on ruster bash -c "ip route del default 2>/dev/null || true"
+# Flush boot/static protocol routes (keep connected subnets)
+run_on ruster bash -c "ip route flush proto boot 2>/dev/null || true"
+run_on ruster bash -c "ip route flush proto static 2>/dev/null || true"
+
+info "  ruster routes after flush:"
+run_on ruster ip route show 2>/dev/null | sed 's/^/    /'
+
+# ── Step 3: Verify client/server routing ─────────────
+
+info "Verifying client/server routes point to ruster as gateway..."
+
+# lan-host should only have: 192.168.1.0/24 dev eth1 + default via 192.168.1.1
+LAN_DEFAULT=$(run_on lan-host ip route show default 2>/dev/null || echo "")
+if echo "$LAN_DEFAULT" | grep -q "192.168.1.1"; then
+    info "  lan-host: default via 192.168.1.1 (OK)"
+else
+    info "  lan-host: setting default route via 192.168.1.1"
+    run_on lan-host bash -c "ip route del default 2>/dev/null || true"
+    run_on lan-host ip route add default via 192.168.1.1
+fi
+
+# wan-host should only have: 10.0.0.0/24 dev eth1 + default via 10.0.0.1
+WAN_DEFAULT=$(run_on wan-host ip route show default 2>/dev/null || echo "")
+if echo "$WAN_DEFAULT" | grep -q "10.0.0.1"; then
+    info "  wan-host: default via 10.0.0.1 (OK)"
+else
+    info "  wan-host: setting default route via 10.0.0.1"
+    run_on wan-host bash -c "ip route del default 2>/dev/null || true"
+    run_on wan-host ip route add default via 10.0.0.1
+fi
+
+# ── Step 4: Verify no bypass paths ──────────────────
+
+info "Verifying no bypass paths exist..."
+
+BYPASS_FOUND=false
+
+# Check that ruster has no default route (it should only forward via dataplane)
+if run_on ruster ip route show default 2>/dev/null | grep -q "default"; then
+    error "ruster has a kernel default route — this is a bypass path!"
+    run_on ruster ip route show default 2>/dev/null | sed 's/^/    /'
+    BYPASS_FOUND=true
+fi
+
+# Check kernel forwarding is truly disabled
+for node in ruster lan-host wan-host; do
+    fwd=$(run_on "$node" cat /proc/sys/net/ipv4/ip_forward 2>/dev/null || echo "unknown")
+    if [ "$fwd" != "0" ]; then
+        error "${node}: ip_forward=${fwd} (expected 0) — bypass risk!"
+        BYPASS_FOUND=true
+    fi
+done
+
+if [ "$BYPASS_FOUND" = true ]; then
+    error "Bypass paths detected. Strict mode is not properly configured."
+    exit 1
+fi
+
+info ""
+info "Strict setup complete. All bypass paths eliminated."
+info "  - ip_forward=0 on all nodes"
+info "  - No kernel default route on ruster"
+info "  - Client/server routes point to ruster as gateway"
+exit 0

--- a/tests/containerlab/scripts/strict-test.sh
+++ b/tests/containerlab/scripts/strict-test.sh
@@ -1,0 +1,259 @@
+#!/bin/bash
+# strict-test.sh — Strict E2E test: verify ruster is the sole forwarding entity
+#
+# Three-phase test:
+#   Phase 1: WITHOUT ruster running -> ping MUST FAIL (proves no kernel bypass)
+#   Phase 2: START ruster           -> ping MUST SUCCEED (ruster forwarding works)
+#   Phase 3: STOP ruster            -> ping MUST FAIL (proves ruster was forwarding)
+#
+# Each phase with clear pass/fail output.
+# On failure: calls strict-diagnose.sh to collect diagnostic logs.
+#
+# Environment variables:
+#   CLAB_TOPO_NAME  — Containerlab topology name (default: ruster-e2e-strict)
+#   STRICT_PING_COUNT   — Number of pings per test (default: 3)
+#   STRICT_PING_TIMEOUT — Ping timeout in seconds (default: 3)
+#   STRICT_SETTLE_TIME  — Seconds to wait after starting/stopping ruster (default: 5)
+#
+# Usage:
+#   bash scripts/strict-test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TOPO_NAME="${CLAB_TOPO_NAME:-ruster-e2e-strict}"
+PREFIX="clab-${TOPO_NAME}"
+PING_COUNT="${STRICT_PING_COUNT:-3}"
+PING_TIMEOUT="${STRICT_PING_TIMEOUT:-3}"
+SETTLE_TIME="${STRICT_SETTLE_TIME:-5}"
+
+PASS=0
+FAIL=0
+ERRORS=""
+
+# ── Helpers ───────────────────────────────────────────
+
+info()  { echo "[strict-test] $*"; }
+error() { echo "[strict-test] ERROR: $*" >&2; }
+
+run_on() {
+    local node="$1"; shift
+    docker exec "${PREFIX}-${node}" "$@"
+}
+
+report() {
+    local name="$1" result="$2"
+    if [ "$result" = "PASS" ]; then
+        PASS=$((PASS + 1))
+        echo "  [PASS] ${name}"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS="${ERRORS}  - ${name}\n"
+        echo "  [FAIL] ${name}"
+    fi
+}
+
+collect_diagnostics() {
+    info "Collecting diagnostics..."
+    if [ -f "${SCRIPT_DIR}/strict-diagnose.sh" ]; then
+        bash "${SCRIPT_DIR}/strict-diagnose.sh" || true
+    else
+        error "strict-diagnose.sh not found; skipping diagnostics"
+    fi
+}
+
+# Ping from lan-host to wan-host (cross-subnet, requires forwarding)
+ping_through_ruster() {
+    run_on lan-host ping -c "$PING_COUNT" -W "$PING_TIMEOUT" 10.0.0.100 > /dev/null 2>&1
+}
+
+# ── Pre-flight checks ────────────────────────────────
+
+info "================================================================"
+info "  Strict E2E Test"
+info "  Topology: ${TOPO_NAME}"
+info "================================================================"
+info ""
+
+# Verify containers are running
+for node in ruster lan-host wan-host; do
+    STATE=$(docker inspect --format '{{.State.Status}}' "${PREFIX}-${node}" 2>/dev/null || echo "not_found")
+    if [ "$STATE" != "running" ]; then
+        error "Container ${PREFIX}-${node} is not running (state: ${STATE})"
+        exit 1
+    fi
+done
+info "All containers are running."
+
+# Run strict setup to harden the topology
+info "Running strict setup..."
+if ! bash "${SCRIPT_DIR}/strict-setup.sh"; then
+    error "Strict setup failed. Cannot proceed."
+    collect_diagnostics
+    exit 1
+fi
+
+# ── Phase 1: WITHOUT ruster — ping MUST FAIL ────────
+
+info ""
+info "================================================================"
+info "  Phase 1: Ruster NOT running — ping MUST FAIL"
+info "================================================================"
+info ""
+
+# Ensure ruster is NOT running
+run_on ruster bash -c "pkill -x ruster 2>/dev/null || true"
+sleep 2
+
+# Verify ruster is not running
+if run_on ruster pgrep -x ruster > /dev/null 2>&1; then
+    error "ruster is still running after pkill — cannot validate strict mode"
+    report "phase1-ruster-stopped" "FAIL"
+    collect_diagnostics
+else
+    report "phase1-ruster-stopped" "PASS"
+fi
+
+# Verify kernel forwarding is disabled
+KERNEL_FWD=$(run_on ruster cat /proc/sys/net/ipv4/ip_forward 2>/dev/null || echo "unknown")
+if [ "$KERNEL_FWD" = "0" ]; then
+    report "phase1-kernel-fwd-disabled" "PASS"
+else
+    error "kernel ip_forward=${KERNEL_FWD} (expected 0)"
+    report "phase1-kernel-fwd-disabled" "FAIL"
+fi
+
+# Ping MUST fail (no forwarding path exists)
+info "Testing cross-subnet ping (should FAIL)..."
+if ping_through_ruster; then
+    error "Ping SUCCEEDED without ruster — kernel bypass detected!"
+    report "phase1-no-bypass" "FAIL"
+    collect_diagnostics
+else
+    info "Ping failed as expected (no forwarding path)."
+    report "phase1-no-bypass" "PASS"
+fi
+
+# ── Phase 2: START ruster — ping MUST SUCCEED ───────
+
+info ""
+info "================================================================"
+info "  Phase 2: Start ruster — ping MUST SUCCEED"
+info "================================================================"
+info ""
+
+# Start ruster in background
+info "Starting ruster..."
+run_on ruster bash -c "nohup /usr/local/bin/ruster --config /etc/ruster/router.toml > /var/log/ruster.log 2>&1 &"
+
+# Wait for ruster to initialize
+info "Waiting ${SETTLE_TIME}s for ruster to initialize..."
+sleep "$SETTLE_TIME"
+
+# Verify ruster started
+if run_on ruster pgrep -x ruster > /dev/null 2>&1; then
+    RUSTER_PID=$(run_on ruster pgrep -x ruster 2>/dev/null)
+    info "ruster is running (PID: ${RUSTER_PID})"
+    report "phase2-ruster-started" "PASS"
+else
+    error "ruster failed to start"
+    info "ruster log:"
+    run_on ruster cat /var/log/ruster.log 2>/dev/null | sed 's/^/    /' || true
+    report "phase2-ruster-started" "FAIL"
+    collect_diagnostics
+fi
+
+# ARP warmup: resolve ruster's MAC on client/server
+info "ARP warmup (resolving ruster's MAC addresses)..."
+run_on lan-host ping -c 1 -W 2 192.168.1.1 > /dev/null 2>&1 || true
+run_on wan-host ping -c 1 -W 2 10.0.0.1 > /dev/null 2>&1 || true
+sleep 2
+
+# Ping MUST succeed (ruster is forwarding)
+info "Testing cross-subnet ping (should SUCCEED)..."
+if ping_through_ruster; then
+    info "Ping succeeded — ruster is forwarding traffic."
+    report "phase2-forwarding-works" "PASS"
+else
+    error "Ping FAILED with ruster running"
+    info "Diagnostic: ping verbose output:"
+    run_on lan-host ping -c "$PING_COUNT" -W "$PING_TIMEOUT" 10.0.0.100 2>&1 | sed 's/^/    /' || true
+    report "phase2-forwarding-works" "FAIL"
+    collect_diagnostics
+fi
+
+# Verify kernel forwarding is still disabled (ruster does forwarding, not kernel)
+KERNEL_FWD=$(run_on ruster cat /proc/sys/net/ipv4/ip_forward 2>/dev/null || echo "unknown")
+if [ "$KERNEL_FWD" = "0" ]; then
+    report "phase2-kernel-fwd-still-disabled" "PASS"
+else
+    error "kernel ip_forward=${KERNEL_FWD} — ruster may have enabled kernel forwarding"
+    report "phase2-kernel-fwd-still-disabled" "FAIL"
+fi
+
+# ── Phase 3: STOP ruster — ping MUST FAIL ───────────
+
+info ""
+info "================================================================"
+info "  Phase 3: Stop ruster — ping MUST FAIL"
+info "================================================================"
+info ""
+
+# Stop ruster
+info "Stopping ruster..."
+run_on ruster bash -c "pkill -x ruster 2>/dev/null || true"
+sleep "$SETTLE_TIME"
+
+# Verify ruster stopped
+if run_on ruster pgrep -x ruster > /dev/null 2>&1; then
+    error "ruster is still running after pkill"
+    # Force kill
+    run_on ruster bash -c "pkill -9 -x ruster 2>/dev/null || true"
+    sleep 2
+    if run_on ruster pgrep -x ruster > /dev/null 2>&1; then
+        report "phase3-ruster-stopped" "FAIL"
+    else
+        info "ruster killed with SIGKILL"
+        report "phase3-ruster-stopped" "PASS"
+    fi
+else
+    info "ruster stopped successfully."
+    report "phase3-ruster-stopped" "PASS"
+fi
+
+# Ping MUST fail again (no forwarding path exists)
+info "Testing cross-subnet ping (should FAIL)..."
+if ping_through_ruster; then
+    error "Ping SUCCEEDED without ruster — indicates kernel bypass or stale state!"
+    report "phase3-no-bypass" "FAIL"
+    collect_diagnostics
+else
+    info "Ping failed as expected (forwarding stopped with ruster)."
+    report "phase3-no-bypass" "PASS"
+fi
+
+# ── Summary ──────────────────────────────────────────
+
+TOTAL=$((PASS + FAIL))
+
+info ""
+info "================================================================"
+info "  Strict E2E Test Summary"
+info "================================================================"
+info ""
+echo "  Phase 1 (no ruster):   ping must fail   — validates no kernel bypass"
+echo "  Phase 2 (ruster up):   ping must succeed — validates ruster forwarding"
+echo "  Phase 3 (ruster down): ping must fail   — validates ruster was forwarding"
+echo ""
+echo "  Tests: ${TOTAL} ran, ${PASS} passed, ${FAIL} failed"
+echo ""
+
+if [ "$FAIL" -gt 0 ]; then
+    echo "  Failed tests:"
+    echo -e "$ERRORS"
+    echo "RESULT: FAIL"
+    exit 1
+else
+    echo "RESULT: PASS"
+    exit 0
+fi


### PR DESCRIPTION
## Summary
- Add strict-mode containerlab topology (`configs/strict.clab.yml`) where kernel `ip_forward=0` on all nodes, ensuring traffic can ONLY pass through the ruster dataplane
- Implement 3-phase test (`strict-test.sh`): (1) no ruster -> ping fails, (2) start ruster -> ping succeeds, (3) stop ruster -> ping fails again
- Add post-deploy hardening script (`strict-setup.sh`) that flushes kernel bypass routes and verifies no forwarding paths exist
- Add automated diagnostic log collector (`strict-diagnose.sh`) for failure analysis
- Rewire `e2e-strict.yml` workflow to use the new strict topology and 3-phase test
- Add Makefile targets: `clab-strict-deploy`, `clab-strict-test`, `clab-strict-destroy`, `clab-strict-e2e`

## Completion Criteria (from #152)
- [x] dataplane停止時は strict E2E が fail (Phase 1 & Phase 3)
- [x] dataplane稼働時のみ strict E2E が pass (Phase 2)
- [x] 失敗時診断ログを自動収集 (`strict-diagnose.sh` + CI artifact upload)

## Test plan
- [ ] Deploy strict topology: `make clab-strict-deploy`
- [ ] Run strict test: `make clab-strict-test` (verify 3-phase pass/fail pattern)
- [ ] Verify Phase 1 fails without ruster running
- [ ] Verify Phase 2 passes with ruster running
- [ ] Verify Phase 3 fails after ruster stopped
- [ ] Verify diagnostic logs are collected on failure
- [ ] Tear down: `make clab-strict-destroy`
- [ ] CI workflow runs on PR

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)