### PR TITLE
feat(core): generate throttled ARP resolution requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
           toolchain: 1.97.1
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - run: cargo test --workspace --all-targets
+      - run: cargo test --doc --workspace
 
   clippy:
     name: Clippy

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ active treeは、そのコードを継承しないv0.2のゼロベース実装�
 この最初の縦切りは、外部依存を持たない二つのlibrary crateだけで構成します。
 
 - `ruster-core`: backend所有packetを借用し、Ethernet II / IPv4検証、LPM、
-  TTL/checksum/MAC rewriteとlocal IPv4向けARP replyを行う。
-- `ruster-io-sim`: rootやNICなしでFIFO、budget、TX/drop、traceを決定的に検証する。
+  TTL/checksum/MAC rewrite、local IPv4向けARP reply、static neighbor miss時の
+  ARP Request生成actionを扱う。
+- `ruster-io-sim`: rootやNICなしでRX/generated TXのFIFO、budget、TX/drop、
+  traceを決定的に検証する。
 
 ```text
 inject Vec<u8>
@@ -26,6 +28,11 @@ fast pathはpacket batchをworkerが専有します。共有`Mutex`、packet単�
 packet clone、`dyn PacketIo`を導入しません。simの`Vec`はcold I/O境界に閉じています。
 ARP replyも同じRX bufferをin-placeで書き換え、受信interfaceへcommitします。現在の
 ARP profileはinterfaceごとにlocal IPv4を一つだけ持つ静的snapshotです。
+
+static neighbor missでは元IPv4 packetをbyte不変でrecycleした後、worker-localな固定
+storageで1秒に一度までARP Requestを生成できます。RX batchとgenerated TX sessionは
+二相に分離し、生成frameもbackend所有bufferを借用します。これはrequest generationと
+flood suppressionまでであり、reply学習やpacket holdを含むactive resolutionではありません。
 
 ## 開発
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ stable Rustだけで検証できます。
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test --workspace --all-targets
+cargo test --doc --workspace
 RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps
 cargo check --workspace
 ```

--- a/crates/core/src/forwarding.rs
+++ b/crates/core/src/forwarding.rs
@@ -392,7 +392,10 @@ fn decide_ipv4<T: TraceSink>(
                     target_ip: target,
                 },
                 *now,
