### PR TITLE
feat(core): add an in-place ARP responder

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ active treeは、そのコードを継承しないv0.2のゼロベース実装�
 この最初の縦切りは、外部依存を持たない二つのlibrary crateだけで構成します。
 
 - `ruster-core`: backend所有packetを借用し、Ethernet II / IPv4検証、LPM、
-  TTL/checksum/MAC rewriteを行う。
+  TTL/checksum/MAC rewriteとlocal IPv4向けARP replyを行う。
 - `ruster-io-sim`: rootやNICなしでFIFO、budget、TX/drop、traceを決定的に検証する。
 
 ```text
@@ -24,6 +24,8 @@ sim RX slot ──borrow──► ruster-core ──commit──► sim TX slot
 
 fast pathはpacket batchをworkerが専有します。共有`Mutex`、packet単位の`String`、
 packet clone、`dyn PacketIo`を導入しません。simの`Vec`はcold I/O境界に閉じています。
+ARP replyも同じRX bufferをin-placeで書き換え、受信interfaceへcommitします。現在の
+ARP profileはinterfaceごとにlocal IPv4を一つだけ持つ静的snapshotです。
 
 ## 開発
 

--- a/crates/core/src/forwarding.rs
+++ b/crates/core/src/forwarding.rs
@@ -1,6 +1,6 @@
 use crate::{
-    rfc1624_update, route, validate_ipv4_frame, BatchCompletion, IfId, Interface, Neighbor,
-    PacketBatch, Route,
+    packet, rfc1624_update, route, validate_arp_request, validate_ipv4_frame, BatchCompletion,
+    IfId, Interface, LocalIpv4Binding, Neighbor, PacketBatch, Route, ARP_ETHERTYPE, IPV4_ETHERTYPE,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -21,6 +21,14 @@ pub enum DropReason {
     RouteMiss = 12,
     NeighborUnresolved = 13,
     InterfaceMiss = 14,
+    ArpPacketTruncated = 15,
+    ArpHardwareTypeUnsupported = 16,
+    ArpProtocolTypeUnsupported = 17,
+    ArpHardwareLengthUnsupported = 18,
+    ArpProtocolLengthUnsupported = 19,
+    ArpReplyUnsupported = 20,
+    ArpOpcodeUnsupported = 21,
+    ArpTargetNotLocal = 22,
 }
 
 use DropReason::*;
@@ -43,6 +51,14 @@ impl DropReason {
             RouteMiss => "ROUTE_MISS",
             NeighborUnresolved => "NEIGHBOR_UNRESOLVED",
             InterfaceMiss => "INTERFACE_MISS",
+            ArpPacketTruncated => "ARP_PACKET_TRUNCATED",
+            ArpHardwareTypeUnsupported => "ARP_HARDWARE_TYPE_UNSUPPORTED",
+            ArpProtocolTypeUnsupported => "ARP_PROTOCOL_TYPE_UNSUPPORTED",
+            ArpHardwareLengthUnsupported => "ARP_HARDWARE_LENGTH_UNSUPPORTED",
+            ArpProtocolLengthUnsupported => "ARP_PROTOCOL_LENGTH_UNSUPPORTED",
+            ArpReplyUnsupported => "ARP_REPLY_UNSUPPORTED",
+            ArpOpcodeUnsupported => "ARP_OPCODE_UNSUPPORTED",
+            ArpTargetNotLocal => "ARP_TARGET_NOT_LOCAL",
         }
     }
 }
@@ -54,6 +70,8 @@ pub enum SnapshotError {
     DuplicateNeighbor,
     RouteUnknownInterface,
     NeighborUnknownInterface,
+    DuplicateLocalIpv4Binding,
+    LocalIpv4BindingUnknownInterface,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -61,6 +79,7 @@ pub struct ForwardingSnapshot<'a> {
     routes: &'a [Route],
     interfaces: &'a [Interface],
     neighbors: &'a [Neighbor],
+    local_ipv4: &'a [LocalIpv4Binding],
 }
 
 impl<'a> ForwardingSnapshot<'a> {
@@ -68,6 +87,7 @@ impl<'a> ForwardingSnapshot<'a> {
         routes: &'a [Route],
         interfaces: &'a [Interface],
         neighbors: &'a [Neighbor],
+        local_ipv4: &'a [LocalIpv4Binding],
     ) -> Result<Self, SnapshotError> {
         for (index, route) in routes.iter().enumerate() {
             if routes[..index].iter().any(|candidate| {
@@ -103,19 +123,38 @@ impl<'a> ForwardingSnapshot<'a> {
                 return Err(SnapshotError::NeighborUnknownInterface);
             }
         }
+        for (index, binding) in local_ipv4.iter().enumerate() {
+            if local_ipv4[..index].iter().any(|candidate| {
+                candidate.interface == binding.interface || candidate.address == binding.address
+            }) {
+                return Err(SnapshotError::DuplicateLocalIpv4Binding);
+            }
+            if !interfaces
+                .iter()
+                .any(|interface| interface.id == binding.interface)
+            {
+                return Err(SnapshotError::LocalIpv4BindingUnknownInterface);
+            }
+        }
         Ok(Self {
             routes,
             interfaces,
             neighbors,
+            local_ipv4,
         })
     }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TraceEvent {
-    Validated {
+    Ipv4Validated {
         ingress: IfId,
         destination: crate::Ipv4Address,
+    },
+    ArpRequestValidated {
+        ingress: IfId,
+        sender_protocol: crate::Ipv4Address,
+        target_protocol: crate::Ipv4Address,
     },
     Routed {
         egress: IfId,
@@ -124,6 +163,10 @@ pub enum TraceEvent {
     /// The packet was handed to the backend, not necessarily accepted by TX.
     TxRequested {
         egress: IfId,
+    },
+    ArpReplyRequested {
+        egress: IfId,
+        target_protocol: crate::Ipv4Address,
     },
     Dropped {
         ingress: IfId,
@@ -159,7 +202,7 @@ pub struct BatchReport<E> {
 }
 
 #[derive(Clone, Copy)]
-struct RewriteDecision {
+struct Ipv4RewriteDecision {
     egress: IfId,
     source_mac: [u8; 6],
     destination_mac: [u8; 6],
@@ -169,6 +212,30 @@ struct RewriteDecision {
     old_ttl_protocol: u16,
     new_ttl_protocol: u16,
     old_checksum: u16,
+}
+
+#[derive(Clone, Copy)]
+struct ArpReplyDecision {
+    egress: IfId,
+    local_mac: [u8; 6],
+    requester_mac: [u8; 6],
+    requester_protocol: [u8; 4],
+    local_protocol: [u8; 4],
+}
+
+#[derive(Clone, Copy)]
+enum PacketDecision {
+    Ipv4(Ipv4RewriteDecision),
+    ArpReply(ArpReplyDecision),
+}
+
+impl PacketDecision {
+    const fn egress(self) -> IfId {
+        match self {
+            Self::Ipv4(decision) => decision.egress,
+            Self::ArpReply(decision) => decision.egress,
+        }
+    }
 }
 
 pub fn forward_batch<B, T>(
@@ -189,15 +256,20 @@ where
         let result = {
             let frame = packet.bytes_mut();
             decide(&*frame, snapshot, ingress, trace)
-                .and_then(|decision| apply_rewrite(frame, decision).map(|()| decision))
+                .and_then(|decision| apply_decision(frame, decision).map(|()| decision))
         };
         match result {
             Ok(decision) => {
-                packet.commit(decision.egress);
+                let egress = decision.egress();
+                packet.commit(egress);
                 tx_requested += 1;
-                trace.record(TraceEvent::TxRequested {
-                    egress: decision.egress,
-                });
+                if let PacketDecision::ArpReply(arp) = decision {
+                    trace.record(TraceEvent::ArpReplyRequested {
+                        egress,
+                        target_protocol: crate::Ipv4Address::from_octets(arp.requester_protocol),
+                    });
+                }
+                trace.record(TraceEvent::TxRequested { egress });
             }
             Err(reason) => {
                 packet.recycle(reason);
@@ -224,9 +296,23 @@ fn decide<T: TraceSink>(
     snapshot: &ForwardingSnapshot<'_>,
     ingress: IfId,
     trace: &mut T,
-) -> Result<RewriteDecision, DropReason> {
+) -> Result<PacketDecision, DropReason> {
+    let ether_type = packet::read_u16(frame, 12).ok_or(EthernetHeaderTruncated)?;
+    match ether_type {
+        IPV4_ETHERTYPE => decide_ipv4(frame, snapshot, ingress, trace).map(PacketDecision::Ipv4),
+        ARP_ETHERTYPE => decide_arp(frame, snapshot, ingress, trace).map(PacketDecision::ArpReply),
+        _ => Err(UnsupportedEtherType),
+    }
+}
+
+fn decide_ipv4<T: TraceSink>(
+    frame: &[u8],
+    snapshot: &ForwardingSnapshot<'_>,
+    ingress: IfId,
+    trace: &mut T,
+) -> Result<Ipv4RewriteDecision, DropReason> {
     let ipv4 = validate_ipv4_frame(frame)?;
-    trace.record(TraceEvent::Validated {
+    trace.record(TraceEvent::Ipv4Validated {
         ingress,
         destination: ipv4.destination,
     });
@@ -263,7 +349,7 @@ fn decide<T: TraceSink>(
         egress: route.egress(),
         neighbor_target: target,
     });
-    Ok(RewriteDecision {
+    Ok(Ipv4RewriteDecision {
         egress: route.egress(),
         source_mac: interface.mac.0,
         destination_mac: neighbor.mac.0,
@@ -276,7 +362,50 @@ fn decide<T: TraceSink>(
     })
 }
 
-fn apply_rewrite(frame: &mut [u8], decision: RewriteDecision) -> Result<(), DropReason> {
+fn decide_arp<T: TraceSink>(
+    frame: &[u8],
+    snapshot: &ForwardingSnapshot<'_>,
+    ingress: IfId,
+    trace: &mut T,
+) -> Result<ArpReplyDecision, DropReason> {
+    let arp = validate_arp_request(frame)?;
+    trace.record(TraceEvent::ArpRequestValidated {
+        ingress,
+        sender_protocol: arp.sender_protocol,
+        target_protocol: arp.target_protocol,
+    });
+    if !snapshot
+        .local_ipv4
+        .iter()
+        .any(|binding| binding.interface == ingress && binding.address == arp.target_protocol)
+    {
+        return Err(ArpTargetNotLocal);
+    }
+    let interface = snapshot
+        .interfaces
+        .iter()
+        .find(|item| item.id == ingress)
+        .ok_or(InterfaceMiss)?;
+    if frame.get(0..packet::ARP_FRAME_LEN).is_none() {
+        return Err(ArpPacketTruncated);
+    }
+    Ok(ArpReplyDecision {
+        egress: ingress,
+        local_mac: interface.mac.0,
+        requester_mac: arp.sender_hardware.0,
+        requester_protocol: arp.sender_protocol.octets(),
+        local_protocol: arp.target_protocol.octets(),
+    })
+}
+
+fn apply_decision(frame: &mut [u8], decision: PacketDecision) -> Result<(), DropReason> {
+    match decision {
+        PacketDecision::Ipv4(ipv4) => apply_ipv4_rewrite(frame, ipv4),
+        PacketDecision::ArpReply(arp) => apply_arp_reply(frame, arp),
+    }
+}
+
+fn apply_ipv4_rewrite(frame: &mut [u8], decision: Ipv4RewriteDecision) -> Result<(), DropReason> {
     if frame.get(0..6).is_none()
         || frame.get(6..12).is_none()
         || frame.get(decision.ttl_offset).is_none()
@@ -295,6 +424,20 @@ fn apply_rewrite(frame: &mut [u8], decision: RewriteDecision) -> Result<(), Drop
         decision.new_ttl_protocol,
     );
     frame[decision.checksum_offset..decision.checksum_end].copy_from_slice(&checksum.to_be_bytes());
+    Ok(())
+}
+
+fn apply_arp_reply(frame: &mut [u8], decision: ArpReplyDecision) -> Result<(), DropReason> {
+    if frame.get(0..packet::ARP_FRAME_LEN).is_none() {
+        return Err(ArpPacketTruncated);
+    }
+    frame[0..6].copy_from_slice(&decision.requester_mac);
+    frame[6..12].copy_from_slice(&decision.local_mac);
+    frame[20..22].copy_from_slice(&2_u16.to_be_bytes());
+    frame[22..28].copy_from_slice(&decision.local_mac);
+    frame[28..32].copy_from_slice(&decision.local_protocol);
+    frame[32..38].copy_from_slice(&decision.requester_mac);
+    frame[38..42].copy_from_slice(&decision.requester_protocol);
     Ok(())
 }
 
@@ -319,6 +462,14 @@ mod tests {
             (12, "ROUTE_MISS"),
             (13, "NEIGHBOR_UNRESOLVED"),
             (14, "INTERFACE_MISS"),
+            (15, "ARP_PACKET_TRUNCATED"),
+            (16, "ARP_HARDWARE_TYPE_UNSUPPORTED"),
+            (17, "ARP_PROTOCOL_TYPE_UNSUPPORTED"),
+            (18, "ARP_HARDWARE_LENGTH_UNSUPPORTED"),
+            (19, "ARP_PROTOCOL_LENGTH_UNSUPPORTED"),
+            (20, "ARP_REPLY_UNSUPPORTED"),
+            (21, "ARP_OPCODE_UNSUPPORTED"),
+            (22, "ARP_TARGET_NOT_LOCAL"),
         ];
         let actual = [
             DropReason::EthernetHeaderTruncated,
@@ -335,6 +486,14 @@ mod tests {
             DropReason::RouteMiss,
             DropReason::NeighborUnresolved,
             DropReason::InterfaceMiss,
+            DropReason::ArpPacketTruncated,
+            DropReason::ArpHardwareTypeUnsupported,
+            DropReason::ArpProtocolTypeUnsupported,
+            DropReason::ArpHardwareLengthUnsupported,
+            DropReason::ArpProtocolLengthUnsupported,
+            DropReason::ArpReplyUnsupported,
+            DropReason::ArpOpcodeUnsupported,
+            DropReason::ArpTargetNotLocal,
         ];
         for (reason, &(discriminant, code)) in actual.iter().zip(&expected) {
             assert_eq!(*reason as u16, discriminant);

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,5 +1,5 @@
 #![forbid(unsafe_code)]
-#![doc = "A small, allocation-free IPv4 forwarding core."]
+#![doc = "A small, allocation-free IPv4 and ARP packet-processing core."]
 
 mod checksum;
 mod forwarding;
@@ -13,5 +13,8 @@ pub use forwarding::{
     TraceSink,
 };
 pub use io::{BatchCompletion, PacketBatch, PacketIo, PacketLease, PacketSlot, SlotCompletion};
-pub use packet::{validate_ipv4_frame, MacAddress, ValidatedIpv4, ETHERNET_HEADER_LEN};
-pub use route::{IfId, Interface, Ipv4Address, Neighbor, Route, RouteError};
+pub use packet::{
+    validate_arp_request, validate_ipv4_frame, MacAddress, ValidatedArpRequest, ValidatedIpv4,
+    ARP_ETHERTYPE, ETHERNET_HEADER_LEN, IPV4_ETHERTYPE,
+};
+pub use route::{IfId, Interface, Ipv4Address, LocalIpv4Binding, Neighbor, Route, RouteError};

--- a/crates/core/src/packet.rs
+++ b/crates/core/src/packet.rs
@@ -1,8 +1,11 @@
 use crate::DropReason;
 
 pub const ETHERNET_HEADER_LEN: usize = 14;
+pub const ARP_PACKET_LEN: usize = 28;
+pub const ARP_FRAME_LEN: usize = ETHERNET_HEADER_LEN + ARP_PACKET_LEN;
 const IPV4_MIN_HEADER_LEN: usize = 20;
-const IPV4_ETHERTYPE: u16 = 0x0800;
+pub const IPV4_ETHERTYPE: u16 = 0x0800;
+pub const ARP_ETHERTYPE: u16 = 0x0806;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct MacAddress(pub [u8; 6]);
@@ -17,6 +20,13 @@ pub struct ValidatedIpv4 {
     pub source: crate::Ipv4Address,
     pub destination: crate::Ipv4Address,
     pub checksum: u16,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ValidatedArpRequest {
+    pub sender_hardware: MacAddress,
+    pub sender_protocol: crate::Ipv4Address,
+    pub target_protocol: crate::Ipv4Address,
 }
 
 /// Validates Ethernet II and the entire IPv4 header without mutating the frame.
@@ -99,7 +109,55 @@ pub fn validate_ipv4_frame(frame: &[u8]) -> Result<ValidatedIpv4, DropReason> {
     })
 }
 
-fn read_u16(bytes: &[u8], offset: usize) -> Option<u16> {
+/// Validates the Ethernet/IPv4 ARP profile and returns a request view.
+///
+/// The target hardware address is intentionally ignored as required by
+/// RFC 826 request processing. Ethernet source and ARP sender hardware are
+/// also not required to match. No bytes are mutated by this function.
+pub fn validate_arp_request(frame: &[u8]) -> Result<ValidatedArpRequest, DropReason> {
+    if frame.len() < ETHERNET_HEADER_LEN {
+        return Err(DropReason::EthernetHeaderTruncated);
+    }
+    if read_u16(frame, 12) != Some(ARP_ETHERTYPE) {
+        return Err(DropReason::UnsupportedEtherType);
+    }
+    if frame.len() < ARP_FRAME_LEN {
+        return Err(DropReason::ArpPacketTruncated);
+    }
+
+    if read_u16(frame, 14) != Some(1) {
+        return Err(DropReason::ArpHardwareTypeUnsupported);
+    }
+    if read_u16(frame, 16) != Some(IPV4_ETHERTYPE) {
+        return Err(DropReason::ArpProtocolTypeUnsupported);
+    }
+    if frame[18] != 6 {
+        return Err(DropReason::ArpHardwareLengthUnsupported);
+    }
+    if frame[19] != 4 {
+        return Err(DropReason::ArpProtocolLengthUnsupported);
+    }
+    match read_u16(frame, 20) {
+        Some(1) => {}
+        Some(2) => return Err(DropReason::ArpReplyUnsupported),
+        Some(_) => return Err(DropReason::ArpOpcodeUnsupported),
+        None => return Err(DropReason::ArpPacketTruncated),
+    }
+
+    Ok(ValidatedArpRequest {
+        sender_hardware: MacAddress([
+            frame[22], frame[23], frame[24], frame[25], frame[26], frame[27],
+        ]),
+        sender_protocol: crate::Ipv4Address::from_octets([
+            frame[28], frame[29], frame[30], frame[31],
+        ]),
+        target_protocol: crate::Ipv4Address::from_octets([
+            frame[38], frame[39], frame[40], frame[41],
+        ]),
+    })
+}
+
+pub(crate) fn read_u16(bytes: &[u8], offset: usize) -> Option<u16> {
     let end = offset.checked_add(2)?;
     let word = bytes.get(offset..end)?;
     Some(u16::from_be_bytes([word[0], word[1]]))

--- a/crates/core/src/route.rs
+++ b/crates/core/src/route.rs
@@ -31,6 +31,18 @@ pub struct Neighbor {
     pub mac: MacAddress,
 }
 
+/// The single IPv4 address owned by one interface in the current profile.
+///
+/// The binding deliberately has no MAC address. [`Interface`] remains the
+/// single source of truth for the link-layer identity used by ARP replies.
+/// [`crate::ForwardingSnapshot::new`] rejects a second address on an interface
+/// and the same address on another interface.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LocalIpv4Binding {
+    pub interface: IfId,
+    pub address: Ipv4Address,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Route {
     prefix: Ipv4Address,

--- a/crates/io-sim/tests/acceptance.rs
+++ b/crates/io-sim/tests/acceptance.rs
@@ -1,17 +1,22 @@
 use ruster_core::{
     forward_batch, ipv4_header_checksum, validate_ipv4_frame, BatchCompletion, DropReason,
-    ForwardingSnapshot, IfId, Interface, Ipv4Address, MacAddress, Neighbor, NoTrace, PacketBatch,
-    PacketIo, PacketLease, PacketSlot, Route, SlotCompletion, SnapshotError, TraceEvent,
-    ETHERNET_HEADER_LEN,
+    ForwardingSnapshot, IfId, Interface, Ipv4Address, LocalIpv4Binding, MacAddress, Neighbor,
+    NoTrace, PacketBatch, PacketIo, PacketLease, PacketSlot, Route, SlotCompletion, SnapshotError,
+    TraceEvent, ETHERNET_HEADER_LEN,
 };
 use ruster_io_sim::{RecycleCause, SimIo, VecTrace};
 
 const LAN: IfId = IfId(1);
 const WAN: IfId = IfId(2);
+const LAN_MAC: MacAddress = MacAddress([0x02, 0, 0, 0, 0, 0x10]);
 const ROUTER_MAC: MacAddress = MacAddress([0x02, 0, 0, 0, 0, 2]);
 const NEXT_HOP_MAC: MacAddress = MacAddress([0x02, 0, 0, 0, 0, 3]);
 const ORIGINAL_DST_MAC: [u8; 6] = [0x02, 0, 0, 0, 0, 9];
 const ORIGINAL_SRC_MAC: [u8; 6] = [0x02, 0, 0, 0, 0, 1];
+const REQUESTER_MAC: [u8; 6] = [0x02, 0, 0, 0, 0, 0x20];
+const FOREIGN_ETHERNET_MAC: [u8; 6] = [0x02, 0, 0, 0, 0, 0x21];
+const LOCAL_IPV4: [u8; 4] = [192, 0, 2, 1];
+const REQUESTER_IPV4: [u8; 4] = [192, 0, 2, 20];
 const DESTINATION: [u8; 4] = [198, 51, 100, 20];
 const GATEWAY: [u8; 4] = [203, 0, 113, 1];
 
@@ -40,6 +45,53 @@ fn gateway_neighbor() -> Neighbor {
         target: ip(GATEWAY),
         mac: NEXT_HOP_MAC,
     }
+}
+
+fn local_interface() -> Interface {
+    Interface {
+        id: LAN,
+        mac: LAN_MAC,
+    }
+}
+
+fn local_binding() -> LocalIpv4Binding {
+    LocalIpv4Binding {
+        interface: LAN,
+        address: ip(LOCAL_IPV4),
+    }
+}
+
+fn arp_frame(
+    opcode: u16,
+    sender_protocol: [u8; 4],
+    target_protocol: [u8; 4],
+    ethernet_source: [u8; 6],
+    sender_hardware: [u8; 6],
+    target_hardware: [u8; 6],
+    tail: &[u8],
+) -> Vec<u8> {
+    let mut bytes = vec![0_u8; 42 + tail.len()];
+    bytes[0..6].copy_from_slice(&[0xff; 6]);
+    bytes[6..12].copy_from_slice(&ethernet_source);
+    bytes[12..14].copy_from_slice(&0x0806_u16.to_be_bytes());
+    bytes[14..16].copy_from_slice(&1_u16.to_be_bytes());
+    bytes[16..18].copy_from_slice(&0x0800_u16.to_be_bytes());
+    bytes[18] = 6;
+    bytes[19] = 4;
+    bytes[20..22].copy_from_slice(&opcode.to_be_bytes());
+    bytes[22..28].copy_from_slice(&sender_hardware);
+    bytes[28..32].copy_from_slice(&sender_protocol);
+    bytes[32..38].copy_from_slice(&target_hardware);
+    bytes[38..42].copy_from_slice(&target_protocol);
+    bytes[42..].copy_from_slice(tail);
+    bytes
+}
+
+fn arp_snapshot<'a>(
+    interfaces: &'a [Interface],
+    bindings: &'a [LocalIpv4Binding],
+) -> ForwardingSnapshot<'a> {
+    ForwardingSnapshot::new(&[], interfaces, &[], bindings).unwrap()
 }
 
 fn frame(ttl: u8, payload: &[u8]) -> Vec<u8> {
@@ -100,7 +152,7 @@ fn gateway_route_rewrites_and_reports_backend_acceptance() {
     let routes = [gateway_route()];
     let interfaces = [interface()];
     let neighbors = [gateway_neighbor()];
-    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors).unwrap();
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &[]).unwrap();
     let packet = frame(64, &[1, 2, 3, 4]);
     let allocation = packet.as_ptr();
     let mut io = SimIo::new();
@@ -136,7 +188,7 @@ fn connected_route_uses_packet_destination_as_neighbor_target() {
         target: ip(DESTINATION),
         mac: NEXT_HOP_MAC,
     }];
-    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors).unwrap();
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &[]).unwrap();
     let mut io = SimIo::new();
     io.inject(LAN, frame(10, &[]));
     let report = io.run_once(1, &snapshot, &mut NoTrace).unwrap();
@@ -162,7 +214,7 @@ fn lpm_supports_default_and_host_routes() {
             mac: MacAddress([4; 6]),
         },
     ];
-    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors).unwrap();
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &[]).unwrap();
     let mut io = SimIo::new();
     io.inject(LAN, frame(9, &[]));
     io.run_once(1, &snapshot, &mut NoTrace).unwrap();
@@ -174,22 +226,27 @@ fn snapshot_constructor_rejects_all_broken_references_and_duplicates() {
     let known_interfaces = [interface()];
     let duplicate_routes = [gateway_route(), gateway_route()];
     assert!(matches!(
-        ForwardingSnapshot::new(&duplicate_routes, &known_interfaces, &[gateway_neighbor()]),
+        ForwardingSnapshot::new(
+            &duplicate_routes,
+            &known_interfaces,
+            &[gateway_neighbor()],
+            &[]
+        ),
         Err(SnapshotError::DuplicateRoute)
     ));
     let duplicate_interfaces = [interface(), interface()];
     assert!(matches!(
-        ForwardingSnapshot::new(&[], &duplicate_interfaces, &[]),
+        ForwardingSnapshot::new(&[], &duplicate_interfaces, &[], &[]),
         Err(SnapshotError::DuplicateInterface)
     ));
     let duplicate_neighbors = [gateway_neighbor(), gateway_neighbor()];
     assert!(matches!(
-        ForwardingSnapshot::new(&[], &known_interfaces, &duplicate_neighbors),
+        ForwardingSnapshot::new(&[], &known_interfaces, &duplicate_neighbors, &[]),
         Err(SnapshotError::DuplicateNeighbor)
     ));
     let unknown_route = [route([0, 0, 0, 0], 0, IfId(99), None)];
     assert!(matches!(
-        ForwardingSnapshot::new(&unknown_route, &known_interfaces, &[]),
+        ForwardingSnapshot::new(&unknown_route, &known_interfaces, &[], &[]),
         Err(SnapshotError::RouteUnknownInterface)
     ));
     let unknown_neighbor = [Neighbor {
@@ -198,8 +255,54 @@ fn snapshot_constructor_rejects_all_broken_references_and_duplicates() {
         mac: NEXT_HOP_MAC,
     }];
     assert!(matches!(
-        ForwardingSnapshot::new(&[], &known_interfaces, &unknown_neighbor),
+        ForwardingSnapshot::new(&[], &known_interfaces, &unknown_neighbor, &[]),
         Err(SnapshotError::NeighborUnknownInterface)
+    ));
+}
+
+#[test]
+fn arp_snapshot_rejects_duplicate_or_unknown_local_addresses() {
+    let interfaces = [
+        local_interface(),
+        Interface {
+            id: WAN,
+            mac: ROUTER_MAC,
+        },
+    ];
+    let duplicate = [local_binding(), local_binding()];
+    assert!(matches!(
+        ForwardingSnapshot::new(&[], &interfaces, &[], &duplicate),
+        Err(SnapshotError::DuplicateLocalIpv4Binding)
+    ));
+    let second_on_interface = [
+        local_binding(),
+        LocalIpv4Binding {
+            interface: LAN,
+            address: ip([192, 0, 2, 2]),
+        },
+    ];
+    assert!(matches!(
+        ForwardingSnapshot::new(&[], &interfaces, &[], &second_on_interface),
+        Err(SnapshotError::DuplicateLocalIpv4Binding)
+    ));
+    let duplicate_across_interfaces = [
+        local_binding(),
+        LocalIpv4Binding {
+            interface: WAN,
+            address: ip(LOCAL_IPV4),
+        },
+    ];
+    assert!(matches!(
+        ForwardingSnapshot::new(&[], &interfaces, &[], &duplicate_across_interfaces),
+        Err(SnapshotError::DuplicateLocalIpv4Binding)
+    ));
+    let unknown = [LocalIpv4Binding {
+        interface: IfId(99),
+        address: ip(LOCAL_IPV4),
+    }];
+    assert!(matches!(
+        ForwardingSnapshot::new(&[], &interfaces, &[], &unknown),
+        Err(SnapshotError::LocalIpv4BindingUnknownInterface)
     ));
 }
 
@@ -208,7 +311,7 @@ fn all_validation_and_decision_drops_are_granular_and_atomic() {
     let routes = [gateway_route()];
     let interfaces = [interface()];
     let neighbors = [gateway_neighbor()];
-    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors).unwrap();
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &[]).unwrap();
 
     let mut ethernet_type = frame(8, &[]);
     ethernet_type[12..14].copy_from_slice(&0x86dd_u16.to_be_bytes());
@@ -245,9 +348,9 @@ fn all_validation_and_decision_drops_are_granular_and_atomic() {
         assert_forwarding_drop(packet, &snapshot, reason);
     }
 
-    let no_routes = ForwardingSnapshot::new(&[], &interfaces, &neighbors).unwrap();
+    let no_routes = ForwardingSnapshot::new(&[], &interfaces, &neighbors, &[]).unwrap();
     assert_forwarding_drop(frame(8, &[]), &no_routes, DropReason::RouteMiss);
-    let unresolved = ForwardingSnapshot::new(&routes, &interfaces, &[]).unwrap();
+    let unresolved = ForwardingSnapshot::new(&routes, &interfaces, &[], &[]).unwrap();
     assert_forwarding_drop(frame(8, &[]), &unresolved, DropReason::NeighborUnresolved);
 }
 
@@ -262,7 +365,7 @@ fn padding_is_ignored_but_preserved() {
     let routes = [gateway_route()];
     let interfaces = [interface()];
     let neighbors = [gateway_neighbor()];
-    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors).unwrap();
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &[]).unwrap();
     let mut padded = frame(10, &[7, 8]);
     let datagram_end = padded.len();
     padded.extend_from_slice(&[0xff; 48]);
@@ -281,7 +384,7 @@ fn fragment_flags_offset_payload_and_checksum_are_preserved_or_updated_correctly
     let routes = [gateway_route()];
     let interfaces = [interface()];
     let neighbors = [gateway_neighbor()];
-    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors).unwrap();
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &[]).unwrap();
     let mut fragment = frame(5, &[0xaa; 8]);
     fragment[20..22].copy_from_slice(&0x2001_u16.to_be_bytes());
     fragment[24..26].fill(0);
@@ -303,7 +406,7 @@ fn mixed_batch_is_fifo_budgeted_and_reports_requested_accepted_recycled() {
     let routes = [gateway_route()];
     let interfaces = [interface()];
     let neighbors = [gateway_neighbor()];
-    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors).unwrap();
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &[]).unwrap();
     let mut io = SimIo::new();
     for ttl in [7, 1, 6] {
         io.inject(LAN, frame(ttl, &[]));
@@ -348,7 +451,7 @@ fn trace_is_deterministic_and_terminal_event_follows_completion() {
         let routes = [gateway_route()];
         let interfaces = [interface()];
         let neighbors = [gateway_neighbor()];
-        let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors).unwrap();
+        let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &[]).unwrap();
         let mut io = SimIo::new();
         let mut trace = VecTrace::default();
         io.inject(LAN, frame(32, &[1, 2, 3]));
@@ -359,7 +462,7 @@ fn trace_is_deterministic_and_terminal_event_follows_completion() {
     assert!(matches!(
         first.1.as_slice(),
         [
-            TraceEvent::Validated { .. },
+            TraceEvent::Ipv4Validated { .. },
             TraceEvent::Routed { egress: WAN, .. },
             TraceEvent::TxRequested { egress: WAN },
             TraceEvent::BatchCompleted {
@@ -424,7 +527,7 @@ fn partial_backend_completion_preserves_report_and_aggregate_trace() {
     let routes = [gateway_route()];
     let interfaces = [interface()];
     let neighbors = [gateway_neighbor()];
-    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors).unwrap();
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &[]).unwrap();
     let batch = PartialBatch {
         packet: Some(frame(8, &[])),
     };
@@ -439,7 +542,7 @@ fn partial_backend_completion_preserves_report_and_aggregate_trace() {
     assert!(matches!(
         trace.events(),
         [
-            TraceEvent::Validated { .. },
+            TraceEvent::Ipv4Validated { .. },
             TraceEvent::Routed { .. },
             TraceEvent::TxRequested { egress: WAN },
             TraceEvent::BatchCompleted {
@@ -448,4 +551,404 @@ fn partial_backend_completion_preserves_report_and_aggregate_trace() {
             }
         ]
     ));
+}
+
+#[test]
+fn arp_request_for_local_ipv4_replies_in_place_on_ingress() {
+    let interfaces = [local_interface()];
+    let bindings = [local_binding()];
+    let snapshot = arp_snapshot(&interfaces, &bindings);
+    let packet = arp_frame(
+        1,
+        REQUESTER_IPV4,
+        LOCAL_IPV4,
+        REQUESTER_MAC,
+        REQUESTER_MAC,
+        [0; 6],
+        &[],
+    );
+    let allocation = packet.as_ptr();
+    let mut io = SimIo::new();
+    io.inject(LAN, packet);
+
+    let report = io.run_once(1, &snapshot, &mut NoTrace).unwrap();
+    assert_eq!(report.received, 1);
+    assert_eq!(report.tx_requested, 1);
+    assert_eq!(report.dropped, 0);
+    assert_eq!(
+        report.completion,
+        BatchCompletion {
+            tx_requested: 1,
+            tx_accepted: 1,
+            tx_rejected: 0,
+            recycled: 0,
+            error: None,
+        }
+    );
+    let tx = io.pop_tx().unwrap();
+    assert_eq!(tx.egress, LAN);
+    assert_eq!(tx.bytes.as_ptr(), allocation, "RX Vec must move, not clone");
+    assert_eq!(&tx.bytes[0..6], &REQUESTER_MAC);
+    assert_eq!(&tx.bytes[6..12], &LAN_MAC.0);
+    assert_eq!(&tx.bytes[12..14], &0x0806_u16.to_be_bytes());
+    assert_eq!(&tx.bytes[20..22], &2_u16.to_be_bytes());
+    assert_eq!(&tx.bytes[22..28], &LAN_MAC.0);
+    assert_eq!(&tx.bytes[28..32], &LOCAL_IPV4);
+    assert_eq!(&tx.bytes[32..38], &REQUESTER_MAC);
+    assert_eq!(&tx.bytes[38..42], &REQUESTER_IPV4);
+}
+
+#[test]
+fn arp_probe_for_local_ipv4_replies_with_zero_target_protocol() {
+    let interfaces = [local_interface()];
+    let bindings = [local_binding()];
+    let snapshot = arp_snapshot(&interfaces, &bindings);
+    let mut io = SimIo::new();
+    io.inject(
+        LAN,
+        arp_frame(
+            1,
+            [0; 4],
+            LOCAL_IPV4,
+            REQUESTER_MAC,
+            REQUESTER_MAC,
+            [0; 6],
+            &[],
+        ),
+    );
+    io.run_once(1, &snapshot, &mut NoTrace).unwrap();
+    let reply = io.pop_tx().unwrap();
+    assert_eq!(&reply.bytes[28..32], &LOCAL_IPV4);
+    assert_eq!(&reply.bytes[38..42], &[0; 4]);
+}
+
+#[test]
+fn arp_request_target_hardware_is_ignored() {
+    let interfaces = [local_interface()];
+    let bindings = [local_binding()];
+    let snapshot = arp_snapshot(&interfaces, &bindings);
+    let mut io = SimIo::new();
+    io.inject(
+        LAN,
+        arp_frame(
+            1,
+            REQUESTER_IPV4,
+            LOCAL_IPV4,
+            FOREIGN_ETHERNET_MAC,
+            REQUESTER_MAC,
+            [0xa5; 6],
+            &[],
+        ),
+    );
+    io.run_once(1, &snapshot, &mut NoTrace).unwrap();
+    let reply = io.pop_tx().unwrap();
+    assert_eq!(&reply.bytes[0..6], &REQUESTER_MAC);
+    assert_eq!(&reply.bytes[32..38], &REQUESTER_MAC);
+}
+
+#[test]
+fn arp_foreign_sender_claiming_local_address_gets_normal_reply() {
+    let interfaces = [local_interface()];
+    let bindings = [local_binding()];
+    let snapshot = arp_snapshot(&interfaces, &bindings);
+    let mut io = SimIo::new();
+    io.inject(
+        LAN,
+        arp_frame(
+            1,
+            LOCAL_IPV4,
+            LOCAL_IPV4,
+            FOREIGN_ETHERNET_MAC,
+            REQUESTER_MAC,
+            [0; 6],
+            &[],
+        ),
+    );
+    let report = io.run_once(1, &snapshot, &mut NoTrace).unwrap();
+    assert_eq!(report.tx_requested, 1);
+    assert_eq!(report.dropped, 0);
+    let reply = io.pop_tx().unwrap();
+    assert_eq!(&reply.bytes[0..6], &REQUESTER_MAC);
+    assert_eq!(&reply.bytes[38..42], &LOCAL_IPV4);
+}
+
+#[test]
+fn arp_profile_validation_drops_are_granular_and_atomic() {
+    let interfaces = [local_interface()];
+    let bindings = [local_binding()];
+    let snapshot = arp_snapshot(&interfaces, &bindings);
+    let request = || {
+        arp_frame(
+            1,
+            REQUESTER_IPV4,
+            LOCAL_IPV4,
+            REQUESTER_MAC,
+            REQUESTER_MAC,
+            [0; 6],
+            &[],
+        )
+    };
+    let mut truncated = request();
+    truncated.truncate(41);
+    let mut hardware_type = request();
+    hardware_type[14..16].copy_from_slice(&2_u16.to_be_bytes());
+    let mut protocol_type = request();
+    protocol_type[16..18].copy_from_slice(&0x86dd_u16.to_be_bytes());
+    let mut hardware_length = request();
+    hardware_length[18] = 8;
+    let mut protocol_length = request();
+    protocol_length[19] = 16;
+    let mut reply = request();
+    reply[20..22].copy_from_slice(&2_u16.to_be_bytes());
+    let mut unknown_opcode = request();
+    unknown_opcode[20..22].copy_from_slice(&99_u16.to_be_bytes());
+
+    let cases = [
+        (truncated, DropReason::ArpPacketTruncated),
+        (hardware_type, DropReason::ArpHardwareTypeUnsupported),
+        (protocol_type, DropReason::ArpProtocolTypeUnsupported),
+        (hardware_length, DropReason::ArpHardwareLengthUnsupported),
+        (protocol_length, DropReason::ArpProtocolLengthUnsupported),
+        (reply, DropReason::ArpReplyUnsupported),
+        (unknown_opcode, DropReason::ArpOpcodeUnsupported),
+    ];
+    for (packet, reason) in cases {
+        assert_forwarding_drop(packet, &snapshot, reason);
+    }
+}
+
+#[test]
+fn arp_padding_is_ignored_and_preserved_on_reply() {
+    let interfaces = [local_interface()];
+    let bindings = [local_binding()];
+    let snapshot = arp_snapshot(&interfaces, &bindings);
+    let padding = [0xde, 0xad, 0xbe, 0xef, 0xa5, 0x5a];
+    let mut io = SimIo::new();
+    io.inject(
+        LAN,
+        arp_frame(
+            1,
+            REQUESTER_IPV4,
+            LOCAL_IPV4,
+            REQUESTER_MAC,
+            REQUESTER_MAC,
+            [0; 6],
+            &padding,
+        ),
+    );
+    io.run_once(1, &snapshot, &mut NoTrace).unwrap();
+    let reply = io.pop_tx().unwrap();
+    assert_eq!(reply.bytes.len(), 42 + padding.len());
+    assert_eq!(&reply.bytes[42..], &padding);
+}
+
+#[test]
+fn arp_nonlocal_and_reply_are_recycled_without_mutation() {
+    let interfaces = [local_interface()];
+    let bindings = [local_binding()];
+    let snapshot = arp_snapshot(&interfaces, &bindings);
+    let nonlocal = arp_frame(
+        1,
+        REQUESTER_IPV4,
+        [192, 0, 2, 99],
+        REQUESTER_MAC,
+        REQUESTER_MAC,
+        [0; 6],
+        &[],
+    );
+    assert_forwarding_drop(nonlocal, &snapshot, DropReason::ArpTargetNotLocal);
+    let reply = arp_frame(
+        2,
+        REQUESTER_IPV4,
+        LOCAL_IPV4,
+        REQUESTER_MAC,
+        REQUESTER_MAC,
+        LAN_MAC.0,
+        &[],
+    );
+    assert_forwarding_drop(reply, &snapshot, DropReason::ArpReplyUnsupported);
+    let unknown_opcode = arp_frame(
+        77,
+        REQUESTER_IPV4,
+        LOCAL_IPV4,
+        REQUESTER_MAC,
+        REQUESTER_MAC,
+        [0; 6],
+        &[],
+    );
+    assert_forwarding_drop(unknown_opcode, &snapshot, DropReason::ArpOpcodeUnsupported);
+
+    let interfaces = [local_interface(), interface()];
+    let wan_binding = [LocalIpv4Binding {
+        interface: WAN,
+        address: ip(LOCAL_IPV4),
+    }];
+    let wrong_ingress_snapshot = arp_snapshot(&interfaces, &wan_binding);
+    let wrong_ingress = arp_frame(
+        1,
+        REQUESTER_IPV4,
+        LOCAL_IPV4,
+        REQUESTER_MAC,
+        REQUESTER_MAC,
+        [0; 6],
+        &[],
+    );
+    assert_forwarding_drop(
+        wrong_ingress,
+        &wrong_ingress_snapshot,
+        DropReason::ArpTargetNotLocal,
+    );
+}
+
+#[test]
+fn arp_trace_is_deterministic_and_tx_follows_commit() {
+    fn run() -> (Vec<u8>, Vec<TraceEvent>) {
+        let interfaces = [local_interface()];
+        let bindings = [local_binding()];
+        let snapshot = arp_snapshot(&interfaces, &bindings);
+        let mut io = SimIo::new();
+        let mut trace = VecTrace::default();
+        io.inject(
+            LAN,
+            arp_frame(
+                1,
+                REQUESTER_IPV4,
+                LOCAL_IPV4,
+                REQUESTER_MAC,
+                REQUESTER_MAC,
+                [0; 6],
+                &[],
+            ),
+        );
+        io.run_once(1, &snapshot, &mut trace).unwrap();
+        (io.pop_tx().unwrap().bytes, trace.events().to_vec())
+    }
+    let first = run();
+    assert!(matches!(
+        first.1.as_slice(),
+        [
+            TraceEvent::ArpRequestValidated { ingress: LAN, .. },
+            TraceEvent::ArpReplyRequested { egress: LAN, .. },
+            TraceEvent::TxRequested { egress: LAN },
+            TraceEvent::BatchCompleted {
+                tx_accepted: 1,
+                tx_rejected: 0
+            }
+        ]
+    ));
+    assert_eq!(first, run());
+}
+
+#[test]
+fn mixed_ipv4_and_arp_batch_is_fifo_budgeted_and_deterministic() {
+    let routes = [gateway_route()];
+    let interfaces = [local_interface(), interface()];
+    let neighbors = [gateway_neighbor()];
+    let bindings = [local_binding()];
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &bindings).unwrap();
+    let mut io = SimIo::new();
+    io.inject(LAN, frame(8, &[]));
+    io.inject(
+        LAN,
+        arp_frame(
+            1,
+            REQUESTER_IPV4,
+            LOCAL_IPV4,
+            REQUESTER_MAC,
+            REQUESTER_MAC,
+            [0; 6],
+            &[],
+        ),
+    );
+    io.inject(LAN, frame(7, &[]));
+
+    let first = io.run_once(2, &snapshot, &mut NoTrace).unwrap();
+    assert_eq!(first.received, 2);
+    assert_eq!(first.tx_requested, 2);
+    assert_eq!(io.pending_rx(), 1);
+    assert_eq!(io.pop_tx().unwrap().sequence, 0);
+    assert_eq!(io.pop_tx().unwrap().sequence, 1);
+    let second = io.run_once(1, &snapshot, &mut NoTrace).unwrap();
+    assert_eq!(second.tx_requested, 1);
+    assert_eq!(io.pop_tx().unwrap().sequence, 2);
+}
+
+#[test]
+fn arp_partial_backend_rejection_preserves_error_report_and_trace() {
+    let interfaces = [local_interface()];
+    let bindings = [local_binding()];
+    let snapshot = arp_snapshot(&interfaces, &bindings);
+    let batch = ArpPartialBatch {
+        packet: Some(arp_frame(
+            1,
+            REQUESTER_IPV4,
+            LOCAL_IPV4,
+            REQUESTER_MAC,
+            REQUESTER_MAC,
+            [0; 6],
+            &[],
+        )),
+    };
+    let mut trace = VecTrace::default();
+    let report = forward_batch(batch, &snapshot, &mut trace);
+    assert_eq!(report.tx_requested, 1);
+    assert_eq!(report.completion.tx_requested, 1);
+    assert_eq!(report.completion.tx_accepted, 0);
+    assert_eq!(report.completion.tx_rejected, 1);
+    assert_eq!(report.completion.error, Some(TestBackendError::RingFull));
+    assert!(matches!(
+        trace.events(),
+        [
+            TraceEvent::ArpRequestValidated { .. },
+            TraceEvent::ArpReplyRequested { egress: LAN, .. },
+            TraceEvent::TxRequested { egress: LAN },
+            TraceEvent::BatchCompleted {
+                tx_accepted: 0,
+                tx_rejected: 1
+            }
+        ]
+    ));
+}
+
+struct ArpPartialBatch {
+    packet: Option<Vec<u8>>,
+}
+
+struct ArpPartialSlot {
+    bytes: Vec<u8>,
+}
+
+impl PacketSlot for ArpPartialSlot {
+    fn ingress(&self) -> IfId {
+        LAN
+    }
+
+    fn bytes_mut(&mut self) -> &mut [u8] {
+        &mut self.bytes
+    }
+
+    fn complete(self, completion: SlotCompletion) {
+        assert!(matches!(completion, SlotCompletion::Transmit(LAN)));
+    }
+}
+
+impl PacketBatch for ArpPartialBatch {
+    type Error = TestBackendError;
+    type Slot<'a> = ArpPartialSlot;
+
+    fn next_packet(&mut self) -> Option<PacketLease<Self::Slot<'_>>> {
+        self.packet
+            .take()
+            .map(|bytes| PacketLease::new(ArpPartialSlot { bytes }))
+    }
+
+    fn finish(self) -> BatchCompletion<Self::Error> {
+        BatchCompletion {
+            tx_requested: 1,
+            tx_accepted: 0,
+            tx_rejected: 1,
+            recycled: 0,
+            error: Some(TestBackendError::RingFull),
+        }
+    }
 }

--- a/crates/io-sim/tests/acceptance.rs
+++ b/crates/io-sim/tests/acceptance.rs
@@ -874,6 +874,78 @@ fn mixed_ipv4_and_arp_batch_is_fifo_budgeted_and_deterministic() {
 }
 
 #[test]
+fn arp_reply_does_not_learn_or_generate_for_unresolved_neighbor() {
+    let routes = [route(REQUESTER_IPV4, 32, LAN, None)];
+    let interfaces = [local_interface()];
+    let bindings = [local_binding()];
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &[], &bindings).unwrap();
+    let request = arp_frame(
+        1,
+        REQUESTER_IPV4,
+        LOCAL_IPV4,
+        REQUESTER_MAC,
+        REQUESTER_MAC,
+        [0; 6],
+        &[],
+    );
+    let mut toward_sender = frame(8, &[]);
+    toward_sender[30..34].copy_from_slice(&REQUESTER_IPV4);
+    toward_sender[24..26].fill(0);
+    let checksum = ipv4_header_checksum(&toward_sender[14..34]);
+    toward_sender[24..26].copy_from_slice(&checksum.to_be_bytes());
+    let original_ipv4 = toward_sender.clone();
+
+    let mut io = SimIo::new();
+    let mut trace = VecTrace::default();
+    io.inject(LAN, request);
+    io.inject(LAN, toward_sender);
+    let report = io.run_once(2, &snapshot, &mut trace).unwrap();
+
+    assert_eq!(report.received, 2);
+    assert_eq!(report.tx_requested, 1, "no generated ARP request");
+    assert_eq!(report.dropped, 1);
+    assert_eq!(
+        report.completion,
+        BatchCompletion {
+            tx_requested: 1,
+            tx_accepted: 1,
+            tx_rejected: 0,
+            recycled: 1,
+            error: None,
+        }
+    );
+    assert_eq!(io.pending_tx(), 1, "only the in-place ARP reply exists");
+    let reply = io.pop_tx().unwrap();
+    assert_eq!(reply.sequence, 0);
+    assert_eq!(&reply.bytes[20..22], &2_u16.to_be_bytes());
+    let recycled = io.pop_recycled().unwrap();
+    assert_eq!(recycled.sequence, 1);
+    assert_eq!(
+        recycled.cause,
+        RecycleCause::Forwarding(DropReason::NeighborUnresolved)
+    );
+    assert_eq!(recycled.bytes, original_ipv4, "unresolved drop is atomic");
+    assert_eq!(io.pending_rx(), 0, "the unresolved packet is not held");
+    assert!(matches!(
+        trace.events(),
+        [
+            TraceEvent::ArpRequestValidated { .. },
+            TraceEvent::ArpReplyRequested { egress: LAN, .. },
+            TraceEvent::TxRequested { egress: LAN },
+            TraceEvent::Ipv4Validated { ingress: LAN, .. },
+            TraceEvent::Dropped {
+                ingress: LAN,
+                reason: DropReason::NeighborUnresolved
+            },
+            TraceEvent::BatchCompleted {
+                tx_accepted: 1,
+                tx_rejected: 0
+            }
+        ]
+    ));
+}
+
+#[test]
 fn arp_partial_backend_rejection_preserves_error_report_and_trace() {
     let interfaces = [local_interface()];
     let bindings = [local_binding()];

--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -65,9 +65,9 @@ forwarding時に`NeighborUnresolved`でbytes不変recycleします。
 このsliceはstatic neighborとARP responderを接続しません。neighbor miss時もARP request
 を生成せず、packetをholdせずに従来どおり`NeighborUnresolved`でrecycleします。
 generated packet用allocator/lifetime contractがまだ無いため、場当たり的にsimの
-`Vec`をcoreへ導入しません。RFC 1122 §2.3.2.2とRFC 1812 §3.3.2が述べるaddress
-resolution中のpacket queue/hold（少なくとも一つを保持するSHOULDを含む）は未達で、
-最初のpacketは解決後に自動再送されません。
+`Vec`をcoreへ導入しません。RFC 1122 §2.3.2.1/§2.3.2.2とRFC 1812 §3.3.2が述べる
+ARP cache/address resolutionとpacket queue/hold（少なくとも一つを保持するSHOULDを
+含む）は未達で、最初のpacketは解決後に自動再送されません。
 
 ## IPv4 scope
 
@@ -82,8 +82,9 @@ v0.2 bootstrapはEthernet II上のIPv4 datagramを転送します。
 ## ARP responder scope
 
 Ethernet II / IPv4 profile（HTYPE 1、PTYPE 0x0800、HLEN 6、PLEN 4）のARP Requestだけを
-扱います。TPAがingress interfaceのlocal IPv4と一致するとき、同じRX bufferを次の
-replyへ書き換えてingressへcommitします。
+扱います。opcode profileはRFC 826に加えてRFC 5494/IANA ARP Parameters registryに
+基づき、Replyと未対応opcodeを別reasonにします。TPAがingress interfaceのlocal IPv4と
+一致するとき、同じRX bufferを次のreplyへ書き換えてingressへcommitします。
 
 - Ethernet destinationとTHAはrequest SHA、Ethernet sourceとSHAはlocal interface MAC。
 - SPAはrequest TPA、TPAはrequest SPA。ARP ProbeのSPA `0.0.0.0`にもTPA zeroでreplyする。

--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -28,9 +28,11 @@ leaseしていないslotはRX backendの所有下に残ります。coreからUME
 
 ```text
 Ethernet validate
