### PR TITLE
ci: add concurrency settings to all GitHub Actions workflows

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -11,6 +11,10 @@ on:
   # pull_request:
   #   branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings

--- a/.github/workflows/e2e-baseline.yml
+++ b/.github/workflows/e2e-baseline.yml
@@ -15,6 +15,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/e2e-strict.yml
+++ b/.github/workflows/e2e-strict.yml
@@ -19,6 +19,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/rfc-check.yml
+++ b/.github/workflows/rfc-check.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   rfc-check:
     name: RFC-DEVIATION validation

--- a/.github/workflows/runner-health.yml
+++ b/.github/workflows/runner-health.yml
@@ -6,6 +6,10 @@ on:
     - cron: "0 9 * * 1"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   health-check:
     name: Self-hosted Runner Health

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -32,6 +32,10 @@ on:
         default: "30"
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
## Summary
- Add `concurrency` settings to all 7 GitHub Actions workflow files
- PR-triggered workflows (ci, e2e-baseline, e2e-strict, rfc-check, bench) use `cancel-in-progress: true` to free runners when newer commits are pushed
- Schedule-only workflows (soak, runner-health) use concurrency groups without cancellation to prevent overlapping runs

## Test plan
- [ ] Verify CI workflows pass with the new concurrency settings
- [ ] Push two commits in quick succession to confirm old runs are cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)