-                route.is_directed_broadcast(target),
+                snapshot.routes.iter().any(|candidate| {
+                    candidate.egress() == route.egress()
+                        && candidate.is_connected_directed_broadcast(target)
+                }),
             );
             trace.record(TraceEvent::NeighborResolution {
                 egress: route.egress(),

--- a/crates/core/src/forwarding.rs
+++ b/crates/core/src/forwarding.rs
@@ -1,6 +1,7 @@
 use crate::{
-    packet, rfc1624_update, route, validate_arp_request, validate_ipv4_frame, BatchCompletion,
-    IfId, Interface, LocalIpv4Binding, Neighbor, PacketBatch, Route, ARP_ETHERTYPE, IPV4_ETHERTYPE,
+    packet, rfc1624_update, route, validate_arp_request, validate_ipv4_frame, ArpRequestAction,
+    BatchCompletion, IfId, Interface, LocalIpv4Binding, MonotonicMillis, Neighbor, PacketBatch,
+    ResolutionResult, ResolutionRuntime, Route, ARP_ETHERTYPE, IPV4_ETHERTYPE,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -72,6 +73,7 @@ pub enum SnapshotError {
     NeighborUnknownInterface,
     DuplicateLocalIpv4Binding,
     LocalIpv4BindingUnknownInterface,
+    LocalIpv4BindingUnspecified,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -124,6 +126,9 @@ impl<'a> ForwardingSnapshot<'a> {
             }
         }
         for (index, binding) in local_ipv4.iter().enumerate() {
+            if binding.address.is_unspecified() {
+                return Err(SnapshotError::LocalIpv4BindingUnspecified);
+            }
             if local_ipv4[..index].iter().any(|candidate| {
                 candidate.interface == binding.interface || candidate.address == binding.address
             }) {
@@ -159,6 +164,11 @@ pub enum TraceEvent {
     Routed {
         egress: IfId,
         neighbor_target: crate::Ipv4Address,
+    },
+    NeighborResolution {
+        egress: IfId,
+        target: crate::Ipv4Address,
+        result: ResolutionResult,
     },
     /// The packet was handed to the backend, not necessarily accepted by TX.
     TxRequested {
@@ -239,8 +249,37 @@ impl PacketDecision {
 }
 
 pub fn forward_batch<B, T>(
+    batch: B,
+    snapshot: &ForwardingSnapshot<'_>,
+    trace: &mut T,
+) -> BatchReport<B::Error>
+where
+    B: PacketBatch,
+    T: TraceSink,
+{
+    forward_batch_inner(batch, snapshot, None, trace)
+}
+
+/// Forwards RX packets and queues resolution actions without allocating TX
+/// frames. Generated execution must start only after this function returns.
+pub fn forward_batch_with_resolution<B, T>(
+    batch: B,
+    snapshot: &ForwardingSnapshot<'_>,
+    runtime: &mut ResolutionRuntime<'_>,
+    now: MonotonicMillis,
+    trace: &mut T,
+) -> BatchReport<B::Error>
+where
+    B: PacketBatch,
+    T: TraceSink,
+{
+    forward_batch_inner(batch, snapshot, Some((runtime, now)), trace)
+}
+
+fn forward_batch_inner<B, T>(
     mut batch: B,
     snapshot: &ForwardingSnapshot<'_>,
+    mut resolution: Option<(&mut ResolutionRuntime<'_>, MonotonicMillis)>,
     trace: &mut T,
 ) -> BatchReport<B::Error>
 where
@@ -255,7 +294,7 @@ where
         let ingress = packet.ingress();
         let result = {
             let frame = packet.bytes_mut();
-            decide(&*frame, snapshot, ingress, trace)
+            decide(&*frame, snapshot, ingress, &mut resolution, trace)
                 .and_then(|decision| apply_decision(frame, decision).map(|()| decision))
         };
         match result {
@@ -295,11 +334,14 @@ fn decide<T: TraceSink>(
     frame: &[u8],
     snapshot: &ForwardingSnapshot<'_>,
     ingress: IfId,
+    resolution: &mut Option<(&mut ResolutionRuntime<'_>, MonotonicMillis)>,
     trace: &mut T,
 ) -> Result<PacketDecision, DropReason> {
     let ether_type = packet::read_u16(frame, 12).ok_or(EthernetHeaderTruncated)?;
     match ether_type {
-        IPV4_ETHERTYPE => decide_ipv4(frame, snapshot, ingress, trace).map(PacketDecision::Ipv4),
+        IPV4_ETHERTYPE => {
+            decide_ipv4(frame, snapshot, ingress, resolution, trace).map(PacketDecision::Ipv4)
+        }
         ARP_ETHERTYPE => decide_arp(frame, snapshot, ingress, trace).map(PacketDecision::ArpReply),
         _ => Err(UnsupportedEtherType),
     }
@@ -309,6 +351,7 @@ fn decide_ipv4<T: TraceSink>(
     frame: &[u8],
     snapshot: &ForwardingSnapshot<'_>,
     ingress: IfId,
+    resolution: &mut Option<(&mut ResolutionRuntime<'_>, MonotonicMillis)>,
     trace: &mut T,
 ) -> Result<Ipv4RewriteDecision, DropReason> {
     let ipv4 = validate_ipv4_frame(frame)?;
@@ -324,16 +367,41 @@ fn decide_ipv4<T: TraceSink>(
     }
     let route = route::lookup(snapshot.routes, ipv4.destination).ok_or(RouteMiss)?;
     let target = route.next_hop().unwrap_or(ipv4.destination);
-    let neighbor = snapshot
-        .neighbors
-        .iter()
-        .find(|item| item.interface == route.egress() && item.target == target)
-        .ok_or(NeighborUnresolved)?;
     let interface = snapshot
         .interfaces
         .iter()
         .find(|item| item.id == route.egress())
         .ok_or(InterfaceMiss)?;
+    let neighbor = snapshot
+        .neighbors
+        .iter()
+        .find(|item| item.interface == route.egress() && item.target == target);
+    let Some(neighbor) = neighbor else {
+        if let (Some(binding), Some((runtime, now))) = (
+            snapshot
+                .local_ipv4
+                .iter()
+                .find(|binding| binding.interface == route.egress()),
+            resolution.as_mut(),
+        ) {
+            let result = runtime.schedule(
+                ArpRequestAction {
+                    egress: route.egress(),
+                    source_mac: interface.mac,
+                    source_ip: binding.address,
+                    target_ip: target,
+                },
+                *now,
+                route.is_directed_broadcast(target),
+            );
+            trace.record(TraceEvent::NeighborResolution {
+                egress: route.egress(),
+                target,
+                result,
+            });
+        }
+        return Err(NeighborUnresolved);
+    };
     let ttl_offset = ipv4
         .header_offset
         .checked_add(8)

--- a/crates/core/src/generated.rs
+++ b/crates/core/src/generated.rs
@@ -1,0 +1,143 @@
+use std::{marker::PhantomData, rc::Rc};
+
+use crate::IfId;
+
+pub trait GeneratedPacketIo {
+    type Error;
+    type Batch<'a>: GeneratedPacketBatch<Error = Self::Error>
+    where
+        Self: 'a;
+
+    /// Starts an independent generated-packet session for one egress.
+    fn begin_generated(&mut self, egress: IfId) -> Self::Batch<'_>;
+}
+
+pub trait GeneratedPacketBatch {
+    type Error;
+    type Slot<'a>: GeneratedPacketSlot
+    where
+        Self: 'a;
+
+    /// Allocates a backend-owned frame with exactly `frame_len` visible bytes.
+    fn allocate(
+        &mut self,
+        frame_len: usize,
+    ) -> Result<GeneratedPacketLease<Self::Slot<'_>>, GeneratedAllocationError>;
+
+    /// Flushes requested transmissions and always returns accounting.
+    ///
+    /// Backends must preserve the three invariants checked by
+    /// [`GeneratedBatchCompletion::invariants_hold`] even when `error` is
+    /// present, and recycle every rejected frame before returning.
+    fn finish(self) -> GeneratedBatchCompletion<Self::Error>;
+}
+
+/// Backend hook hidden behind [`GeneratedPacketLease`].
+pub trait GeneratedPacketSlot {
+    fn bytes_mut(&mut self) -> &mut [u8];
+    fn complete(self, completion: GeneratedSlotCompletion);
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GeneratedAllocationError {
+    ZeroLength,
+    FrameTooLarge,
+    Unavailable,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GeneratedSlotCompletion {
+    Transmit,
+    Cancelled,
+    Abandoned,
+}
+
+/// Worker-local ownership of one exact-length generated frame.
+///
+/// A live lease cannot cross a worker boundary:
+///
+/// ```compile_fail
+/// fn require_send<T: Send>() {}
+/// require_send::<ruster_core::GeneratedPacketLease<MySlot>>();
+/// # struct MySlot;
+/// # impl ruster_core::GeneratedPacketSlot for MySlot {
+/// #   fn bytes_mut(&mut self) -> &mut [u8] { &mut [] }
+/// #   fn complete(self, _: ruster_core::GeneratedSlotCompletion) {}
+/// # }
+/// ```
+///
+/// ```compile_fail
+/// fn require_sync<T: Sync>() {}
+/// require_sync::<ruster_core::GeneratedPacketLease<MySlot>>();
+/// # struct MySlot;
+/// # impl ruster_core::GeneratedPacketSlot for MySlot {
+/// #   fn bytes_mut(&mut self) -> &mut [u8] { &mut [] }
+/// #   fn complete(self, _: ruster_core::GeneratedSlotCompletion) {}
+/// # }
+/// ```
+pub struct GeneratedPacketLease<S: GeneratedPacketSlot> {
+    slot: Option<S>,
+    _worker_local: PhantomData<Rc<()>>,
+}
+
+impl<S: GeneratedPacketSlot> GeneratedPacketLease<S> {
+    #[must_use]
+    pub fn new(slot: S) -> Self {
+        Self {
+            slot: Some(slot),
+            _worker_local: PhantomData,
+        }
+    }
+
+    pub fn bytes_mut(&mut self) -> &mut [u8] {
+        self.slot
+            .as_mut()
+            .expect("live generated lease")
+            .bytes_mut()
+    }
+
+    pub fn commit(mut self) {
+        self.complete(GeneratedSlotCompletion::Transmit);
+    }
+
+    pub fn cancel(mut self) {
+        self.complete(GeneratedSlotCompletion::Cancelled);
+    }
+
+    fn complete(&mut self, completion: GeneratedSlotCompletion) {
+        self.slot
+            .take()
+            .expect("generated lease completed exactly once")
+            .complete(completion);
+    }
+}
+
+impl<S: GeneratedPacketSlot> Drop for GeneratedPacketLease<S> {
+    fn drop(&mut self) {
+        if let Some(slot) = self.slot.take() {
+            slot.complete(GeneratedSlotCompletion::Abandoned);
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct GeneratedBatchCompletion<E> {
+    pub attempts: usize,
+    pub allocated: usize,
+    pub failed: usize,
+    pub requested: usize,
+    pub cancelled: usize,
+    pub abandoned: usize,
+    pub accepted: usize,
+    pub rejected: usize,
+    pub error: Option<E>,
+}
+
+impl<E> GeneratedBatchCompletion<E> {
+    #[must_use]
+    pub const fn invariants_hold(&self) -> bool {
+        self.attempts == self.allocated + self.failed
+            && self.allocated == self.requested + self.cancelled + self.abandoned
+            && self.accepted + self.rejected == self.requested
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -3,18 +3,30 @@
 
 mod checksum;
 mod forwarding;
+mod generated;
 mod io;
 mod packet;
+mod resolution;
 mod route;
 
 pub use checksum::{ipv4_header_checksum, rfc1624_update};
 pub use forwarding::{
-    forward_batch, BatchReport, DropReason, ForwardingSnapshot, NoTrace, SnapshotError, TraceEvent,
-    TraceSink,
+    forward_batch, forward_batch_with_resolution, BatchReport, DropReason, ForwardingSnapshot,
+    NoTrace, SnapshotError, TraceEvent, TraceSink,
+};
+pub use generated::{
+    GeneratedAllocationError, GeneratedBatchCompletion, GeneratedPacketBatch, GeneratedPacketIo,
+    GeneratedPacketLease, GeneratedPacketSlot, GeneratedSlotCompletion,
 };
 pub use io::{BatchCompletion, PacketBatch, PacketIo, PacketLease, PacketSlot, SlotCompletion};
 pub use packet::{
     validate_arp_request, validate_ipv4_frame, MacAddress, ValidatedArpRequest, ValidatedIpv4,
     ARP_ETHERTYPE, ETHERNET_HEADER_LEN, IPV4_ETHERTYPE,
+};
+pub use resolution::{
+    execute_one_arp_request, ArpRequestAction, ArpRequestBuildError, ExecuteArpRequestError,
+    GeneratedArpReport, GeneratedArpTrace, GeneratedTraceSink, MonotonicMillis, NoGeneratedTrace,
+    ResolutionActionSlot, ResolutionCounters, ResolutionPolicy, ResolutionPolicyError,
+    ResolutionResult, ResolutionRuntime, ResolutionStateSlot, ARP_REQUEST_FRAME_LEN,
 };
 pub use route::{IfId, Interface, Ipv4Address, LocalIpv4Binding, Neighbor, Route, RouteError};

--- a/crates/core/src/resolution.rs
+++ b/crates/core/src/resolution.rs
@@ -1,0 +1,404 @@
+use std::{marker::PhantomData, rc::Rc};
+
+use crate::{
+    GeneratedAllocationError, GeneratedBatchCompletion, GeneratedPacketBatch, GeneratedPacketIo,
+    IfId, Ipv4Address, MacAddress, ARP_ETHERTYPE, IPV4_ETHERTYPE,
+};
+
+pub const ARP_REQUEST_FRAME_LEN: usize = 60;
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct MonotonicMillis(pub u64);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ResolutionPolicyError {
+    IntervalTooShort,
+    StateTtlTooShort,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ResolutionPolicy {
+    interval_ms: u64,
+    state_ttl_ms: u64,
+}
+
+impl ResolutionPolicy {
+    pub fn new(interval_ms: u64, state_ttl_ms: u64) -> Result<Self, ResolutionPolicyError> {
+        if interval_ms < 1_000 {
+            return Err(ResolutionPolicyError::IntervalTooShort);
+        }
+        if state_ttl_ms < interval_ms {
+            return Err(ResolutionPolicyError::StateTtlTooShort);
+        }
+        Ok(Self {
+            interval_ms,
+            state_ttl_ms,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ArpRequestAction {
+    pub egress: IfId,
+    pub source_mac: MacAddress,
+    pub source_ip: Ipv4Address,
+    pub target_ip: Ipv4Address,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ResolutionKey {
+    egress: IfId,
+    target: Ipv4Address,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct QueuedAction {
+    action: ArpRequestAction,
+    generation: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ResolutionActionSlot(Option<QueuedAction>);
+
+impl ResolutionActionSlot {
+    pub const EMPTY: Self = Self(None);
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ResolutionStateSlot {
+    key: ResolutionKey,
+    generation: u64,
+    requested_at: MonotonicMillis,
+    occupied: bool,
+    action_queued: bool,
+    has_requested: bool,
+}
+
+impl ResolutionStateSlot {
+    pub const EMPTY: Self = Self {
+        key: ResolutionKey {
+            egress: IfId(0),
+            target: Ipv4Address::from_octets([0; 4]),
+        },
+        generation: 0,
+        requested_at: MonotonicMillis(0),
+        occupied: false,
+        action_queued: false,
+        has_requested: false,
+    };
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ResolutionResult {
+    Queued,
+    Suppressed,
+    StateFull,
+    ActionFull,
+    ClockRegression,
+    ForbiddenTarget,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ResolutionCounters {
+    pub queued: usize,
+    pub suppressed: usize,
+    pub state_full: usize,
+    pub action_full: usize,
+    pub clock_regressions: usize,
+    pub forbidden_target: usize,
+    pub dequeued: usize,
+}
+
+/// Caller-backed worker-local resolution state.
+///
+/// ```compile_fail
+/// fn require_send<T: Send>() {}
+/// require_send::<ruster_core::ResolutionRuntime<'static>>();
+/// ```
+///
+/// ```compile_fail
+/// fn require_sync<T: Sync>() {}
+/// require_sync::<ruster_core::ResolutionRuntime<'static>>();
+/// ```
+pub struct ResolutionRuntime<'a> {
+    policy: ResolutionPolicy,
+    states: &'a mut [ResolutionStateSlot],
+    actions: &'a mut [ResolutionActionSlot],
+    head: usize,
+    len: usize,
+    last_now: Option<MonotonicMillis>,
+    counters: ResolutionCounters,
+    _worker_local: PhantomData<Rc<()>>,
+}
+
+impl<'a> ResolutionRuntime<'a> {
+    #[must_use]
+    pub fn new(
+        policy: ResolutionPolicy,
+        states: &'a mut [ResolutionStateSlot],
+        action_storage: &'a mut [ResolutionActionSlot],
+    ) -> Self {
+        action_storage.fill(ResolutionActionSlot::EMPTY);
+        Self {
+            policy,
+            states,
+            actions: action_storage,
+            head: 0,
+            len: 0,
+            last_now: None,
+            counters: ResolutionCounters::default(),
+            _worker_local: PhantomData,
+        }
+    }
+
+    #[must_use]
+    pub const fn counters(&self) -> ResolutionCounters {
+        self.counters
+    }
+
+    #[must_use]
+    pub const fn pending_actions(&self) -> usize {
+        self.len
+    }
+
+    pub(crate) fn schedule(
+        &mut self,
+        action: ArpRequestAction,
+        now: MonotonicMillis,
+        directed_broadcast: bool,
+    ) -> ResolutionResult {
+        if self.last_now.is_some_and(|last| now < last) {
+            self.counters.clock_regressions += 1;
+            return ResolutionResult::ClockRegression;
+        }
+        self.last_now = Some(now);
+        if directed_broadcast || forbidden_target(action.target_ip) {
+            self.counters.forbidden_target += 1;
+            return ResolutionResult::ForbiddenTarget;
+        }
+        let key = ResolutionKey {
+            egress: action.egress,
+            target: action.target_ip,
+        };
+        let existing = self
+            .states
+            .iter()
+            .position(|slot| slot.occupied && slot.key == key);
+        if let Some(index) = existing {
+            let state = &self.states[index];
+            if state.action_queued
+                || (state.has_requested
+                    && now.0.saturating_sub(state.requested_at.0) < self.policy.interval_ms)
+            {
+                self.counters.suppressed += 1;
+                return ResolutionResult::Suppressed;
+            }
+            return self.enqueue_at(index, action);
+        }
+        let reusable = self.states.iter().position(|slot| {
+            !slot.occupied
+                || (!slot.action_queued
+                    && slot.has_requested
+                    && now.0.saturating_sub(slot.requested_at.0) >= self.policy.state_ttl_ms)
+        });
+        let Some(index) = reusable else {
+            self.counters.state_full += 1;
+            return ResolutionResult::StateFull;
+        };
+        if self.len == self.actions.len() {
+            self.counters.action_full += 1;
+            return ResolutionResult::ActionFull;
+        }
+        self.states[index] = ResolutionStateSlot {
+            key,
+            generation: self.states[index].generation.wrapping_add(1),
+            requested_at: MonotonicMillis(0),
+            occupied: true,
+            action_queued: false,
+            has_requested: false,
+        };
+        self.enqueue_at(index, action)
+    }
+
+    fn enqueue_at(&mut self, index: usize, action: ArpRequestAction) -> ResolutionResult {
+        if self.len == self.actions.len() {
+            self.counters.action_full += 1;
+            return ResolutionResult::ActionFull;
+        }
+        let generation = self.states[index].generation.wrapping_add(1);
+        let tail = (self.head + self.len) % self.actions.len();
+        self.actions[tail].0 = Some(QueuedAction { action, generation });
+        self.states[index].generation = generation;
+        self.states[index].action_queued = true;
+        self.len += 1;
+        self.counters.queued += 1;
+        ResolutionResult::Queued
+    }
+
+    fn front(&self) -> Option<QueuedAction> {
+        self.actions.get(self.head).and_then(|item| item.0)
+    }
+
+    fn execution_time_valid(&mut self, now: MonotonicMillis) -> bool {
+        if self.last_now.is_some_and(|last| now < last) {
+            self.counters.clock_regressions += 1;
+            return false;
+        }
+        self.last_now = Some(now);
+        true
+    }
+
+    fn committed(&mut self, queued: QueuedAction, now: MonotonicMillis) {
+        let item = self.actions[self.head]
+            .0
+            .take()
+            .expect("committed action is queue front");
+        debug_assert_eq!(item, queued);
+        self.head = (self.head + 1) % self.actions.len();
+        self.len -= 1;
+        self.counters.dequeued += 1;
+        if let Some(state) = self.states.iter_mut().find(|state| {
+            state.occupied
+                && state.key.egress == queued.action.egress
+                && state.key.target == queued.action.target_ip
+                && state.generation == queued.generation
+        }) {
+            state.action_queued = false;
+            state.has_requested = true;
+            state.requested_at = now;
+        }
+    }
+}
+
+fn forbidden_target(target: Ipv4Address) -> bool {
+    let octets = target.octets();
+    octets == [0, 0, 0, 0] || octets == [255; 4] || (octets[0] & 0xf0) == 0xe0
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GeneratedArpTrace {
+    AllocationFailed(GeneratedAllocationError),
+    BuildFailed(ArpRequestBuildError),
+    ClockRegression,
+    TxRequested { egress: IfId, target: Ipv4Address },
+    BatchCompleted { accepted: usize, rejected: usize },
+}
+
+pub trait GeneratedTraceSink {
+    fn record_generated(&mut self, event: GeneratedArpTrace);
+}
+
+#[derive(Default)]
+pub struct NoGeneratedTrace;
+
+impl GeneratedTraceSink for NoGeneratedTrace {
+    #[inline]
+    fn record_generated(&mut self, _event: GeneratedArpTrace) {}
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ArpRequestBuildError {
+    ExactLengthRequired,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ExecuteArpRequestError {
+    ClockRegression,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct GeneratedArpReport<E> {
+    pub action: ArpRequestAction,
+    pub allocation_error: Option<GeneratedAllocationError>,
+    pub build_error: Option<ArpRequestBuildError>,
+    pub completion: GeneratedBatchCompletion<E>,
+}
+
+/// Executes at most one queued action. Allocation failure retains the action.
+pub fn execute_one_arp_request<I, T>(
+    io: &mut I,
+    runtime: &mut ResolutionRuntime<'_>,
+    now: MonotonicMillis,
+    trace: &mut T,
+) -> Result<Option<GeneratedArpReport<I::Error>>, ExecuteArpRequestError>
+where
+    I: GeneratedPacketIo,
+    T: GeneratedTraceSink,
+{
+    let Some(queued) = runtime.front() else {
+        return Ok(None);
+    };
+    if !runtime.execution_time_valid(now) {
+        trace.record_generated(GeneratedArpTrace::ClockRegression);
+        return Err(ExecuteArpRequestError::ClockRegression);
+    }
+    let mut batch = io.begin_generated(queued.action.egress);
+    let (allocation_error, build_error) = match allocate_arp_request(&mut batch, queued.action) {
+        Ok(()) => {
+            runtime.committed(queued, now);
+            trace.record_generated(GeneratedArpTrace::TxRequested {
+                egress: queued.action.egress,
+                target: queued.action.target_ip,
+            });
+            (None, None)
+        }
+        Err(ArpRequestGenerationError::Allocation(error)) => {
+            trace.record_generated(GeneratedArpTrace::AllocationFailed(error));
+            (Some(error), None)
+        }
+        Err(ArpRequestGenerationError::Build(error)) => {
+            trace.record_generated(GeneratedArpTrace::BuildFailed(error));
+            (None, Some(error))
+        }
+    };
+    let completion = batch.finish();
+    trace.record_generated(GeneratedArpTrace::BatchCompleted {
+        accepted: completion.accepted,
+        rejected: completion.rejected,
+    });
+    Ok(Some(GeneratedArpReport {
+        action: queued.action,
+        allocation_error,
+        build_error,
+        completion,
+    }))
+}
+
+enum ArpRequestGenerationError {
+    Allocation(GeneratedAllocationError),
+    Build(ArpRequestBuildError),
+}
+
+fn allocate_arp_request<B: GeneratedPacketBatch>(
+    batch: &mut B,
+    action: ArpRequestAction,
+) -> Result<(), ArpRequestGenerationError> {
+    let mut lease = batch
+        .allocate(ARP_REQUEST_FRAME_LEN)
+        .map_err(ArpRequestGenerationError::Allocation)?;
+    if lease.bytes_mut().len() != ARP_REQUEST_FRAME_LEN {
+        lease.cancel();
+        return Err(ArpRequestGenerationError::Build(
+            ArpRequestBuildError::ExactLengthRequired,
+        ));
+    }
+    build_arp_request(lease.bytes_mut(), action);
+    lease.commit();
+    Ok(())
+}
+
+fn build_arp_request(frame: &mut [u8], action: ArpRequestAction) {
+    debug_assert_eq!(frame.len(), ARP_REQUEST_FRAME_LEN);
+    frame.fill(0);
+    frame[0..6].fill(0xff);
+    frame[6..12].copy_from_slice(&action.source_mac.0);
+    frame[12..14].copy_from_slice(&ARP_ETHERTYPE.to_be_bytes());
+    frame[14..16].copy_from_slice(&1_u16.to_be_bytes());
+    frame[16..18].copy_from_slice(&IPV4_ETHERTYPE.to_be_bytes());
+    frame[18] = 6;
+    frame[19] = 4;
+    frame[20..22].copy_from_slice(&1_u16.to_be_bytes());
+    frame[22..28].copy_from_slice(&action.source_mac.0);
+    frame[28..32].copy_from_slice(&action.source_ip.octets());
+    frame[38..42].copy_from_slice(&action.target_ip.octets());
+}

--- a/crates/core/src/resolution.rs
+++ b/crates/core/src/resolution.rs
@@ -138,6 +138,7 @@ impl<'a> ResolutionRuntime<'a> {
         states: &'a mut [ResolutionStateSlot],
         action_storage: &'a mut [ResolutionActionSlot],
     ) -> Self {
+        states.fill(ResolutionStateSlot::EMPTY);
         action_storage.fill(ResolutionActionSlot::EMPTY);
         Self {
             policy,
@@ -172,7 +173,10 @@ impl<'a> ResolutionRuntime<'a> {
             return ResolutionResult::ClockRegression;
         }
         self.last_now = Some(now);
-        if directed_broadcast || forbidden_target(action.target_ip) {
+        if directed_broadcast
+            || action.target_ip == action.source_ip
+            || forbidden_target(action.target_ip)
+        {
             self.counters.forbidden_target += 1;
             return ResolutionResult::ForbiddenTarget;
         }

--- a/crates/core/src/route.rs
+++ b/crates/core/src/route.rs
@@ -106,8 +106,8 @@ impl Route {
         address.0 & mask == self.prefix.0
     }
 
-    pub(crate) fn is_directed_broadcast(self, address: Ipv4Address) -> bool {
-        if self.next_hop.is_some() || self.prefix_len >= 31 || !self.matches(address) {
+    pub(crate) fn is_connected_directed_broadcast(self, address: Ipv4Address) -> bool {
+        if self.next_hop.is_some() || self.prefix_len > 30 || !self.matches(address) {
             return false;
         }
         let mask = prefix_mask(self.prefix_len).expect("Route::new validates prefix length");

--- a/crates/core/src/route.rs
+++ b/crates/core/src/route.rs
@@ -16,6 +16,11 @@ impl Ipv4Address {
     pub const fn octets(self) -> [u8; 4] {
         self.0.to_be_bytes()
     }
+
+    #[must_use]
+    pub const fn is_unspecified(self) -> bool {
+        self.0 == 0
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -99,6 +104,14 @@ impl Route {
     pub(crate) fn matches(self, address: Ipv4Address) -> bool {
         let mask = prefix_mask(self.prefix_len).expect("Route::new validates prefix length");
         address.0 & mask == self.prefix.0
+    }
+
+    pub(crate) fn is_directed_broadcast(self, address: Ipv4Address) -> bool {
+        if self.next_hop.is_some() || self.prefix_len >= 31 || !self.matches(address) {
+            return false;
+        }
+        let mask = prefix_mask(self.prefix_len).expect("Route::new validates prefix length");
+        address.0 == self.prefix.0 | !mask
     }
 }
 

--- a/crates/io-sim/src/lib.rs
+++ b/crates/io-sim/src/lib.rs
@@ -4,8 +4,11 @@
 use std::{collections::VecDeque, convert::Infallible};
 
 use ruster_core::{
-    forward_batch, BatchCompletion, BatchReport, DropReason, ForwardingSnapshot, IfId, PacketBatch,
-    PacketIo, PacketLease, PacketSlot, SlotCompletion, TraceEvent, TraceSink,
+    forward_batch, BatchCompletion, BatchReport, DropReason, ForwardingSnapshot,
+    GeneratedAllocationError, GeneratedArpTrace, GeneratedBatchCompletion, GeneratedPacketBatch,
+    GeneratedPacketIo, GeneratedPacketLease, GeneratedPacketSlot, GeneratedSlotCompletion,
+    GeneratedTraceSink, IfId, PacketBatch, PacketIo, PacketLease, PacketSlot, SlotCompletion,
+    TraceEvent, TraceSink,
 };
 
 #[derive(Debug, Eq, PartialEq)]
@@ -20,7 +23,14 @@ pub struct TxFrame {
     pub sequence: u64,
     pub ingress: IfId,
     pub egress: IfId,
+    pub origin: FrameOrigin,
     pub bytes: Vec<u8>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FrameOrigin {
+    Received { ingress: IfId },
+    Generated,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -37,12 +47,53 @@ pub struct RecycledFrame {
     pub bytes: Vec<u8>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GeneratedRecycleCause {
+    Cancelled,
+    Abandoned,
+    TxRejected,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct GeneratedRecycledFrame {
+    pub sequence: u64,
+    pub egress: IfId,
+    pub cause: GeneratedRecycleCause,
+    pub bytes: Vec<u8>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SimGeneratedError {
+    Injected,
+}
+
+#[derive(Debug)]
 pub struct SimIo {
     next_sequence: u64,
     rx: VecDeque<Slot>,
     tx: VecDeque<TxFrame>,
     recycled: VecDeque<RecycledFrame>,
+    generated_recycled: VecDeque<GeneratedRecycledFrame>,
+    generated_budget: usize,
+    generated_max_frame: usize,
+    generated_accept_budget: usize,
+    fail_generated_finish: bool,
+}
+
+impl Default for SimIo {
+    fn default() -> Self {
+        Self {
+            next_sequence: 0,
+            rx: VecDeque::new(),
+            tx: VecDeque::new(),
+            recycled: VecDeque::new(),
+            generated_recycled: VecDeque::new(),
+            generated_budget: usize::MAX,
+            generated_max_frame: 1_514,
+            generated_accept_budget: usize::MAX,
+            fail_generated_finish: false,
+        }
+    }
 }
 
 impl SimIo {
@@ -83,6 +134,26 @@ impl SimIo {
 
     pub fn pop_recycled(&mut self) -> Option<RecycledFrame> {
         self.recycled.pop_front()
+    }
+
+    pub fn pop_generated_recycled(&mut self) -> Option<GeneratedRecycledFrame> {
+        self.generated_recycled.pop_front()
+    }
+
+    pub fn set_generated_budget(&mut self, budget: usize) {
+        self.generated_budget = budget;
+    }
+
+    pub fn set_generated_max_frame(&mut self, max_frame: usize) {
+        self.generated_max_frame = max_frame;
+    }
+
+    pub fn set_generated_accept_budget(&mut self, budget: usize) {
+        self.generated_accept_budget = budget;
+    }
+
+    pub fn fail_next_generated_finish(&mut self) {
+        self.fail_generated_finish = true;
     }
 
     pub fn run_once<T: TraceSink>(
@@ -184,6 +255,9 @@ impl PacketSlot for SimSlot<'_> {
                     sequence: slot.sequence,
                     ingress: slot.ingress,
                     egress,
+                    origin: FrameOrigin::Received {
+                        ingress: slot.ingress,
+                    },
                     bytes: slot.bytes,
                 });
                 self.counters.tx_accepted += 1;
@@ -195,6 +269,179 @@ impl PacketSlot for SimSlot<'_> {
                 self.recycle(slot, RecycleCause::LeaseAbandoned);
             }
         }
+    }
+}
+
+impl GeneratedPacketIo for SimIo {
+    type Error = SimGeneratedError;
+    type Batch<'a> = SimGeneratedBatch<'a>;
+
+    fn begin_generated(&mut self, egress: IfId) -> Self::Batch<'_> {
+        let fail_finish = self.fail_generated_finish;
+        self.fail_generated_finish = false;
+        SimGeneratedBatch {
+            next_sequence: &mut self.next_sequence,
+            tx: &mut self.tx,
+            recycled: &mut self.generated_recycled,
+            egress,
+            remaining_allocations: self.generated_budget,
+            max_frame: self.generated_max_frame,
+            accept_budget: self.generated_accept_budget,
+            fail_finish,
+            pending: VecDeque::new(),
+            counters: GeneratedCounters::default(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct GeneratedSlot {
+    sequence: u64,
+    bytes: Vec<u8>,
+}
+
+#[derive(Debug, Default)]
+struct GeneratedCounters {
+    attempts: usize,
+    allocated: usize,
+    failed: usize,
+    requested: usize,
+    cancelled: usize,
+    abandoned: usize,
+}
+
+pub struct SimGeneratedBatch<'a> {
+    next_sequence: &'a mut u64,
+    tx: &'a mut VecDeque<TxFrame>,
+    recycled: &'a mut VecDeque<GeneratedRecycledFrame>,
+    egress: IfId,
+    remaining_allocations: usize,
+    max_frame: usize,
+    accept_budget: usize,
+    fail_finish: bool,
+    pending: VecDeque<GeneratedSlot>,
+    counters: GeneratedCounters,
+}
+
+impl GeneratedPacketBatch for SimGeneratedBatch<'_> {
+    type Error = SimGeneratedError;
+    type Slot<'a>
+        = SimGeneratedSlot<'a>
+    where
+        Self: 'a;
+
+    fn allocate(
+        &mut self,
+        frame_len: usize,
+    ) -> Result<GeneratedPacketLease<Self::Slot<'_>>, GeneratedAllocationError> {
+        self.counters.attempts += 1;
+        let error = if frame_len == 0 {
+            Some(GeneratedAllocationError::ZeroLength)
+        } else if frame_len > self.max_frame {
+            Some(GeneratedAllocationError::FrameTooLarge)
+        } else if self.remaining_allocations == 0 {
+            Some(GeneratedAllocationError::Unavailable)
+        } else {
+            None
+        };
+        if let Some(error) = error {
+            self.counters.failed += 1;
+            return Err(error);
+        }
+        self.remaining_allocations -= 1;
+        self.counters.allocated += 1;
+        let sequence = *self.next_sequence;
+        *self.next_sequence = self.next_sequence.wrapping_add(1);
+        Ok(GeneratedPacketLease::new(SimGeneratedSlot {
+            slot: Some(GeneratedSlot {
+                sequence,
+                bytes: vec![0xa5; frame_len],
+            }),
+            pending: &mut self.pending,
+            recycled: self.recycled,
+            counters: &mut self.counters,
+            egress: self.egress,
+        }))
+    }
+
+    fn finish(mut self) -> GeneratedBatchCompletion<Self::Error> {
+        let accepted = self.accept_budget.min(self.pending.len());
+        for _ in 0..accepted {
+            let slot = self.pending.pop_front().expect("accepted generated slot");
+            self.tx.push_back(TxFrame {
+                sequence: slot.sequence,
+                ingress: self.egress,
+                egress: self.egress,
+                origin: FrameOrigin::Generated,
+                bytes: slot.bytes,
+            });
+        }
+        let rejected = self.pending.len();
+        while let Some(slot) = self.pending.pop_front() {
+            self.recycled.push_back(GeneratedRecycledFrame {
+                sequence: slot.sequence,
+                egress: self.egress,
+                cause: GeneratedRecycleCause::TxRejected,
+                bytes: slot.bytes,
+            });
+        }
+        GeneratedBatchCompletion {
+            attempts: self.counters.attempts,
+            allocated: self.counters.allocated,
+            failed: self.counters.failed,
+            requested: self.counters.requested,
+            cancelled: self.counters.cancelled,
+            abandoned: self.counters.abandoned,
+            accepted,
+            rejected,
+            error: self.fail_finish.then_some(SimGeneratedError::Injected),
+        }
+    }
+}
+
+pub struct SimGeneratedSlot<'a> {
+    slot: Option<GeneratedSlot>,
+    pending: &'a mut VecDeque<GeneratedSlot>,
+    recycled: &'a mut VecDeque<GeneratedRecycledFrame>,
+    counters: &'a mut GeneratedCounters,
+    egress: IfId,
+}
+
+impl GeneratedPacketSlot for SimGeneratedSlot<'_> {
+    fn bytes_mut(&mut self) -> &mut [u8] {
+        &mut self.slot.as_mut().expect("live generated sim slot").bytes
+    }
+
+    fn complete(mut self, completion: GeneratedSlotCompletion) {
+        let slot = self
+            .slot
+            .take()
+            .expect("generated sim slot completed exactly once");
+        match completion {
+            GeneratedSlotCompletion::Transmit => {
+                self.counters.requested += 1;
+                self.pending.push_back(slot);
+            }
+            GeneratedSlotCompletion::Cancelled => {
+                self.counters.cancelled += 1;
+                self.recycle(slot, GeneratedRecycleCause::Cancelled);
+            }
+            GeneratedSlotCompletion::Abandoned => {
+                self.counters.abandoned += 1;
+                self.recycle(slot, GeneratedRecycleCause::Abandoned);
+            }
+        }
+    }
+}
+
+impl SimGeneratedSlot<'_> {
+    fn recycle(&mut self, slot: GeneratedSlot, cause: GeneratedRecycleCause) {
+        self.recycled.push_back(GeneratedRecycledFrame {
+            sequence: slot.sequence,
+            egress: self.egress,
+            cause,
+            bytes: slot.bytes,
+        });
     }
 }
 
@@ -228,6 +475,24 @@ impl VecTrace {
 
 impl TraceSink for VecTrace {
     fn record(&mut self, event: TraceEvent) {
+        self.events.push(event);
+    }
+}
+
+#[derive(Debug, Default, Eq, PartialEq)]
+pub struct VecGeneratedTrace {
+    events: Vec<GeneratedArpTrace>,
+}
+
+impl VecGeneratedTrace {
+    #[must_use]
+    pub fn events(&self) -> &[GeneratedArpTrace] {
+        &self.events
+    }
+}
+
+impl GeneratedTraceSink for VecGeneratedTrace {
+    fn record_generated(&mut self, event: GeneratedArpTrace) {
         self.events.push(event);
     }
 }

--- a/crates/io-sim/tests/acceptance.rs
+++ b/crates/io-sim/tests/acceptance.rs
@@ -304,6 +304,14 @@ fn arp_snapshot_rejects_duplicate_or_unknown_local_addresses() {
         ForwardingSnapshot::new(&[], &interfaces, &[], &unknown),
         Err(SnapshotError::LocalIpv4BindingUnknownInterface)
     ));
+    let unspecified = [LocalIpv4Binding {
+        interface: LAN,
+        address: ip([0; 4]),
+    }];
+    assert!(matches!(
+        ForwardingSnapshot::new(&[], &interfaces, &[], &unspecified),
+        Err(SnapshotError::LocalIpv4BindingUnspecified)
+    ));
 }
 
 #[test]

--- a/crates/io-sim/tests/generated_resolution.rs
+++ b/crates/io-sim/tests/generated_resolution.rs
@@ -70,6 +70,43 @@ fn resolution_policy_rejects_short_interval_and_state_ttl() {
     );
 }
 
+#[test]
+fn recreating_runtime_clears_caller_state_and_queued_actions() {
+    let routes = [gateway_route()];
+    let interfaces = [interface()];
+    let bindings = [binding()];
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &[], &bindings).unwrap();
+    let mut states = [ResolutionStateSlot::EMPTY; 1];
+    let mut actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut io = SimIo::new();
+    let destination = Ipv4Address::from_octets([198, 51, 100, 20]);
+    {
+        let mut runtime = ResolutionRuntime::new(policy(), &mut states, &mut actions);
+        run_miss(
+            &mut io,
+            &snapshot,
+            &mut runtime,
+            0,
+            destination,
+            &mut VecTrace::default(),
+        );
+        assert_eq!(runtime.pending_actions(), 1);
+    }
+    let mut recreated = ResolutionRuntime::new(policy(), &mut states, &mut actions);
+    assert_eq!(recreated.pending_actions(), 0);
+    run_miss(
+        &mut io,
+        &snapshot,
+        &mut recreated,
+        0,
+        destination,
+        &mut VecTrace::default(),
+    );
+    assert_eq!(recreated.pending_actions(), 1);
+    assert_eq!(recreated.counters().queued, 1);
+    assert_eq!(recreated.counters().suppressed, 0);
+}
+
 fn run_miss(
     io: &mut SimIo,
     snapshot: &ForwardingSnapshot<'_>,
@@ -242,6 +279,48 @@ fn same_target_is_rate_limited_to_one_request_per_second_at_exact_deadline() {
     run_miss(&mut io, &snapshot, &mut runtime, 1_000, dst, &mut trace);
     assert_eq!(runtime.pending_actions(), 1);
     assert_eq!(runtime.counters().queued, 2);
+    assert_eq!(runtime.counters().suppressed, 1);
+}
+
+#[test]
+fn suppression_deadline_starts_at_generated_commit_time() {
+    let routes = [gateway_route()];
+    let interfaces = [interface()];
+    let bindings = [binding()];
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &[], &bindings).unwrap();
+    let mut states = [ResolutionStateSlot::EMPTY; 1];
+    let mut actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut runtime = ResolutionRuntime::new(policy(), &mut states, &mut actions);
+    let mut io = SimIo::new();
+    let mut trace = VecTrace::default();
+    let destination = Ipv4Address::from_octets([198, 51, 100, 20]);
+    run_miss(&mut io, &snapshot, &mut runtime, 0, destination, &mut trace);
+    execute_one_arp_request(
+        &mut io,
+        &mut runtime,
+        MonotonicMillis(700),
+        &mut VecGeneratedTrace::default(),
+    )
+    .unwrap()
+    .unwrap();
+    run_miss(
+        &mut io,
+        &snapshot,
+        &mut runtime,
+        1_699,
+        destination,
+        &mut trace,
+    );
+    assert_eq!(runtime.pending_actions(), 0);
+    run_miss(
+        &mut io,
+        &snapshot,
+        &mut runtime,
+        1_700,
+        destination,
+        &mut trace,
+    );
+    assert_eq!(runtime.pending_actions(), 1);
     assert_eq!(runtime.counters().suppressed, 1);
 }
 
@@ -483,6 +562,75 @@ fn local_binding_missing_and_forbidden_targets_generate_nothing() {
             .count(),
         4
     );
+}
+
+#[test]
+fn local_source_ip_is_forbidden_as_connected_or_gateway_target() {
+    let interfaces = [interface()];
+    let bindings = [binding()];
+    let mut states = [ResolutionStateSlot::EMPTY; 1];
+    let mut actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut runtime = ResolutionRuntime::new(policy(), &mut states, &mut actions);
+    let mut io = SimIo::new();
+    let mut trace = VecTrace::default();
+
+    let connected = Route::new(Ipv4Address::from_octets([203, 0, 113, 0]), 24, WAN, None).unwrap();
+    let routes = [connected];
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &[], &bindings).unwrap();
+    run_miss(&mut io, &snapshot, &mut runtime, 0, LOCAL_IP, &mut trace);
+
+    let gateway = Route::new(Ipv4Address::from_octets([0; 4]), 0, WAN, Some(LOCAL_IP)).unwrap();
+    let routes = [gateway];
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &[], &bindings).unwrap();
+    run_miss(
+        &mut io,
+        &snapshot,
+        &mut runtime,
+        0,
+        Ipv4Address::from_octets([198, 51, 100, 20]),
+        &mut trace,
+    );
+    assert_eq!(runtime.pending_actions(), 0);
+    assert_eq!(runtime.counters().forbidden_target, 2);
+}
+
+#[test]
+fn gateway_target_matching_same_egress_connected_broadcast_is_forbidden() {
+    let connected = Route::new(Ipv4Address::from_octets([203, 0, 113, 0]), 24, WAN, None).unwrap();
+    let default = Route::new(
+        Ipv4Address::from_octets([0; 4]),
+        0,
+        WAN,
+        Some(Ipv4Address::from_octets([203, 0, 113, 255])),
+    )
+    .unwrap();
+    let routes = [connected, default];
+    let interfaces = [interface()];
+    let bindings = [binding()];
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &[], &bindings).unwrap();
+    let mut states = [ResolutionStateSlot::EMPTY; 1];
+    let mut actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut runtime = ResolutionRuntime::new(policy(), &mut states, &mut actions);
+    let mut io = SimIo::new();
+    let mut trace = VecTrace::default();
+    run_miss(
+        &mut io,
+        &snapshot,
+        &mut runtime,
+        0,
+        Ipv4Address::from_octets([198, 51, 100, 20]),
+        &mut trace,
+    );
+    assert_eq!(runtime.pending_actions(), 0);
+    assert_eq!(runtime.counters().forbidden_target, 1);
+    assert!(trace.events().iter().any(|event| matches!(
+        event,
+        TraceEvent::NeighborResolution {
+            target,
+            result: ResolutionResult::ForbiddenTarget,
+            ..
+        } if *target == Ipv4Address::from_octets([203, 0, 113, 255])
+    )));
 }
 
 #[test]

--- a/crates/io-sim/tests/generated_resolution.rs
+++ b/crates/io-sim/tests/generated_resolution.rs
@@ -1,0 +1,799 @@
+use std::convert::Infallible;
+
+use ruster_core::{
+    execute_one_arp_request, forward_batch_with_resolution, ipv4_header_checksum,
+    ArpRequestBuildError, BatchCompletion, DropReason, ExecuteArpRequestError, ForwardingSnapshot,
+    GeneratedAllocationError, GeneratedBatchCompletion, GeneratedPacketBatch, GeneratedPacketIo,
+    GeneratedPacketLease, GeneratedPacketSlot, GeneratedSlotCompletion, IfId, Interface,
+    Ipv4Address, LocalIpv4Binding, MacAddress, MonotonicMillis, Neighbor, NoTrace, PacketIo,
+    ResolutionActionSlot, ResolutionPolicy, ResolutionPolicyError, ResolutionResult,
+    ResolutionRuntime, ResolutionStateSlot, Route, TraceEvent, ETHERNET_HEADER_LEN,
+};
+use ruster_io_sim::{
+    FrameOrigin, GeneratedRecycleCause, RecycleCause, SimGeneratedError, SimIo, VecGeneratedTrace,
+    VecTrace,
+};
+
+const LAN: IfId = IfId(1);
+const WAN: IfId = IfId(2);
+const ROUTER_MAC: MacAddress = MacAddress([0x02, 0, 0, 0, 0, 2]);
+const LOCAL_IP: Ipv4Address = Ipv4Address::from_octets([203, 0, 113, 2]);
+const TARGET: Ipv4Address = Ipv4Address::from_octets([203, 0, 113, 1]);
+
+fn frame(destination: Ipv4Address) -> Vec<u8> {
+    let mut bytes = vec![0_u8; ETHERNET_HEADER_LEN + 20];
+    bytes[0..6].copy_from_slice(&[9; 6]);
+    bytes[6..12].copy_from_slice(&[1; 6]);
+    bytes[12..14].copy_from_slice(&0x0800_u16.to_be_bytes());
+    bytes[14] = 0x45;
+    bytes[16..18].copy_from_slice(&20_u16.to_be_bytes());
+    bytes[22] = 64;
+    bytes[23] = 17;
+    bytes[26..30].copy_from_slice(&[192, 0, 2, 10]);
+    bytes[30..34].copy_from_slice(&destination.octets());
+    let checksum = ipv4_header_checksum(&bytes[14..34]);
+    bytes[24..26].copy_from_slice(&checksum.to_be_bytes());
+    bytes
+}
+
+fn interface() -> Interface {
+    Interface {
+        id: WAN,
+        mac: ROUTER_MAC,
+    }
+}
+
+fn binding() -> LocalIpv4Binding {
+    LocalIpv4Binding {
+        interface: WAN,
+        address: LOCAL_IP,
+    }
+}
+
+fn gateway_route() -> Route {
+    Route::new(Ipv4Address::from_octets([0; 4]), 0, WAN, Some(TARGET)).unwrap()
+}
+
+fn policy() -> ResolutionPolicy {
+    ResolutionPolicy::new(1_000, 2_000).unwrap()
+}
+
+#[test]
+fn resolution_policy_rejects_short_interval_and_state_ttl() {
+    assert_eq!(
+        ResolutionPolicy::new(999, 2_000),
+        Err(ResolutionPolicyError::IntervalTooShort)
+    );
+    assert_eq!(
+        ResolutionPolicy::new(1_000, 999),
+        Err(ResolutionPolicyError::StateTtlTooShort)
+    );
+}
+
+fn run_miss(
+    io: &mut SimIo,
+    snapshot: &ForwardingSnapshot<'_>,
+    runtime: &mut ResolutionRuntime<'_>,
+    now: u64,
+    destination: Ipv4Address,
+    trace: &mut VecTrace,
+) {
+    let original = frame(destination);
+    io.inject(LAN, original.clone());
+    let batch = io.receive(1).unwrap();
+    let report =
+        forward_batch_with_resolution(batch, snapshot, runtime, MonotonicMillis(now), trace);
+    assert_eq!(report.dropped, 1);
+    assert_eq!(
+        report.completion,
+        BatchCompletion {
+            tx_requested: 0,
+            tx_accepted: 0,
+            tx_rejected: 0,
+            recycled: 1,
+            error: None,
+        }
+    );
+    let recycled = io.pop_recycled().unwrap();
+    assert_eq!(
+        recycled.cause,
+        RecycleCause::Forwarding(DropReason::NeighborUnresolved)
+    );
+    assert_eq!(recycled.bytes, original);
+}
+
+#[test]
+fn unresolved_neighbor_generates_broadcast_arp_request_and_recycles_trigger_atomically() {
+    let routes = [gateway_route()];
+    let interfaces = [interface()];
+    let bindings = [binding()];
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &[], &bindings).unwrap();
+    let mut states = [ResolutionStateSlot::EMPTY; 2];
+    let mut actions = [ResolutionActionSlot::EMPTY; 2];
+    let mut runtime = ResolutionRuntime::new(policy(), &mut states, &mut actions);
+    let mut io = SimIo::new();
+    let mut rx_trace = VecTrace::default();
+    run_miss(
+        &mut io,
+        &snapshot,
+        &mut runtime,
+        10,
+        Ipv4Address::from_octets([198, 51, 100, 20]),
+        &mut rx_trace,
+    );
+    assert!(matches!(
+        rx_trace.events(),
+        [
+            TraceEvent::Ipv4Validated { .. },
+            TraceEvent::NeighborResolution {
+                result: ResolutionResult::Queued,
+                ..
+            },
+            TraceEvent::Dropped {
+                reason: DropReason::NeighborUnresolved,
+                ..
+            },
+            TraceEvent::BatchCompleted { .. }
+        ]
+    ));
+
+    let mut generated_trace = VecGeneratedTrace::default();
+    let report = execute_one_arp_request(
+        &mut io,
+        &mut runtime,
+        MonotonicMillis(10),
+        &mut generated_trace,
+    )
+    .unwrap()
+    .unwrap();
+    assert!(report.completion.invariants_hold());
+    assert_eq!(report.completion.requested, 1);
+    assert_eq!(report.completion.accepted, 1);
+    assert_eq!(runtime.counters().dequeued, 1);
+    assert!(matches!(
+        generated_trace.events(),
+        [
+            ruster_core::GeneratedArpTrace::TxRequested { .. },
+            ruster_core::GeneratedArpTrace::BatchCompleted {
+                accepted: 1,
+                rejected: 0
+            }
+        ]
+    ));
+    let tx = io.pop_tx().unwrap();
+    assert_eq!(tx.origin, FrameOrigin::Generated);
+    assert_eq!(tx.egress, WAN);
+    assert_eq!(tx.bytes.len(), 60);
+    assert_eq!(&tx.bytes[0..6], &[0xff; 6]);
+    assert_eq!(&tx.bytes[6..12], &ROUTER_MAC.0);
+    assert_eq!(&tx.bytes[12..14], &0x0806_u16.to_be_bytes());
+    assert_eq!(&tx.bytes[14..16], &1_u16.to_be_bytes());
+    assert_eq!(&tx.bytes[16..18], &0x0800_u16.to_be_bytes());
+    assert_eq!(&tx.bytes[18..22], &[6, 4, 0, 1]);
+    assert_eq!(&tx.bytes[22..28], &ROUTER_MAC.0);
+    assert_eq!(&tx.bytes[28..32], &LOCAL_IP.octets());
+    assert_eq!(&tx.bytes[32..38], &[0; 6]);
+    assert_eq!(&tx.bytes[38..42], &TARGET.octets());
+    assert_eq!(&tx.bytes[42..60], &[0; 18]);
+}
+
+#[test]
+fn ordinary_resolution_request_is_not_probe_or_announcement() {
+    let routes = [gateway_route()];
+    let interfaces = [interface()];
+    let bindings = [binding()];
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &[], &bindings).unwrap();
+    let mut states = [ResolutionStateSlot::EMPTY; 1];
+    let mut actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut runtime = ResolutionRuntime::new(policy(), &mut states, &mut actions);
+    let mut io = SimIo::new();
+    run_miss(
+        &mut io,
+        &snapshot,
+        &mut runtime,
+        0,
+        Ipv4Address::from_octets([198, 51, 100, 20]),
+        &mut VecTrace::default(),
+    );
+    execute_one_arp_request(
+        &mut io,
+        &mut runtime,
+        MonotonicMillis(0),
+        &mut VecGeneratedTrace::default(),
+    )
+    .unwrap()
+    .unwrap();
+    let request = io.pop_tx().unwrap().bytes;
+    assert_eq!(&request[0..6], &[0xff; 6]);
+    assert_eq!(&request[20..22], &1_u16.to_be_bytes());
+    assert_eq!(&request[28..32], &LOCAL_IP.octets());
+    assert_ne!(&request[28..32], &[0; 4], "not an ARP Probe");
+    assert_eq!(&request[32..38], &[0; 6]);
+    assert_eq!(&request[38..42], &TARGET.octets());
+    assert_ne!(&request[28..32], &request[38..42], "not an Announcement");
+}
+
+#[test]
+fn same_target_is_rate_limited_to_one_request_per_second_at_exact_deadline() {
+    let routes = [gateway_route()];
+    let interfaces = [interface()];
+    let bindings = [binding()];
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &[], &bindings).unwrap();
+    let mut states = [ResolutionStateSlot::EMPTY; 1];
+    let mut actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut runtime = ResolutionRuntime::new(policy(), &mut states, &mut actions);
+    let mut io = SimIo::new();
+    let mut trace = VecTrace::default();
+    let dst = Ipv4Address::from_octets([198, 51, 100, 20]);
+
+    run_miss(&mut io, &snapshot, &mut runtime, 0, dst, &mut trace);
+    io.set_generated_accept_budget(0);
+    let first_request = execute_one_arp_request(
+        &mut io,
+        &mut runtime,
+        MonotonicMillis(0),
+        &mut VecGeneratedTrace::default(),
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(first_request.completion.rejected, 1);
+    run_miss(&mut io, &snapshot, &mut runtime, 999, dst, &mut trace);
+    assert_eq!(runtime.pending_actions(), 0);
+    run_miss(&mut io, &snapshot, &mut runtime, 1_000, dst, &mut trace);
+    assert_eq!(runtime.pending_actions(), 1);
+    assert_eq!(runtime.counters().queued, 2);
+    assert_eq!(runtime.counters().suppressed, 1);
+}
+
+#[test]
+fn resolution_keys_are_independent_by_interface_and_target() {
+    let direct = Route::new(Ipv4Address::from_octets([198, 51, 100, 0]), 24, WAN, None).unwrap();
+    let routes = [direct];
+    let interfaces = [interface()];
+    let bindings = [binding()];
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &[], &bindings).unwrap();
+    let mut states = [ResolutionStateSlot::EMPTY; 3];
+    let mut actions = [ResolutionActionSlot::EMPTY; 3];
+    let mut runtime = ResolutionRuntime::new(policy(), &mut states, &mut actions);
+    let mut io = SimIo::new();
+    let mut trace = VecTrace::default();
+    run_miss(
+        &mut io,
+        &snapshot,
+        &mut runtime,
+        0,
+        Ipv4Address::from_octets([198, 51, 100, 10]),
+        &mut trace,
+    );
+    run_miss(
+        &mut io,
+        &snapshot,
+        &mut runtime,
+        0,
+        Ipv4Address::from_octets([198, 51, 100, 11]),
+        &mut trace,
+    );
+    assert_eq!(runtime.pending_actions(), 2);
+
+    let other_interface = Interface {
+        id: IfId(3),
+        mac: MacAddress([3; 6]),
+    };
+    let other_route = Route::new(
+        Ipv4Address::from_octets([198, 51, 100, 10]),
+        32,
+        IfId(3),
+        None,
+    )
+    .unwrap();
+    let other_binding = LocalIpv4Binding {
+        interface: IfId(3),
+        address: Ipv4Address::from_octets([198, 18, 0, 1]),
+    };
+    let routes = [other_route];
+    let interfaces = [other_interface];
+    let bindings = [other_binding];
+    let other = ForwardingSnapshot::new(&routes, &interfaces, &[], &bindings).unwrap();
+    run_miss(
+        &mut io,
+        &other,
+        &mut runtime,
+        0,
+        Ipv4Address::from_octets([198, 51, 100, 10]),
+        &mut trace,
+    );
+    assert_eq!(runtime.pending_actions(), 3);
+}
+
+#[test]
+fn clock_regression_is_typed_and_does_not_mutate_queue() {
+    let routes = [gateway_route()];
+    let interfaces = [interface()];
+    let bindings = [binding()];
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &[], &bindings).unwrap();
+    let mut states = [ResolutionStateSlot::EMPTY; 2];
+    let mut actions = [ResolutionActionSlot::EMPTY; 2];
+    let mut runtime = ResolutionRuntime::new(policy(), &mut states, &mut actions);
+    let mut io = SimIo::new();
+    let mut trace = VecTrace::default();
+    let dst = Ipv4Address::from_octets([198, 51, 100, 20]);
+    run_miss(&mut io, &snapshot, &mut runtime, 100, dst, &mut trace);
+    run_miss(&mut io, &snapshot, &mut runtime, 99, dst, &mut trace);
+    assert_eq!(runtime.pending_actions(), 1);
+    assert_eq!(runtime.counters().clock_regressions, 1);
+    assert!(trace.events().iter().any(|event| matches!(
+        event,
+        TraceEvent::NeighborResolution {
+            result: ResolutionResult::ClockRegression,
+            ..
+        }
+    )));
+}
+
+#[test]
+fn generated_commit_clock_regression_retains_action() {
+    let routes = [gateway_route()];
+    let interfaces = [interface()];
+    let bindings = [binding()];
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &[], &bindings).unwrap();
+    let mut states = [ResolutionStateSlot::EMPTY; 1];
+    let mut actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut runtime = ResolutionRuntime::new(policy(), &mut states, &mut actions);
+    let mut io = SimIo::new();
+    run_miss(
+        &mut io,
+        &snapshot,
+        &mut runtime,
+        100,
+        Ipv4Address::from_octets([198, 51, 100, 20]),
+        &mut VecTrace::default(),
+    );
+    assert_eq!(
+        execute_one_arp_request(
+            &mut io,
+            &mut runtime,
+            MonotonicMillis(99),
+            &mut VecGeneratedTrace::default(),
+        ),
+        Err(ExecuteArpRequestError::ClockRegression)
+    );
+    assert_eq!(runtime.pending_actions(), 1);
+    assert_eq!(io.pending_tx(), 0);
+}
+
+#[test]
+fn state_full_never_evicts_live_entry_and_ttl_allows_reuse() {
+    let direct = Route::new(Ipv4Address::from_octets([198, 51, 100, 0]), 24, WAN, None).unwrap();
+    let routes = [direct];
+    let interfaces = [interface()];
+    let bindings = [binding()];
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &[], &bindings).unwrap();
+    let mut states = [ResolutionStateSlot::EMPTY; 1];
+    let mut actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut runtime = ResolutionRuntime::new(policy(), &mut states, &mut actions);
+    let mut io = SimIo::new();
+    let mut trace = VecTrace::default();
+    let first = Ipv4Address::from_octets([198, 51, 100, 10]);
+    let second = Ipv4Address::from_octets([198, 51, 100, 11]);
+    run_miss(&mut io, &snapshot, &mut runtime, 0, first, &mut trace);
+    execute_one_arp_request(
+        &mut io,
+        &mut runtime,
+        MonotonicMillis(0),
+        &mut VecGeneratedTrace::default(),
+    )
+    .unwrap()
+    .unwrap();
+    run_miss(&mut io, &snapshot, &mut runtime, 1_999, second, &mut trace);
+    assert_eq!(runtime.counters().state_full, 1);
+    run_miss(&mut io, &snapshot, &mut runtime, 2_000, second, &mut trace);
+    assert_eq!(runtime.pending_actions(), 1);
+}
+
+#[test]
+fn action_full_does_not_create_phantom_suppression() {
+    let direct = Route::new(Ipv4Address::from_octets([198, 51, 100, 0]), 24, WAN, None).unwrap();
+    let routes = [direct];
+    let interfaces = [interface()];
+    let bindings = [binding()];
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &[], &bindings).unwrap();
+    let mut states = [ResolutionStateSlot::EMPTY; 2];
+    let mut actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut runtime = ResolutionRuntime::new(policy(), &mut states, &mut actions);
+    let mut io = SimIo::new();
+    let mut trace = VecTrace::default();
+    let first = Ipv4Address::from_octets([198, 51, 100, 10]);
+    let second = Ipv4Address::from_octets([198, 51, 100, 11]);
+    run_miss(&mut io, &snapshot, &mut runtime, 0, first, &mut trace);
+    run_miss(&mut io, &snapshot, &mut runtime, 0, second, &mut trace);
+    assert_eq!(runtime.counters().action_full, 1);
+    execute_one_arp_request(
+        &mut io,
+        &mut runtime,
+        MonotonicMillis(0),
+        &mut VecGeneratedTrace::default(),
+    )
+    .unwrap()
+    .unwrap();
+    run_miss(&mut io, &snapshot, &mut runtime, 0, second, &mut trace);
+    assert_eq!(runtime.pending_actions(), 1);
+    assert_eq!(runtime.counters().suppressed, 0);
+}
+
+#[test]
+fn local_binding_missing_and_forbidden_targets_generate_nothing() {
+    let routes = [gateway_route()];
+    let interfaces = [interface()];
+    let no_binding = ForwardingSnapshot::new(&routes, &interfaces, &[], &[]).unwrap();
+    let mut states = [ResolutionStateSlot::EMPTY; 4];
+    let mut actions = [ResolutionActionSlot::EMPTY; 4];
+    let mut runtime = ResolutionRuntime::new(policy(), &mut states, &mut actions);
+    let mut io = SimIo::new();
+    let mut trace = VecTrace::default();
+    run_miss(
+        &mut io,
+        &no_binding,
+        &mut runtime,
+        0,
+        Ipv4Address::from_octets([198, 51, 100, 20]),
+        &mut trace,
+    );
+    assert_eq!(runtime.pending_actions(), 0);
+
+    for target in [[0, 0, 0, 0], [224, 0, 0, 1], [255, 255, 255, 255]] {
+        let target = Ipv4Address::from_octets(target);
+        let route = Route::new(Ipv4Address::from_octets([0; 4]), 0, WAN, Some(target)).unwrap();
+        let routes = [route];
+        let bindings = [binding()];
+        let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &[], &bindings).unwrap();
+        run_miss(
+            &mut io,
+            &snapshot,
+            &mut runtime,
+            0,
+            Ipv4Address::from_octets([198, 51, 100, 20]),
+            &mut trace,
+        );
+    }
+    let direct = Route::new(Ipv4Address::from_octets([198, 51, 100, 0]), 24, WAN, None).unwrap();
+    let routes = [direct];
+    let bindings = [binding()];
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &[], &bindings).unwrap();
+    run_miss(
+        &mut io,
+        &snapshot,
+        &mut runtime,
+        0,
+        Ipv4Address::from_octets([198, 51, 100, 255]),
+        &mut trace,
+    );
+    assert_eq!(runtime.pending_actions(), 0);
+    assert_eq!(runtime.counters().forbidden_target, 4);
+    assert_eq!(
+        trace
+            .events()
+            .iter()
+            .filter(|event| matches!(
+                event,
+                TraceEvent::NeighborResolution {
+                    result: ResolutionResult::ForbiddenTarget,
+                    ..
+                }
+            ))
+            .count(),
+        4
+    );
+}
+
+#[test]
+fn static_neighbor_hit_leaves_resolution_runtime_untouched() {
+    let routes = [gateway_route()];
+    let interfaces = [interface()];
+    let bindings = [binding()];
+    let neighbors = [Neighbor {
+        interface: WAN,
+        target: TARGET,
+        mac: MacAddress([4; 6]),
+    }];
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &bindings).unwrap();
+    let mut states = [ResolutionStateSlot::EMPTY; 1];
+    let mut actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut runtime = ResolutionRuntime::new(policy(), &mut states, &mut actions);
+    let mut io = SimIo::new();
+    io.inject(LAN, frame(Ipv4Address::from_octets([198, 51, 100, 20])));
+    let batch = io.receive(1).unwrap();
+    let report = forward_batch_with_resolution(
+        batch,
+        &snapshot,
+        &mut runtime,
+        MonotonicMillis(0),
+        &mut NoTrace,
+    );
+    assert_eq!(report.tx_requested, 1);
+    assert_eq!(runtime.counters(), Default::default());
+    assert_eq!(runtime.pending_actions(), 0);
+}
+
+#[test]
+fn generated_lease_commit_cancel_abandon_and_allocation_failures_are_exact() {
+    let mut io = SimIo::new();
+    io.set_generated_max_frame(60);
+    let (completion, committed_allocation) = {
+        let mut batch = io.begin_generated(WAN);
+        assert_eq!(
+            batch.allocate(0).err(),
+            Some(GeneratedAllocationError::ZeroLength)
+        );
+        assert_eq!(
+            batch.allocate(61).err(),
+            Some(GeneratedAllocationError::FrameTooLarge)
+        );
+        let mut committed = batch.allocate(60).unwrap();
+        let committed_allocation = committed.bytes_mut().as_ptr();
+        committed.commit();
+        batch.allocate(60).unwrap().cancel();
+        drop(batch.allocate(60).unwrap());
+        (batch.finish(), committed_allocation)
+    };
+    assert!(completion.invariants_hold());
+    assert_eq!(completion.attempts, 5);
+    assert_eq!(completion.allocated, 3);
+    assert_eq!(completion.failed, 2);
+    assert_eq!(completion.requested, 1);
+    assert_eq!(completion.cancelled, 1);
+    assert_eq!(completion.abandoned, 1);
+    assert_eq!(
+        io.pop_tx().unwrap().bytes.as_ptr(),
+        committed_allocation,
+        "backend allocation must move into TX without cloning"
+    );
+    assert_eq!(
+        io.pop_generated_recycled().unwrap().cause,
+        GeneratedRecycleCause::Cancelled
+    );
+    assert_eq!(
+        io.pop_generated_recycled().unwrap().cause,
+        GeneratedRecycleCause::Abandoned
+    );
+
+    io.set_generated_budget(0);
+    let completion = {
+        let mut batch = io.begin_generated(WAN);
+        assert_eq!(
+            batch.allocate(60).err(),
+            Some(GeneratedAllocationError::Unavailable)
+        );
+        batch.finish()
+    };
+    assert!(completion.invariants_hold());
+    assert_eq!(completion.allocated, 0, "failure transfers no ownership");
+}
+
+#[test]
+fn generated_partial_tx_error_preserves_invariants_and_recycles_rejects() {
+    let mut io = SimIo::new();
+    io.set_generated_accept_budget(1);
+    io.fail_next_generated_finish();
+    let completion = {
+        let mut batch = io.begin_generated(WAN);
+        batch.allocate(60).unwrap().commit();
+        batch.allocate(60).unwrap().commit();
+        batch.finish()
+    };
+    assert!(completion.invariants_hold());
+    assert_eq!(completion.accepted, 1);
+    assert_eq!(completion.rejected, 1);
+    assert_eq!(completion.error, Some(SimGeneratedError::Injected));
+    assert_eq!(
+        io.pop_generated_recycled().unwrap().cause,
+        GeneratedRecycleCause::TxRejected
+    );
+}
+
+#[test]
+fn allocation_failure_retains_action_and_does_not_start_deadline() {
+    let routes = [gateway_route()];
+    let interfaces = [interface()];
+    let bindings = [binding()];
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &[], &bindings).unwrap();
+    let mut states = [ResolutionStateSlot::EMPTY; 1];
+    let mut actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut runtime = ResolutionRuntime::new(policy(), &mut states, &mut actions);
+    let mut io = SimIo::new();
+    let mut trace = VecTrace::default();
+    let dst = Ipv4Address::from_octets([198, 51, 100, 20]);
+    run_miss(&mut io, &snapshot, &mut runtime, 0, dst, &mut trace);
+    io.set_generated_budget(0);
+    let mut generated_trace = VecGeneratedTrace::default();
+    let failed = execute_one_arp_request(
+        &mut io,
+        &mut runtime,
+        MonotonicMillis(500),
+        &mut generated_trace,
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(
+        failed.allocation_error,
+        Some(GeneratedAllocationError::Unavailable)
+    );
+    assert!(matches!(
+        generated_trace.events(),
+        [
+            ruster_core::GeneratedArpTrace::AllocationFailed(GeneratedAllocationError::Unavailable),
+            ruster_core::GeneratedArpTrace::BatchCompleted {
+                accepted: 0,
+                rejected: 0
+            }
+        ]
+    ));
+    assert_eq!(runtime.pending_actions(), 1);
+    io.set_generated_budget(1);
+    execute_one_arp_request(
+        &mut io,
+        &mut runtime,
+        MonotonicMillis(700),
+        &mut VecGeneratedTrace::default(),
+    )
+    .unwrap()
+    .unwrap();
+    run_miss(&mut io, &snapshot, &mut runtime, 1_699, dst, &mut trace);
+    assert_eq!(runtime.pending_actions(), 0);
+    run_miss(&mut io, &snapshot, &mut runtime, 1_700, dst, &mut trace);
+    assert_eq!(runtime.pending_actions(), 1);
+}
+
+#[test]
+fn builder_failure_cancels_lease_and_retains_action() {
+    let routes = [gateway_route()];
+    let interfaces = [interface()];
+    let bindings = [binding()];
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &[], &bindings).unwrap();
+    let mut states = [ResolutionStateSlot::EMPTY; 1];
+    let mut actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut runtime = ResolutionRuntime::new(policy(), &mut states, &mut actions);
+    let mut rx = SimIo::new();
+    run_miss(
+        &mut rx,
+        &snapshot,
+        &mut runtime,
+        0,
+        Ipv4Address::from_octets([198, 51, 100, 20]),
+        &mut VecTrace::default(),
+    );
+    let report = execute_one_arp_request(
+        &mut ShortBufferIo,
+        &mut runtime,
+        MonotonicMillis(0),
+        &mut VecGeneratedTrace::default(),
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(
+        report.build_error,
+        Some(ArpRequestBuildError::ExactLengthRequired)
+    );
+    assert!(report.completion.invariants_hold());
+    assert_eq!(report.completion.cancelled, 1);
+    assert_eq!(runtime.pending_actions(), 1);
+}
+
+struct ShortBufferIo;
+
+struct ShortBufferBatch {
+    allocated: usize,
+    cancelled: usize,
+    abandoned: usize,
+}
+
+struct ShortBufferSlot<'a> {
+    bytes: Vec<u8>,
+    cancelled: &'a mut usize,
+    abandoned: &'a mut usize,
+}
+
+impl GeneratedPacketIo for ShortBufferIo {
+    type Error = Infallible;
+    type Batch<'a> = ShortBufferBatch;
+
+    fn begin_generated(&mut self, _egress: IfId) -> Self::Batch<'_> {
+        ShortBufferBatch {
+            allocated: 0,
+            cancelled: 0,
+            abandoned: 0,
+        }
+    }
+}
+
+impl GeneratedPacketBatch for ShortBufferBatch {
+    type Error = Infallible;
+    type Slot<'a>
+        = ShortBufferSlot<'a>
+    where
+        Self: 'a;
+
+    fn allocate(
+        &mut self,
+        frame_len: usize,
+    ) -> Result<GeneratedPacketLease<Self::Slot<'_>>, GeneratedAllocationError> {
+        self.allocated += 1;
+        Ok(GeneratedPacketLease::new(ShortBufferSlot {
+            bytes: vec![0; frame_len - 1],
+            cancelled: &mut self.cancelled,
+            abandoned: &mut self.abandoned,
+        }))
+    }
+
+    fn finish(self) -> GeneratedBatchCompletion<Self::Error> {
+        GeneratedBatchCompletion {
+            attempts: 1,
+            allocated: self.allocated,
+            failed: 0,
+            requested: 0,
+            cancelled: self.cancelled,
+            abandoned: self.abandoned,
+            accepted: 0,
+            rejected: 0,
+            error: None,
+        }
+    }
+}
+
+impl GeneratedPacketSlot for ShortBufferSlot<'_> {
+    fn bytes_mut(&mut self) -> &mut [u8] {
+        &mut self.bytes
+    }
+
+    fn complete(self, completion: GeneratedSlotCompletion) {
+        match completion {
+            GeneratedSlotCompletion::Cancelled => *self.cancelled += 1,
+            GeneratedSlotCompletion::Abandoned => *self.abandoned += 1,
+            GeneratedSlotCompletion::Transmit => panic!("short buffer must not be transmitted"),
+        }
+    }
+}
+
+#[test]
+fn mixed_rx_and_generated_tx_are_fifo_budgeted_and_origin_typed() {
+    let routes = [gateway_route()];
+    let interfaces = [interface()];
+    let bindings = [binding()];
+    let neighbors = [Neighbor {
+        interface: WAN,
+        target: TARGET,
+        mac: MacAddress([4; 6]),
+    }];
+    let hit = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &bindings).unwrap();
+    let miss = ForwardingSnapshot::new(&routes, &interfaces, &[], &bindings).unwrap();
+    let mut states = [ResolutionStateSlot::EMPTY; 1];
+    let mut actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut runtime = ResolutionRuntime::new(policy(), &mut states, &mut actions);
+    let mut io = SimIo::new();
+    io.set_generated_budget(1);
+    io.inject(LAN, frame(Ipv4Address::from_octets([198, 51, 100, 10])));
+    io.inject(LAN, frame(Ipv4Address::from_octets([198, 51, 100, 11])));
+    let first = io.receive(1).unwrap();
+    forward_batch_with_resolution(first, &hit, &mut runtime, MonotonicMillis(0), &mut NoTrace);
+    let second = io.receive(1).unwrap();
+    forward_batch_with_resolution(
+        second,
+        &miss,
+        &mut runtime,
+        MonotonicMillis(0),
+        &mut NoTrace,
+    );
+    execute_one_arp_request(
+        &mut io,
+        &mut runtime,
+        MonotonicMillis(0),
+        &mut VecGeneratedTrace::default(),
+    )
+    .unwrap()
+    .unwrap();
+    let rx_tx = io.pop_tx().unwrap();
+    let generated_tx = io.pop_tx().unwrap();
+    assert_eq!(rx_tx.sequence, 0);
+    assert_eq!(rx_tx.origin, FrameOrigin::Received { ingress: LAN });
+    assert_eq!(generated_tx.sequence, 2);
+    assert_eq!(generated_tx.origin, FrameOrigin::Generated);
+}

--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -62,12 +62,42 @@ local bindingはMACを持ちません。ARP replyのlocal MACは対応する`Int
 routeに対応するneighborがまだ無いこと自体はvalidです。ARP解決前の通常状態として
 forwarding時に`NeighborUnresolved`でbytes不変recycleします。
 
-このsliceはstatic neighborとARP responderを接続しません。neighbor miss時もARP request
-を生成せず、packetをholdせずに従来どおり`NeighborUnresolved`でrecycleします。
-generated packet用allocator/lifetime contractがまだ無いため、場当たり的にsimの
-`Vec`をcoreへ導入しません。RFC 1122 §2.3.2.1/§2.3.2.2とRFC 1812 §3.3.2が述べる
-ARP cache/address resolutionとpacket queue/hold（少なくとも一つを保持するSHOULDを
-含む）は未達で、最初のpacketは解決後に自動再送されません。
+static neighbor missでは、routeが選んだ`(egress, next-hopまたはdestination)`と、
+egress interfaceのMAC/local IPv4からtyped `ArpRequestAction`を作れます。RX処理中は
+caller提供の固定ringへactionを積むだけで、RX batchの`finish`後に独立したgenerated
+sessionを開始します。元packetは常にbyte不変`NeighborUnresolved`でrecycleし、hold
+しません。
+
+generated sessionはbegin時にegressを固定し、最終Ethernet frame長ちょうどの
+backend-owned bufferをGAT/RAII leaseで借用します。coreにはheadroom、capacity全体、
+UMEM、mbufを公開しません。leaseは`!Send + !Sync`で、`commit`、`cancel`、未完了Dropの
+いずれかをexactly onceでbackendへ返します。allocationのzero length、max frame超過、
+buffer unavailableを区別し、失敗時はownershipを移しません。finishはerror時も
+`attempts=allocated+failed`、`allocated=requested+cancelled+abandoned`、
+`accepted+rejected=requested`のaccountingを返し、rejectをreturn前にrecycleします。
+
+resolution runtimeも`!Send + !Sync`で、caller提供のlinear fixed tableとaction ringだけを
+借用します。keyは`(IfId,target IPv4)`です。intervalは1000ms以上、state TTLはinterval
+以上とし、batch単位で注入された`MonotonicMillis`だけを使います。加算deadlineを作らず
+順序確認後の差分で判定するため`u64` overflowはありません。逆行はtyped resultとして
+action/stateを変更しません。live entryはevictせず、TTL後だけreuseします。
+
+同じkeyのactionは一つだけqueueできます。抑制deadlineはenqueue時でなく、generated
+leaseをcommitしてTX requestedになった注入時刻から開始します。allocation/build失敗時は
+actionを保持しdeadlineを開始しません。backendのpartial rejectでもcommit済みなので
+抑制を開始します。retryは新しいtraffic missでだけ起きます。target `0.0.0.0`、IPv4
+multicast、limited broadcast、およびcanonical connected routeから確定できるdirected
+broadcastにはARP Requestを生成しません。
+
+生成する通常RequestはFCSを含まない60 bytesです。先頭42 bytesをRFC 826の
+Ethernet/IPv4 ARP（Ethernet destination broadcast、SHA/source MACはlocal、SPAはnonzero
+local IPv4、THA zero、TPA target）として書き、残り18 bytesを必ずzero paddingします。
+THA zeroは決定的なlocal profile choiceであり、RFCのMUSTとは主張しません。
+
+これはRFC 826の通常ARP Request生成とRFC 1122 §2.3.2.1のflood preventionまでです。
+reply learning/cache/aging/flush、timer-only retry/max attempts/Failed、unresolved packet
+hold/replay（RFC 1122 §2.3.2.2、RFC 1812 §3.3.2）、multi-worker resolution ownership/
+SPSCは未実装です。最初のpacketは解決後に自動再送されません。
 
 ## IPv4 scope
 
@@ -98,13 +128,15 @@ RFC 5227 §2.4のaddress conflict detection/defenseは未実装です。foreign 
 conflict状態やdefensive announcementを生成しません。正常なlocal target requestを
 追加policyでdropしないことを優先した明示deviationです。
 
-ARP learning/cache、ARP request生成、retry、unresolved packet hold queue、gratuitous
-ARP、proxy ARP、VLAN、generated-packet allocator、Address Conflict Detection、ICMP生成、
+ARP learning/cache/aging/flush、timer retry、unresolved packet hold queue、gratuitous
+ARP、ARP Probe/Announcement生成、proxy ARP、VLAN、Address Conflict Detection、ICMP生成、
 NAT、firewall、config parser、pcap、AF_XDP、DPDK、binary、thread、benchmarkはこの
 sliceのscope外です。
 
 ## backend progression
 
-`ruster-io-sim`はFIFOとbudgetを決定的に実装します。RXの`Vec<u8>`そのものをTX/dropへ
-moveし、packet bytesをcloneしません。次の実I/O backendも同じlease contractを実装し、
+`ruster-io-sim`はRXとgenerated TXのFIFO、budget、max frame、allocation exhaustion、
+cancel/abandon、partial TX/reject、finish errorを決定的に実装します。captureは
+`FrameOrigin`でRXとgeneratedを区別します。RX/生成の`Vec<u8>`そのものをTX/dropへmoveし、
+packet bytesをcloneしません。次の実I/O backendも同じlease contractを実装し、
 backend固有pointerをcoreへ漏らしません。

--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -80,16 +80,21 @@ resolution runtimeも`!Send + !Sync`で、caller提供のlinear fixed tableとac
 借用します。keyは`(IfId,target IPv4)`です。intervalは1000ms以上、state TTLはinterval
 以上とし、batch単位で注入された`MonotonicMillis`だけを使います。加算deadlineを作らず
 順序確認後の差分で判定するため`u64` overflowはありません。逆行はtyped resultとして
-action/stateを変更しません。live entryはevictせず、TTL後だけreuseします。
+action/stateを変更しません。live entryはevictせず、TTL後だけreuseします。runtimeの
+生成時はcaller storageをすべてemptyへ初期化します。processをまたぐstate永続化/resumeは
+未実装です。
 
 同じkeyのactionは一つだけqueueできます。抑制deadlineはenqueue時でなく、generated
 leaseをcommitしてTX requestedになった注入時刻から開始します。allocation/build失敗時は
 actionを保持しdeadlineを開始しません。backendのpartial rejectでもcommit済みなので
 抑制を開始します。retryは新しいtraffic missでだけ起きます。target `0.0.0.0`、IPv4
 multicast、limited broadcast、およびcanonical connected routeから確定できるdirected
-broadcastにはARP Requestを生成しません。
+broadcastにはARP Requestを生成しません。directed broadcast判定はpacketを選択したroute
+だけでなく、snapshot内の同一egressにある全connected routeを確認します。source local
+IPv4自身がtargetになる場合も生成しません。
 
-生成する通常RequestはFCSを含まない60 bytesです。先頭42 bytesをRFC 826の
+生成する通常RequestはRFC 894のEthernet minimum framingに合わせた、FCSを含まない
+60 bytesです。先頭42 bytesをRFC 826の
 Ethernet/IPv4 ARP（Ethernet destination broadcast、SHA/source MACはlocal、SPAはnonzero
 local IPv4、THA zero、TPA target）として書き、残り18 bytesを必ずzero paddingします。
 THA zeroは決定的なlocal profile choiceであり、RFCのMUSTとは主張しません。

--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -87,7 +87,9 @@ action/stateを変更しません。live entryはevictせず、TTL後だけreuse
 同じkeyのactionは一つだけqueueできます。抑制deadlineはenqueue時でなく、generated
 leaseをcommitしてTX requestedになった注入時刻から開始します。allocation/build失敗時は
 actionを保持しdeadlineを開始しません。backendのpartial rejectでもcommit済みなので
-抑制を開始します。retryは新しいtraffic missでだけ起きます。target `0.0.0.0`、IPv4
+抑制を開始します。commit済みARP Requestの次回生成は、deadline後に新しいtraffic missが
+来た場合だけです。allocation/build失敗で未commitの保持actionはexecutorを再実行できます。
+target `0.0.0.0`、IPv4
 multicast、limited broadcast、およびcanonical connected routeから確定できるdirected
 broadcastにはARP Requestを生成しません。directed broadcast判定はpacketを選択したroute
 だけでなく、snapshot内の同一egressにある全connected routeを確認します。source local

--- a/docs/requirements-v0.2.md
+++ b/docs/requirements-v0.2.md
@@ -10,6 +10,9 @@ Statusは`implemented`、`deferred`、`deviation`のいずれかです。test名
 | IO-003 requested/accepted/recycled accounting | architecture contract | `mixed_batch_is_fifo_budgeted_and_reports_requested_accepted_recycled` | implemented | backend finishで確定 |
 | IO-004 partial/error completion preserves report | architecture contract | `partial_backend_completion_preserves_report_and_aggregate_trace` | implemented | rejected slotはbackend所有で解放 |
 | IO-005 ARP partial/error completion preserves report | architecture contract | `arp_partial_backend_rejection_preserves_error_report_and_trace` | implemented | requested=1/accepted=0/rejected=1とerrorを保持 |
+| IO-006 generated GAT lease lifecycle/exact accounting | architecture contract | `generated_lease_commit_cancel_abandon_and_allocation_failures_are_exact` | implemented | beginでegress固定。commit/cancel/abandon accounting、allocation failure ownershipなし、allocation address moveを検証 |
+| IO-007 generated partial/error completion | architecture contract | `generated_partial_tx_error_preserves_invariants_and_recycles_rejects` | implemented | 三つのaccounting不変条件を保持しrejectをreturn前にrecycle |
+| IO-008 generated builder failure isolation | defensive backend boundary | `builder_failure_cancels_lease_and_retains_action` | implemented | exact-length契約違反bufferをcancelしactionを保持 |
 | ETH-001 Ethernet II framing | RFC 894 | `all_validation_and_decision_drops_are_granular_and_atomic` | implemented | 802.3 LLC/VLANはdeferred |
 | IP4-001 Version/IHL/Total Length validation | RFC 791 §3.1 | `all_validation_and_decision_drops_are_granular_and_atomic` | implemented | なし |
 | IP4-002 Total Length後のpadding無視 | RFC 791 §3.1 | `padding_is_ignored_but_preserved` | implemented | なし |
@@ -23,21 +26,33 @@ Statusは`implemented`、`deferred`、`deviation`のいずれかです。test名
 | FWD-004 incremental checksum update | RFC 1624 §4 | `rfc_1624_negative_zero_boundary_is_positive_zero` | implemented | `0xdd2f,0x5555→0x3285 = 0x0000` |
 | FWD-005 drop atomicity | architecture contract | `all_validation_and_decision_drops_are_granular_and_atomic` | implemented | なし |
 | FWD-006 snapshot integrity | architecture contract | `snapshot_constructor_rejects_all_broken_references_and_duplicates` | implemented | 公開前にvalidation |
-| FWD-007 unresolved packet hold/ARP request generation | RFC 1122 §2.3.2.1/§2.3.2.2, RFC 1812 §3.3.2 | `arp_reply_does_not_learn_or_generate_for_unresolved_neighbor` | deferred | static neighbor missはbyte不変NeighborUnresolved。allocator/request/retry/hold queueが無く、最初のpacketは自動再送されない |
+| FWD-007 unresolved trigger atomicity/request action | RFC 1122 §2.3.2.1 | `unresolved_neighbor_generates_broadcast_arp_request_and_recycles_trigger_atomically` | implemented | 元IPv4はbyte不変NeighborUnresolved、RX finish後にgenerated session |
+| FWD-008 unresolved packet hold/replay | RFC 1122 §2.3.2.2, RFC 1812 §3.3.2 | `unresolved_neighbor_generates_broadcast_arp_request_and_recycles_trigger_atomically` | deferred | hold/replayなし。最初のpacketは解決後も自動再送されない |
 | ARP-001 Ethernet/IPv4 request profile validation | RFC 826, RFC 5494/IANA ARP Parameters | `arp_profile_validation_drops_are_granular_and_atomic` | implemented | HTYPE=1/PTYPE=0x0800/HLEN=6/PLEN=4/opcode=1。replyとunknown opcodeを区別 |
 | ARP-002 local target in-place reply on ingress | RFC 826 | `arp_request_for_local_ipv4_replies_in_place_on_ingress` | implemented | 同じRX allocation、egress=ingress、wire fieldsを検証 |
 | ARP-003 probe reply with zero target protocol | RFC 5227 §2.5（Probe形式は§1.1/§2.1.1） | `arp_probe_for_local_ipv4_replies_with_zero_target_protocol` | implemented | SPA=0 requestにも通常reply |
 | ARP-004 request THA ignored/source identities not coupled | RFC 826 | `arp_request_target_hardware_is_ignored` | implemented | Ethernet source≠ARP SHAも受理 |
 | ARP-005 tail/padding preservation | RFC 826 wire profile | `arp_padding_is_ignored_and_preserved_on_reply` | implemented | 42 byte以後を変更しない |
 | ARP-006 nonlocal/proxy-disabled/reply/unknown opcode stable recycle | RFC 826, RFC 1027, RFC 5494/IANA ARP Parameters | `arp_nonlocal_and_reply_are_recycled_without_mutation` | implemented | nonlocal targetへ応答せずproxy ARPは無効。replyとunknown opcodeは別stable reason |
-| ARP-007 local binding snapshot integrity | architecture contract | `arp_snapshot_rejects_duplicate_or_unknown_local_addresses` | implemented | 現profileはinterfaceごとにlocal IPv4一つ、address重複も拒否。MACはInterfaceのみ |
+| ARP-007 local binding snapshot integrity | architecture contract | `arp_snapshot_rejects_duplicate_or_unknown_local_addresses` | implemented | interfaceごとにlocal IPv4一つ、address重複/unknown interface/unspecified SPAを拒否。MACはInterfaceのみ |
 | ARP-008 address conflict detection/defense | RFC 5227 §2.4 | `arp_foreign_sender_claiming_local_address_gets_normal_reply` | deviation | foreign SHAがlocal SPAを名乗ってもconflict state/defensive announcementなし。local targetへの通常replyのみ |
-| ARP-009 learning/cache/request/retry/hold | RFC 826, RFC 1122 §2.3.2.1/§2.3.2.2, RFC 1812 §3.3.2 | `arp_reply_does_not_learn_or_generate_for_unresolved_neighbor` | deferred | reply直後もsenderを学習せず、static missはARP生成・retry・holdなし |
+| ARP-009 learning/cache/aging/flush | RFC 826 | `arp_reply_does_not_learn_or_generate_for_unresolved_neighbor` | deferred | responderとrequest generatorはneighbor snapshotを変更しない |
+| ARP-010 normal request 60-byte wire profile | RFC 826 | `unresolved_neighbor_generates_broadcast_arp_request_and_recycles_trigger_atomically` | implemented | broadcast Ethernet、SPAはnonzero local、THA zero、18-byte zero padding、FCSなし |
+| ARP-010A ordinary request is not Probe/Announcement | RFC 826, local deterministic profile | `ordinary_resolution_request_is_not_probe_or_announcement` | implemented | SPA nonzero、SPA≠TPA、opcode Request |
+| ARP-011 flood suppression exact deadline | RFC 1122 §2.3.2.1 | `same_target_is_rate_limited_to_one_request_per_second_at_exact_deadline` | implemented | commit時刻基準、999ms suppress/1000ms queue。partial rejectもrequestedなので開始 |
+| ARP-011A suppression policy validation | RFC 1122 §2.3.2.1, local policy | `resolution_policy_rejects_short_interval_and_state_ttl` | implemented | interval>=1000ms、state TTL>=interval |
+| ARP-012 action ring full semantics | architecture contract | `action_full_does_not_create_phantom_suppression` | implemented | action fullはphantom deadlineなし |
+| ARP-012A state table full semantics | architecture contract | `state_full_never_evicts_live_entry_and_ttl_allows_reuse` | implemented | live非evict、TTL到達でreuse |
+| ARP-012B monotonic clock regression | architecture contract | `clock_regression_is_typed_and_does_not_mutate_queue` | implemented | typed result/counter/trace、queue非変更 |
+| ARP-012C resolution key independence | architecture contract | `resolution_keys_are_independent_by_interface_and_target` | implemented | target違いとIfId違いを独立queue |
+| ARP-013 forbidden request targets | local safety policy | `local_binding_missing_and_forbidden_targets_generate_nothing` | implemented | unspecified/multicast/limited broadcast/確定可能なdirected broadcastとbindingなしは生成しない |
+| ARP-014 traffic-driven retry/timer retry | RFC 1122 §2.3.2.1 | `allocation_failure_retains_action_and_does_not_start_deadline` | deferred | action保持とtraffic miss retryのみ。timer-only retry/max attempts/Failedなし |
 | OBS-001 stable reason code | explainability requirement | `drop_reason_discriminants_and_codes_are_stable_and_unique` | implemented | repr(u16) |
 | OBS-002 requestedとaggregate TX outcome trace | explainability requirement | `partial_backend_completion_preserves_report_and_aggregate_trace` | implemented | packet単位accepted traceはdeferred |
 | OBS-003 protocol-aware ARP trace ordering | explainability requirement | `arp_trace_is_deterministic_and_tx_follows_commit` | implemented | validated/reply requested/TX requested/completionを順序検証 |
 | SIM-001 FIFO/budget/mixed batch | deterministic test requirement | `mixed_batch_is_fifo_budgeted_and_reports_requested_accepted_recycled` | implemented | なし |
 | SIM-002 mixed IPv4/ARP FIFO and budget | deterministic test requirement | `mixed_ipv4_and_arp_batch_is_fifo_budgeted_and_deterministic` | implemented | protocol混在でもsequenceとbudgetを保持 |
+| SIM-003 mixed RX/generated FIFO and typed origin | deterministic test requirement | `mixed_rx_and_generated_tx_are_fifo_budgeted_and_origin_typed` | implemented | RX batch finish後に生成しoriginを型で区別 |
 
 ## RFC deviation rule
 

--- a/docs/requirements-v0.2.md
+++ b/docs/requirements-v0.2.md
@@ -1,11 +1,12 @@
 # v0.2 requirement and RFC ledger
 
 Statusは`implemented`、`deferred`、`deviation`のいずれかです。test名はそのまま
-`cargo test`のfilterとして利用できます。
+`cargo test`のfilterとして利用できます。直接test不能な将来要件に限り、`deferred`
+かつnote付きでTest IDを`—`にできます。
 
 | Requirement ID | 根拠 | Test ID | Status | deviation / note |
 |---|---|---|---|---|
-| IO-001 borrowed GAT batch/core RAII completion | architecture contract | `unfinished_core_lease_is_backend_lifecycle_recycle` | implemented | leaseは!Send/!Sync |
+| IO-001 borrowed GAT batch/core RAII completion | architecture contract | `unfinished_core_lease_is_backend_lifecycle_recycle` | implemented | unfinished leaseのRAII recycleを検証 |
 | IO-002 RX bufferをcloneせずTXへmove | architecture contract | `gateway_route_rewrites_and_reports_backend_acceptance` | implemented | allocation addressも検証 |
 | IO-003 requested/accepted/recycled accounting | architecture contract | `mixed_batch_is_fifo_budgeted_and_reports_requested_accepted_recycled` | implemented | backend finishで確定 |
 | IO-004 partial/error completion preserves report | architecture contract | `partial_backend_completion_preserves_report_and_aggregate_trace` | implemented | rejected slotはbackend所有で解放 |
@@ -13,6 +14,7 @@ Statusは`implemented`、`deferred`、`deviation`のいずれかです。test名
 | IO-006 generated GAT lease lifecycle/exact accounting | architecture contract | `generated_lease_commit_cancel_abandon_and_allocation_failures_are_exact` | implemented | beginでegress固定。commit/cancel/abandon accounting、allocation failure ownershipなし、allocation address moveを検証 |
 | IO-007 generated partial/error completion | architecture contract | `generated_partial_tx_error_preserves_invariants_and_recycles_rejects` | implemented | 三つのaccounting不変条件を保持しrejectをreturn前にrecycle |
 | IO-008 generated builder failure isolation | defensive backend boundary | `builder_failure_cancels_lease_and_retains_action` | implemented | exact-length契約違反bufferをcancelしactionを保持 |
+| IO-009 real generated backend | backend roadmap | — | deferred | AF_XDP/DPDK generated allocator/TXは未実装 |
 | ETH-001 Ethernet II framing | RFC 894 | `all_validation_and_decision_drops_are_granular_and_atomic` | implemented | 802.3 LLC/VLANはdeferred |
 | IP4-001 Version/IHL/Total Length validation | RFC 791 §3.1 | `all_validation_and_decision_drops_are_granular_and_atomic` | implemented | なし |
 | IP4-002 Total Length後のpadding無視 | RFC 791 §3.1 | `padding_is_ignored_but_preserved` | implemented | なし |
@@ -27,7 +29,7 @@ Statusは`implemented`、`deferred`、`deviation`のいずれかです。test名
 | FWD-005 drop atomicity | architecture contract | `all_validation_and_decision_drops_are_granular_and_atomic` | implemented | なし |
 | FWD-006 snapshot integrity | architecture contract | `snapshot_constructor_rejects_all_broken_references_and_duplicates` | implemented | 公開前にvalidation |
 | FWD-007 unresolved trigger atomicity/request action | RFC 1122 §2.3.2.1 | `unresolved_neighbor_generates_broadcast_arp_request_and_recycles_trigger_atomically` | implemented | 元IPv4はbyte不変NeighborUnresolved、RX finish後にgenerated session |
-| FWD-008 unresolved packet hold/replay | RFC 1122 §2.3.2.2, RFC 1812 §3.3.2 | `unresolved_neighbor_generates_broadcast_arp_request_and_recycles_trigger_atomically` | deferred | hold/replayなし。最初のpacketは解決後も自動再送されない |
+| FWD-008 unresolved packet hold/replay | RFC 1122 §2.3.2.2, RFC 1812 §3.3.2 | — | deferred | hold/replay未実装。最初のpacketは解決後も自動再送されない |
 | ARP-001 Ethernet/IPv4 request profile validation | RFC 826, RFC 5494/IANA ARP Parameters | `arp_profile_validation_drops_are_granular_and_atomic` | implemented | HTYPE=1/PTYPE=0x0800/HLEN=6/PLEN=4/opcode=1。replyとunknown opcodeを区別 |
 | ARP-002 local target in-place reply on ingress | RFC 826 | `arp_request_for_local_ipv4_replies_in_place_on_ingress` | implemented | 同じRX allocation、egress=ingress、wire fieldsを検証 |
 | ARP-003 probe reply with zero target protocol | RFC 5227 §2.5（Probe形式は§1.1/§2.1.1） | `arp_probe_for_local_ipv4_replies_with_zero_target_protocol` | implemented | SPA=0 requestにも通常reply |
@@ -36,17 +38,26 @@ Statusは`implemented`、`deferred`、`deviation`のいずれかです。test名
 | ARP-006 nonlocal/proxy-disabled/reply/unknown opcode stable recycle | RFC 826, RFC 1027, RFC 5494/IANA ARP Parameters | `arp_nonlocal_and_reply_are_recycled_without_mutation` | implemented | nonlocal targetへ応答せずproxy ARPは無効。replyとunknown opcodeは別stable reason |
 | ARP-007 local binding snapshot integrity | architecture contract | `arp_snapshot_rejects_duplicate_or_unknown_local_addresses` | implemented | interfaceごとにlocal IPv4一つ、address重複/unknown interface/unspecified SPAを拒否。MACはInterfaceのみ |
 | ARP-008 address conflict detection/defense | RFC 5227 §2.4 | `arp_foreign_sender_claiming_local_address_gets_normal_reply` | deviation | foreign SHAがlocal SPAを名乗ってもconflict state/defensive announcementなし。local targetへの通常replyのみ |
-| ARP-009 learning/cache/aging/flush | RFC 826 | `arp_reply_does_not_learn_or_generate_for_unresolved_neighbor` | deferred | responderとrequest generatorはneighbor snapshotを変更しない |
-| ARP-010 normal request 60-byte wire profile | RFC 826 | `unresolved_neighbor_generates_broadcast_arp_request_and_recycles_trigger_atomically` | implemented | broadcast Ethernet、SPAはnonzero local、THA zero、18-byte zero padding、FCSなし |
+| ARP-009 responder learning absent | RFC 826 | `arp_reply_does_not_learn_or_generate_for_unresolved_neighbor` | deferred | 現sliceは受信requestからsenderを学習せず、直後のIPv4 neighbor missを実証 |
+| ARP-009A neighbor cache aging/flush | RFC 826 | — | deferred | mutable neighbor cache自体が未実装 |
+| ARP-010 normal request 60-byte wire profile | RFC 826, RFC 894 | `unresolved_neighbor_generates_broadcast_arp_request_and_recycles_trigger_atomically` | implemented | broadcast Ethernet、SPAはnonzero local、THA zero、18-byte zero padding、FCSなし |
 | ARP-010A ordinary request is not Probe/Announcement | RFC 826, local deterministic profile | `ordinary_resolution_request_is_not_probe_or_announcement` | implemented | SPA nonzero、SPA≠TPA、opcode Request |
-| ARP-011 flood suppression exact deadline | RFC 1122 §2.3.2.1 | `same_target_is_rate_limited_to_one_request_per_second_at_exact_deadline` | implemented | commit時刻基準、999ms suppress/1000ms queue。partial rejectもrequestedなので開始 |
+| ARP-011 commit-based suppression deadline | RFC 1122 §2.3.2.1 | `suppression_deadline_starts_at_generated_commit_time` | implemented | enqueue=0ms、commit=700ms、1699ms suppress、1700ms queue |
+| ARP-011B exact interval and rejected request suppression | RFC 1122 §2.3.2.1 | `same_target_is_rate_limited_to_one_request_per_second_at_exact_deadline` | implemented | partial rejectもTX requestedなので0msから999ms suppress、1000ms queue |
 | ARP-011A suppression policy validation | RFC 1122 §2.3.2.1, local policy | `resolution_policy_rejects_short_interval_and_state_ttl` | implemented | interval>=1000ms、state TTL>=interval |
 | ARP-012 action ring full semantics | architecture contract | `action_full_does_not_create_phantom_suppression` | implemented | action fullはphantom deadlineなし |
 | ARP-012A state table full semantics | architecture contract | `state_full_never_evicts_live_entry_and_ttl_allows_reuse` | implemented | live非evict、TTL到達でreuse |
 | ARP-012B monotonic clock regression | architecture contract | `clock_regression_is_typed_and_does_not_mutate_queue` | implemented | typed result/counter/trace、queue非変更 |
 | ARP-012C resolution key independence | architecture contract | `resolution_keys_are_independent_by_interface_and_target` | implemented | target違いとIfId違いを独立queue |
+| ARP-012D runtime storage initialization | architecture contract | `recreating_runtime_clears_caller_state_and_queued_actions` | implemented | constructorはstate/action storageをemptyへ初期化 |
+| ARP-012E runtime state persistence/resume | architecture contract | — | deferred | process/runtime再生成をまたぐresolution state永続化は未実装 |
 | ARP-013 forbidden request targets | local safety policy | `local_binding_missing_and_forbidden_targets_generate_nothing` | implemented | unspecified/multicast/limited broadcast/確定可能なdirected broadcastとbindingなしは生成しない |
-| ARP-014 traffic-driven retry/timer retry | RFC 1122 §2.3.2.1 | `allocation_failure_retains_action_and_does_not_start_deadline` | deferred | action保持とtraffic miss retryのみ。timer-only retry/max attempts/Failedなし |
+| ARP-013A local source address target prohibition | local safety policy | `local_source_ip_is_forbidden_as_connected_or_gateway_target` | implemented | connected destinationとgateway next-hopの両方でsource local IPを拒否 |
+| ARP-013B all-connected-route directed broadcast check | local safety policy | `gateway_target_matching_same_egress_connected_broadcast_is_forbidden` | implemented | packet選択default route以外の同一egress connected /24も確認 |
+| ARP-014 allocation failure action retention | architecture contract | `allocation_failure_retains_action_and_does_not_start_deadline` | implemented | unavailable時はaction保持、deadline非開始、後続executorでretry可能 |
+| ARP-014A timer-only retry/max attempts/Failed | RFC 1122 §2.3.2.1 | — | deferred | retryはtraffic-drivenまたは保持actionのexecutor再実行のみ |
+| ARP-015 multi-worker resolution ownership/sharding | concurrency design | — | deferred | 現sliceはsingle worker ownerのみ。shard/SPSC handoff未実装 |
+| ARP-016 Probe/Announcement/GARP/ACD generation | RFC 5227 | — | deferred | generated pathは通常ARP Requestだけ。Probe/Announcement/GARP/ACDは未実装 |
 | OBS-001 stable reason code | explainability requirement | `drop_reason_discriminants_and_codes_are_stable_and_unique` | implemented | repr(u16) |
 | OBS-002 requestedとaggregate TX outcome trace | explainability requirement | `partial_backend_completion_preserves_report_and_aggregate_trace` | implemented | packet単位accepted traceはdeferred |
 | OBS-003 protocol-aware ARP trace ordering | explainability requirement | `arp_trace_is_deterministic_and_tx_follows_commit` | implemented | validated/reply requested/TX requested/completionを順序検証 |

--- a/scripts/check-requirements.sh
+++ b/scripts/check-requirements.sh
@@ -42,16 +42,27 @@ table && /^\|/ {
         printf "%s:%d: deviation %s requires a note\n", FILENAME, NR, id > "/dev/stderr"
         failed = 1
     }
-    if (test !~ /^`[a-zA-Z0-9_]+`$/) {
-        printf "%s:%d: Test ID must be one backticked Rust test name\n", FILENAME, NR > "/dev/stderr"
-        failed = 1
-        next
-    }
-    gsub(/`/, "", test)
     if (seen[requirement_id]++) {
         printf "%s:%d: duplicate requirement ID %s\n", FILENAME, NR, requirement_id > "/dev/stderr"
         failed = 1
     }
+    if (test == "—") {
+        if (status != "deferred") {
+            printf "%s:%d: only deferred requirements may use — for Test ID\n", FILENAME, NR > "/dev/stderr"
+            failed = 1
+        }
+        if (note == "" || note == "なし") {
+            printf "%s:%d: deferred requirement %s with — requires a note\n", FILENAME, NR, id > "/dev/stderr"
+            failed = 1
+        }
+        next
+    }
+    if (test !~ /^`[a-zA-Z0-9_]+`$/) {
+        printf "%s:%d: Test ID must be one backticked Rust test name or deferred —\n", FILENAME, NR > "/dev/stderr"
+        failed = 1
+        next
+    }
+    gsub(/`/, "", test)
     print requirement_id "\t" test
     next
 }


### PR DESCRIPTION
## Summary

- add a backend-owned generated-TX GAT/RAII lease independent from RX batches
- queue typed ARP request actions on static neighbor misses while recycling the triggering IPv4 frame byte-for-byte
- execute generated actions only after the RX batch is fully finished
- generate deterministic 60-byte RFC 826 Ethernet/IPv4 ARP Requests with zero padding
- suppress requests per `(IfId, target)` for at least one second using an injected monotonic clock
- add deterministic sim allocation, capacity, partial-TX, error, recycle, budget, FIFO, and origin handling

## Ownership and lifecycle

- generated sessions fix the egress before allocation
- leases expose only an exact final-frame slice; backend headroom/raw buffers remain private
- commit, cancel, and abandonment complete ownership exactly once
- allocation failure creates no ownership and retains the queued action
- generated completion preserves all accounting even on backend errors
- `attempts = allocated + failed`
- `allocated = requested + cancelled + abandoned`
- `accepted + rejected = requested`
- rejected slots are recycled before `finish` returns
- live generated leases and resolution runtime are compile-time `!Send + !Sync`

## Resolution semantics

- static neighbor hits remain the unchanged fast path
- first miss queues at most one action and remains `NeighborUnresolved`
- suppression begins at generated TX commit/request time, not enqueue time
- partial TX rejection still starts suppression because TX was requested
- allocation/build failure retains the uncommitted action and starts no deadline
- keys are isolated by interface and target
- unspecified, multicast, limited broadcast, local source/self target, and detectable same-egress directed broadcast targets are rejected
- runtime state/action storage is caller-owned, fixed-capacity, and reset together

## Standards and scope

Implemented:

- RFC 826 normal ARP Request wire image
- RFC 894 minimum Ethernet frame handling with an 18-byte zero tail and no FCS
- RFC 1122 §2.3.2.1 per-target flood prevention

Explicitly deferred:

- ARP reply learning, dynamic cache, aging, and stale flush
- unresolved packet hold/replay; the first packet is recycled and not automatically replayed
- timer-only retry, max-attempt, and Failed state
- Probe/Announcement/GARP generation and ACD
- multi-worker owner sharding/SPSC handoff
- AF_XDP/DPDK backends

This PR is request generation and suppression, not complete active resolution.

## Validation

- 49 unit/integration/acceptance tests
- 4 compile-fail doctests for `!Send + !Sync`
- format, check, clippy `-D warnings`, rustdoc `-D warnings`
- requirement-ledger lint and diff check
- required CI now explicitly runs workspace doctests
- independent ownership/core-safety review: no Critical/High/Medium findings
- independent RFC/tests/docs review: no Critical/High/Medium findings
- zero external crate dependencies and no unsafe code

The next slice will consume valid ARP Replies into a worker-local bounded dynamic cache, then demonstrate miss → request → reply learning → reinjected IPv4 forwarding.