-  → IPv4 version/IHL/Total Length/header checksum validate
-  → options policy → TTL check → LPM → typed neighbor lookup → typed interface lookup
-  → TTL/checksum/MAC rewrite → commit
+  ├─ IPv4 version/IHL/Total Length/header checksum validate
+  │    → options policy → TTL check → LPM → typed neighbor/interface lookup
+  │    → TTL/checksum/MAC rewrite → commit
+  └─ Ethernet/IPv4 ARP profile validate → ingress local target lookup
+       → request bufferをARP replyへrewrite → ingressへcommit
 ```
 
 leaseからmutable sliceを一度だけ取得し、同じsliceをimmutable reborrowして全判断を
@@ -41,17 +43,31 @@ ordered outcome/tokenを導入するまではpacket単位accepted traceを主張
 `TraceSink`はpanic禁止の契約で、productionの`NoTrace`はallocationしません。
 `VecTrace`はsim crateだけに存在します。
 
-route、interface、neighborはvalidated immutable snapshotのborrowed sliceです。routeは
-canonical prefixだけを受け付け、lookupは`/0`と`/32`を含むlongest-prefix matchです。
-gateway routeはnext-hopを、connected routeはpacket destinationをneighbor targetにします。
+route、interface、neighbor、local IPv4 bindingはvalidated immutable snapshotのborrowed
+sliceです。routeはcanonical prefixだけを受け付け、lookupは`/0`と`/32`を含む
+longest-prefix matchです。gateway routeはnext-hopを、connected routeはpacket
+destinationをneighbor targetにします。
 
 snapshot公開前にcontrol planeが守る不変条件は次の通りです。
 
 - route prefix/length、interface `IfId`、neighbor `(IfId, target)`は重複しない。
 - routeとneighborが参照するegress `IfId`はinterface snapshot内で解決できる。
+- local IPv4 bindingが参照する`IfId`は解決でき、現profileでは一つのinterfaceに
+  local IPv4は一つだけ、同じlocal IPv4を複数interfaceへ設定しない。
+
+local bindingはMACを持ちません。ARP replyのlocal MACは対応する`Interface`からだけ
+取得し、link-layer identityのsingle source of truthを維持します。複数local IPv4を
+一つのinterfaceへ設定するprofileは将来scopeです。
 
 routeに対応するneighborがまだ無いこと自体はvalidです。ARP解決前の通常状態として
 forwarding時に`NeighborUnresolved`でbytes不変recycleします。
+
+このsliceはstatic neighborとARP responderを接続しません。neighbor miss時もARP request
+を生成せず、packetをholdせずに従来どおり`NeighborUnresolved`でrecycleします。
+generated packet用allocator/lifetime contractがまだ無いため、場当たり的にsimの
+`Vec`をcoreへ導入しません。RFC 1122 §2.3.2.2とRFC 1812 §3.3.2が述べるaddress
+resolution中のpacket queue/hold（少なくとも一つを保持するSHOULDを含む）は未達で、
+最初のpacketは解決後に自動再送されません。
 
 ## IPv4 scope
 
@@ -63,8 +79,28 @@ v0.2 bootstrapはEthernet II上のIPv4 datagramを転送します。
 - fragment offsetやMFに関係なく、このsliceはL4を参照しないためdatagramとして転送する。
 - TTLは1減算し、header checksumはRFC 1624のincremental updateで更新する。
 
-ARP、ICMP生成、NAT、firewall、config parser、pcap、AF_XDP、DPDK、binary、thread、
-benchmarkはこのPRのscope外です。
+## ARP responder scope
+
+Ethernet II / IPv4 profile（HTYPE 1、PTYPE 0x0800、HLEN 6、PLEN 4）のARP Requestだけを
+扱います。TPAがingress interfaceのlocal IPv4と一致するとき、同じRX bufferを次の
+replyへ書き換えてingressへcommitします。
+
+- Ethernet destinationとTHAはrequest SHA、Ethernet sourceとSHAはlocal interface MAC。
+- SPAはrequest TPA、TPAはrequest SPA。ARP ProbeのSPA `0.0.0.0`にもTPA zeroでreplyする。
+- request THAは無視し、Ethernet sourceとrequest SHAの一致も要求しない。
+- 42 byte以後はpadding/tailとして長さと内容を保存する。
+- ARP Reply、unknown opcode、nonlocal targetはstable reasonでbytes不変recycleする。
+- 学習やneighbor snapshot更新は一切行わない。
+
+RFC 5227 §2.4のaddress conflict detection/defenseは未実装です。foreign SHAがlocal SPAを
+名乗り、同じlocal addressをTPAにしたrequestも通常requestとしてdirected replyするだけで、
+conflict状態やdefensive announcementを生成しません。正常なlocal target requestを
+追加policyでdropしないことを優先した明示deviationです。
+
+ARP learning/cache、ARP request生成、retry、unresolved packet hold queue、gratuitous
+ARP、proxy ARP、VLAN、generated-packet allocator、Address Conflict Detection、ICMP生成、
+NAT、firewall、config parser、pcap、AF_XDP、DPDK、binary、thread、benchmarkはこの
+sliceのscope外です。
 
 ## backend progression
 

--- a/docs/requirements-v0.2.md
+++ b/docs/requirements-v0.2.md
@@ -9,6 +9,7 @@ Statusは`implemented`、`deferred`、`deviation`のいずれかです。test名
 | IO-002 RX bufferをcloneせずTXへmove | architecture contract | `gateway_route_rewrites_and_reports_backend_acceptance` | implemented | allocation addressも検証 |
 | IO-003 requested/accepted/recycled accounting | architecture contract | `mixed_batch_is_fifo_budgeted_and_reports_requested_accepted_recycled` | implemented | backend finishで確定 |
 | IO-004 partial/error completion preserves report | architecture contract | `partial_backend_completion_preserves_report_and_aggregate_trace` | implemented | rejected slotはbackend所有で解放 |
+| IO-005 ARP partial/error completion preserves report | architecture contract | `arp_partial_backend_rejection_preserves_error_report_and_trace` | implemented | requested=1/accepted=0/rejected=1とerrorを保持 |
 | ETH-001 Ethernet II framing | RFC 894 | `all_validation_and_decision_drops_are_granular_and_atomic` | implemented | 802.3 LLC/VLANはdeferred |
 | IP4-001 Version/IHL/Total Length validation | RFC 791 §3.1 | `all_validation_and_decision_drops_are_granular_and_atomic` | implemented | なし |
 | IP4-002 Total Length後のpadding無視 | RFC 791 §3.1 | `padding_is_ignored_but_preserved` | implemented | なし |
@@ -22,9 +23,21 @@ Statusは`implemented`、`deferred`、`deviation`のいずれかです。test名
 | FWD-004 incremental checksum update | RFC 1624 §4 | `rfc_1624_negative_zero_boundary_is_positive_zero` | implemented | `0xdd2f,0x5555→0x3285 = 0x0000` |
 | FWD-005 drop atomicity | architecture contract | `all_validation_and_decision_drops_are_granular_and_atomic` | implemented | なし |
 | FWD-006 snapshot integrity | architecture contract | `snapshot_constructor_rejects_all_broken_references_and_duplicates` | implemented | 公開前にvalidation |
+| FWD-007 unresolved packet hold/ARP request generation | RFC 1122 §2.3.2.2, RFC 1812 §3.3.2 | `all_validation_and_decision_drops_are_granular_and_atomic` | deferred | static neighbor missはbyte不変NeighborUnresolved。allocator/request/retry/hold queueが無く、最初のpacketは自動再送されない |
+| ARP-001 Ethernet/IPv4 request profile validation | RFC 826 | `arp_profile_validation_drops_are_granular_and_atomic` | implemented | HTYPE=1/PTYPE=0x0800/HLEN=6/PLEN=4/opcode=1 |
+| ARP-002 local target in-place reply on ingress | RFC 826 | `arp_request_for_local_ipv4_replies_in_place_on_ingress` | implemented | 同じRX allocation、egress=ingress、wire fieldsを検証 |
+| ARP-003 probe reply with zero target protocol | RFC 5227 §2.1 | `arp_probe_for_local_ipv4_replies_with_zero_target_protocol` | implemented | SPA=0 requestにも通常reply |
+| ARP-004 request THA ignored/source identities not coupled | RFC 826 | `arp_request_target_hardware_is_ignored` | implemented | Ethernet source≠ARP SHAも受理 |
+| ARP-005 tail/padding preservation | RFC 826 wire profile | `arp_padding_is_ignored_and_preserved_on_reply` | implemented | 42 byte以後を変更しない |
+| ARP-006 nonlocal/reply/unknown opcode stable recycle | explainability requirement | `arp_nonlocal_and_reply_are_recycled_without_mutation` | implemented | replyとunknown opcodeは別stable reason |
+| ARP-007 local binding snapshot integrity | architecture contract | `arp_snapshot_rejects_duplicate_or_unknown_local_addresses` | implemented | 現profileはinterfaceごとにlocal IPv4一つ、address重複も拒否。MACはInterfaceのみ |
+| ARP-008 address conflict detection/defense | RFC 5227 §2.4 | `arp_foreign_sender_claiming_local_address_gets_normal_reply` | deviation | foreign SHAがlocal SPAを名乗ってもconflict state/defensive announcementなし。local targetへの通常replyのみ |
+| ARP-009 learning/cache/request/retry/hold/proxy/gratuitous/ACD | RFC 826, RFC 5227 | `arp_nonlocal_and_reply_are_recycled_without_mutation` | deferred | immutable responder sliceのみ。neighbor学習・VLAN・generated allocatorも非対象 |
 | OBS-001 stable reason code | explainability requirement | `drop_reason_discriminants_and_codes_are_stable_and_unique` | implemented | repr(u16) |
 | OBS-002 requestedとaggregate TX outcome trace | explainability requirement | `partial_backend_completion_preserves_report_and_aggregate_trace` | implemented | packet単位accepted traceはdeferred |
+| OBS-003 protocol-aware ARP trace ordering | explainability requirement | `arp_trace_is_deterministic_and_tx_follows_commit` | implemented | validated/reply requested/TX requested/completionを順序検証 |
 | SIM-001 FIFO/budget/mixed batch | deterministic test requirement | `mixed_batch_is_fifo_budgeted_and_reports_requested_accepted_recycled` | implemented | なし |
+| SIM-002 mixed IPv4/ARP FIFO and budget | deterministic test requirement | `mixed_ipv4_and_arp_batch_is_fifo_budgeted_and_deterministic` | implemented | protocol混在でもsequenceとbudgetを保持 |
 
 ## RFC deviation rule
 

--- a/docs/requirements-v0.2.md
+++ b/docs/requirements-v0.2.md
@@ -29,10 +29,10 @@ Statusは`implemented`、`deferred`、`deviation`のいずれかです。test名
 | ARP-003 probe reply with zero target protocol | RFC 5227 §2.5（Probe形式は§1.1/§2.1.1） | `arp_probe_for_local_ipv4_replies_with_zero_target_protocol` | implemented | SPA=0 requestにも通常reply |
 | ARP-004 request THA ignored/source identities not coupled | RFC 826 | `arp_request_target_hardware_is_ignored` | implemented | Ethernet source≠ARP SHAも受理 |
 | ARP-005 tail/padding preservation | RFC 826 wire profile | `arp_padding_is_ignored_and_preserved_on_reply` | implemented | 42 byte以後を変更しない |
-| ARP-006 nonlocal/reply/unknown opcode stable recycle | explainability requirement | `arp_nonlocal_and_reply_are_recycled_without_mutation` | implemented | replyとunknown opcodeは別stable reason |
+| ARP-006 nonlocal/proxy-disabled/reply/unknown opcode stable recycle | RFC 826, RFC 1027, RFC 5494/IANA ARP Parameters | `arp_nonlocal_and_reply_are_recycled_without_mutation` | implemented | nonlocal targetへ応答せずproxy ARPは無効。replyとunknown opcodeは別stable reason |
 | ARP-007 local binding snapshot integrity | architecture contract | `arp_snapshot_rejects_duplicate_or_unknown_local_addresses` | implemented | 現profileはinterfaceごとにlocal IPv4一つ、address重複も拒否。MACはInterfaceのみ |
 | ARP-008 address conflict detection/defense | RFC 5227 §2.4 | `arp_foreign_sender_claiming_local_address_gets_normal_reply` | deviation | foreign SHAがlocal SPAを名乗ってもconflict state/defensive announcementなし。local targetへの通常replyのみ |
-| ARP-009 learning/cache/request/retry/hold/proxy/gratuitous/ACD | RFC 826, RFC 1122 §2.3.2.1/§2.3.2.2, RFC 1812 §3.3.2, RFC 5227 | `arp_reply_does_not_learn_or_generate_for_unresolved_neighbor` | deferred | reply直後もsenderを学習せず、static missはARP生成/holdなし。neighbor学習・VLAN・generated allocatorも非対象 |
+| ARP-009 learning/cache/request/retry/hold | RFC 826, RFC 1122 §2.3.2.1/§2.3.2.2, RFC 1812 §3.3.2 | `arp_reply_does_not_learn_or_generate_for_unresolved_neighbor` | deferred | reply直後もsenderを学習せず、static missはARP生成・retry・holdなし |
 | OBS-001 stable reason code | explainability requirement | `drop_reason_discriminants_and_codes_are_stable_and_unique` | implemented | repr(u16) |
 | OBS-002 requestedとaggregate TX outcome trace | explainability requirement | `partial_backend_completion_preserves_report_and_aggregate_trace` | implemented | packet単位accepted traceはdeferred |
 | OBS-003 protocol-aware ARP trace ordering | explainability requirement | `arp_trace_is_deterministic_and_tx_follows_commit` | implemented | validated/reply requested/TX requested/completionを順序検証 |

--- a/docs/requirements-v0.2.md
+++ b/docs/requirements-v0.2.md
@@ -23,16 +23,16 @@ Statusは`implemented`、`deferred`、`deviation`のいずれかです。test名
 | FWD-004 incremental checksum update | RFC 1624 §4 | `rfc_1624_negative_zero_boundary_is_positive_zero` | implemented | `0xdd2f,0x5555→0x3285 = 0x0000` |
 | FWD-005 drop atomicity | architecture contract | `all_validation_and_decision_drops_are_granular_and_atomic` | implemented | なし |
 | FWD-006 snapshot integrity | architecture contract | `snapshot_constructor_rejects_all_broken_references_and_duplicates` | implemented | 公開前にvalidation |
-| FWD-007 unresolved packet hold/ARP request generation | RFC 1122 §2.3.2.2, RFC 1812 §3.3.2 | `all_validation_and_decision_drops_are_granular_and_atomic` | deferred | static neighbor missはbyte不変NeighborUnresolved。allocator/request/retry/hold queueが無く、最初のpacketは自動再送されない |
-| ARP-001 Ethernet/IPv4 request profile validation | RFC 826 | `arp_profile_validation_drops_are_granular_and_atomic` | implemented | HTYPE=1/PTYPE=0x0800/HLEN=6/PLEN=4/opcode=1 |
+| FWD-007 unresolved packet hold/ARP request generation | RFC 1122 §2.3.2.1/§2.3.2.2, RFC 1812 §3.3.2 | `arp_reply_does_not_learn_or_generate_for_unresolved_neighbor` | deferred | static neighbor missはbyte不変NeighborUnresolved。allocator/request/retry/hold queueが無く、最初のpacketは自動再送されない |
+| ARP-001 Ethernet/IPv4 request profile validation | RFC 826, RFC 5494/IANA ARP Parameters | `arp_profile_validation_drops_are_granular_and_atomic` | implemented | HTYPE=1/PTYPE=0x0800/HLEN=6/PLEN=4/opcode=1。replyとunknown opcodeを区別 |
 | ARP-002 local target in-place reply on ingress | RFC 826 | `arp_request_for_local_ipv4_replies_in_place_on_ingress` | implemented | 同じRX allocation、egress=ingress、wire fieldsを検証 |
-| ARP-003 probe reply with zero target protocol | RFC 5227 §2.1 | `arp_probe_for_local_ipv4_replies_with_zero_target_protocol` | implemented | SPA=0 requestにも通常reply |
+| ARP-003 probe reply with zero target protocol | RFC 5227 §2.5（Probe形式は§1.1/§2.1.1） | `arp_probe_for_local_ipv4_replies_with_zero_target_protocol` | implemented | SPA=0 requestにも通常reply |
 | ARP-004 request THA ignored/source identities not coupled | RFC 826 | `arp_request_target_hardware_is_ignored` | implemented | Ethernet source≠ARP SHAも受理 |
 | ARP-005 tail/padding preservation | RFC 826 wire profile | `arp_padding_is_ignored_and_preserved_on_reply` | implemented | 42 byte以後を変更しない |
 | ARP-006 nonlocal/reply/unknown opcode stable recycle | explainability requirement | `arp_nonlocal_and_reply_are_recycled_without_mutation` | implemented | replyとunknown opcodeは別stable reason |
 | ARP-007 local binding snapshot integrity | architecture contract | `arp_snapshot_rejects_duplicate_or_unknown_local_addresses` | implemented | 現profileはinterfaceごとにlocal IPv4一つ、address重複も拒否。MACはInterfaceのみ |
 | ARP-008 address conflict detection/defense | RFC 5227 §2.4 | `arp_foreign_sender_claiming_local_address_gets_normal_reply` | deviation | foreign SHAがlocal SPAを名乗ってもconflict state/defensive announcementなし。local targetへの通常replyのみ |
-| ARP-009 learning/cache/request/retry/hold/proxy/gratuitous/ACD | RFC 826, RFC 5227 | `arp_nonlocal_and_reply_are_recycled_without_mutation` | deferred | immutable responder sliceのみ。neighbor学習・VLAN・generated allocatorも非対象 |
+| ARP-009 learning/cache/request/retry/hold/proxy/gratuitous/ACD | RFC 826, RFC 1122 §2.3.2.1/§2.3.2.2, RFC 1812 §3.3.2, RFC 5227 | `arp_reply_does_not_learn_or_generate_for_unresolved_neighbor` | deferred | reply直後もsenderを学習せず、static missはARP生成/holdなし。neighbor学習・VLAN・generated allocatorも非対象 |
 | OBS-001 stable reason code | explainability requirement | `drop_reason_discriminants_and_codes_are_stable_and_unique` | implemented | repr(u16) |
 | OBS-002 requestedとaggregate TX outcome trace | explainability requirement | `partial_backend_completion_preserves_report_and_aggregate_trace` | implemented | packet単位accepted traceはdeferred |
 | OBS-003 protocol-aware ARP trace ordering | explainability requirement | `arp_trace_is_deterministic_and_tx_follows_commit` | implemented | validated/reply requested/TX requested/completionを順序検証 |


### PR DESCRIPTION
## Summary

- validate the Ethernet/IPv4 ARP request profile without mutating the frame
- add validated local IPv4 bindings while keeping interface MAC as the single source of truth
- reply to requests for an ingress-local address by rewriting the backend-owned RX slot in place and committing it back to the ingress interface
- preserve ARP Probe semantics, ignored request THA, differing Ethernet/ARP sender identities, and trailing padding
- add stable granular drop reasons and protocol-aware trace events
- keep existing static IPv4 forwarding, FIFO budgets, and partial-TX accounting intact

## Ownership and fast path

- no `PacketIo` API expansion or generated-packet allocator
- no packet clone, per-packet heap allocation, shared `Mutex`, `String`, `dyn PacketIo`, raw backend pointer, or unsafe code
- all validation and local-target decisions finish before mutation
- every ARP drop path is byte-for-byte atomic
- the same RX allocation becomes the reply TX slot; egress is always ingress

## Scope and standards

Implemented:

- RFC 826 Ethernet/IPv4 request validation and reply field rewrite
- RFC 5227 Probe reply behavior, including zero target protocol in the reply
- RFC 5494/IANA opcode-aware unsupported handling
- nonlocal/reply/profile failures with stable reasons

Explicitly deferred:

- dynamic learning/cache and aging
- generated ARP requests, retry/rate limiting, unresolved-packet hold queue
- gratuitous/proxy ARP, VLAN, generated-packet allocator

RFC 5227 address-conflict defense remains a documented deviation. A foreign sender claiming the local SPA receives the normal directed reply, but no conflict state or defensive announcement is generated.

## Validation

- 29 tests: 5 core unit + 24 sim acceptance
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets`
- rustdoc with `-D warnings`
- requirement-ledger lint and `git diff --check`
- independent ownership/core-safety review: no Critical/High/Medium findings
- independent RFC/tests/docs review: no Critical/High/Medium findings

The next slice will introduce a separate backend-owned generated-TX lease and worker-local typed action queue before implementing active ARP resolution.