### PR TITLE
feat(core): learn dynamic ARP neighbors

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ active treeは、そのコードを継承しないv0.2のゼロベース実装�
 
 - `ruster-core`: backend所有packetを借用し、Ethernet II / IPv4検証、LPM、
   TTL/checksum/MAC rewrite、local IPv4向けARP reply、static neighbor miss時の
-  ARP Request生成actionを扱う。
+  ARP Request生成action、fixed-capacity dynamic ARP cacheを扱う。
 - `ruster-io-sim`: rootやNICなしでRX/generated TXのFIFO、budget、TX/drop、
   traceを決定的に検証する。
 
@@ -31,8 +31,8 @@ ARP profileはinterfaceごとにlocal IPv4を一つだけ持つ静的snapshotで
 
 static neighbor missでは元IPv4 packetをbyte不変でrecycleした後、worker-localな固定
 storageで1秒に一度までARP Requestを生成できます。RX batchとgenerated TX sessionは
-二相に分離し、生成frameもbackend所有bufferを借用します。これはrequest generationと
-flood suppressionまでであり、reply学習やpacket holdを含むactive resolutionではありません。
+二相に分離し、生成frameもbackend所有bufferを借用します。ARP Reply/RequestはRFC 826
+mergeでworker-local cacheへ学習しますが、元IPv4 packetのhold/replayは行いません。
 
 ## 開発
 

--- a/crates/core/src/forwarding.rs
+++ b/crates/core/src/forwarding.rs
@@ -1,7 +1,9 @@
+use crate::resolution::DynamicLookup;
 use crate::{
-    packet, rfc1624_update, route, validate_arp_request, validate_ipv4_frame, ArpRequestAction,
-    BatchCompletion, IfId, Interface, LocalIpv4Binding, MonotonicMillis, Neighbor, PacketBatch,
-    ResolutionResult, ResolutionRuntime, Route, ARP_ETHERTYPE, IPV4_ETHERTYPE,
+    packet, rfc1624_update, route, validate_arp, validate_ipv4_frame, ArpOpcode, ArpRequestAction,
+    BatchCompletion, ConsumeReason, ControlDisposition, IfId, Interface, LocalIpv4Binding,
+    MonotonicMillis, Neighbor, PacketBatch, ResolutionResult, ResolutionRuntime, Route,
+    ARP_ETHERTYPE, IPV4_ETHERTYPE,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -30,6 +32,9 @@ pub enum DropReason {
     ArpReplyUnsupported = 20,
     ArpOpcodeUnsupported = 21,
     ArpTargetNotLocal = 22,
+    ArpSenderHardwareZero = 23,
+    ArpSenderHardwareBroadcast = 24,
+    ArpSenderHardwareMulticast = 25,
 }
 
 use DropReason::*;
@@ -60,6 +65,9 @@ impl DropReason {
             ArpReplyUnsupported => "ARP_REPLY_UNSUPPORTED",
             ArpOpcodeUnsupported => "ARP_OPCODE_UNSUPPORTED",
             ArpTargetNotLocal => "ARP_TARGET_NOT_LOCAL",
+            ArpSenderHardwareZero => "ARP_SENDER_HARDWARE_ZERO",
+            ArpSenderHardwareBroadcast => "ARP_SENDER_HARDWARE_BROADCAST",
+            ArpSenderHardwareMulticast => "ARP_SENDER_HARDWARE_MULTICAST",
         }
     }
 }
@@ -161,6 +169,15 @@ pub enum TraceEvent {
         sender_protocol: crate::Ipv4Address,
         target_protocol: crate::Ipv4Address,
     },
+    ArpReplyValidated {
+        ingress: IfId,
+        sender_protocol: crate::Ipv4Address,
+        target_protocol: crate::Ipv4Address,
+    },
+    ArpControl {
+        ingress: IfId,
+        disposition: ControlDisposition,
+    },
     Routed {
         egress: IfId,
         neighbor_target: crate::Ipv4Address,
@@ -181,6 +198,11 @@ pub enum TraceEvent {
     Dropped {
         ingress: IfId,
         reason: DropReason,
+    },
+    Consumed {
+        ingress: IfId,
+        reason: ConsumeReason,
+        disposition: ControlDisposition,
     },
     BatchCompleted {
         tx_accepted: usize,
@@ -208,6 +230,7 @@ pub struct BatchReport<E> {
     /// Packets requested for TX; this does not mean backend or wire acceptance.
     pub tx_requested: usize,
     pub dropped: usize,
+    pub consumed: usize,
     pub completion: BatchCompletion<E>,
 }
 
@@ -237,13 +260,15 @@ struct ArpReplyDecision {
 enum PacketDecision {
     Ipv4(Ipv4RewriteDecision),
     ArpReply(ArpReplyDecision),
+    Consume(ControlDisposition),
 }
 
 impl PacketDecision {
-    const fn egress(self) -> IfId {
+    fn egress(self) -> IfId {
         match self {
             Self::Ipv4(decision) => decision.egress,
             Self::ArpReply(decision) => decision.egress,
+            Self::Consume(_) => unreachable!("consumed controls have no egress"),
         }
     }
 }
@@ -289,15 +314,30 @@ where
     let mut received = 0;
     let mut tx_requested = 0;
     let mut dropped = 0;
+    let mut consumed = 0;
     while let Some(mut packet) = batch.next_packet() {
         received += 1;
         let ingress = packet.ingress();
         let result = {
             let frame = packet.bytes_mut();
-            decide(&*frame, snapshot, ingress, &mut resolution, trace)
-                .and_then(|decision| apply_decision(frame, decision).map(|()| decision))
+            decide(&*frame, snapshot, ingress, &mut resolution, trace).and_then(|decision| {
+                if matches!(decision, PacketDecision::Consume(_)) {
+                    Ok(decision)
+                } else {
+                    apply_decision(frame, decision).map(|()| decision)
+                }
+            })
         };
         match result {
+            Ok(PacketDecision::Consume(disposition)) => {
+                packet.consume(ConsumeReason::ArpControl);
+                consumed += 1;
+                trace.record(TraceEvent::Consumed {
+                    ingress,
+                    reason: ConsumeReason::ArpControl,
+                    disposition,
+                });
+            }
             Ok(decision) => {
                 let egress = decision.egress();
                 packet.commit(egress);
@@ -318,6 +358,7 @@ where
         }
     }
     let completion = batch.finish();
+    debug_assert_eq!(received, tx_requested + dropped + consumed);
     trace.record(TraceEvent::BatchCompleted {
         tx_accepted: completion.tx_accepted,
         tx_rejected: completion.tx_rejected,
@@ -326,6 +367,7 @@ where
         received,
         tx_requested,
         dropped,
+        consumed,
         completion,
     }
 }
@@ -342,7 +384,7 @@ fn decide<T: TraceSink>(
         IPV4_ETHERTYPE => {
             decide_ipv4(frame, snapshot, ingress, resolution, trace).map(PacketDecision::Ipv4)
         }
-        ARP_ETHERTYPE => decide_arp(frame, snapshot, ingress, trace).map(PacketDecision::ArpReply),
+        ARP_ETHERTYPE => decide_arp(frame, snapshot, ingress, resolution, trace),
         _ => Err(UnsupportedEtherType),
     }
 }
@@ -372,37 +414,52 @@ fn decide_ipv4<T: TraceSink>(
         .iter()
         .find(|item| item.id == route.egress())
         .ok_or(InterfaceMiss)?;
-    let neighbor = snapshot
+    let static_neighbor = snapshot
         .neighbors
         .iter()
         .find(|item| item.interface == route.egress() && item.target == target);
-    let Some(neighbor) = neighbor else {
-        if let (Some(binding), Some((runtime, now))) = (
-            snapshot
-                .local_ipv4
-                .iter()
-                .find(|binding| binding.interface == route.egress()),
-            resolution.as_mut(),
-        ) {
-            let result = runtime.schedule(
-                ArpRequestAction {
+    let destination_mac = if let Some(neighbor) = static_neighbor {
+        neighbor.mac
+    } else if let Some((runtime, now)) = resolution.as_mut() {
+        match runtime.lookup_dynamic(route.egress(), target, *now) {
+            DynamicLookup::Hit(mac) => mac,
+            DynamicLookup::ClockRegression => {
+                trace.record(TraceEvent::NeighborResolution {
                     egress: route.egress(),
-                    source_mac: interface.mac,
-                    source_ip: binding.address,
-                    target_ip: target,
-                },
-                *now,
-                snapshot.routes.iter().any(|candidate| {
-                    candidate.egress() == route.egress()
-                        && candidate.is_connected_directed_broadcast(target)
-                }),
-            );
-            trace.record(TraceEvent::NeighborResolution {
-                egress: route.egress(),
-                target,
-                result,
-            });
+                    target,
+                    result: ResolutionResult::ClockRegression,
+                });
+                return Err(NeighborUnresolved);
+            }
+            DynamicLookup::Miss => {
+                if let Some(binding) = snapshot
+                    .local_ipv4
+                    .iter()
+                    .find(|binding| binding.interface == route.egress())
+                {
+                    let result = runtime.schedule(
+                        ArpRequestAction {
+                            egress: route.egress(),
+                            source_mac: interface.mac,
+                            source_ip: binding.address,
+                            target_ip: target,
+                        },
+                        *now,
+                        snapshot.routes.iter().any(|candidate| {
+                            candidate.egress() == route.egress()
+                                && candidate.is_connected_directed_broadcast(target)
+                        }),
+                    );
+                    trace.record(TraceEvent::NeighborResolution {
+                        egress: route.egress(),
+                        target,
+                        result,
+                    });
+                }
+                return Err(NeighborUnresolved);
+            }
         }
+    } else {
         return Err(NeighborUnresolved);
     };
     let ttl_offset = ipv4
@@ -423,7 +480,7 @@ fn decide_ipv4<T: TraceSink>(
     Ok(Ipv4RewriteDecision {
         egress: route.egress(),
         source_mac: interface.mac.0,
-        destination_mac: neighbor.mac.0,
+        destination_mac: destination_mac.0,
         ttl_offset,
         checksum_offset,
         checksum_end,
@@ -437,20 +494,88 @@ fn decide_arp<T: TraceSink>(
     frame: &[u8],
     snapshot: &ForwardingSnapshot<'_>,
     ingress: IfId,
+    resolution: &mut Option<(&mut ResolutionRuntime<'_>, MonotonicMillis)>,
     trace: &mut T,
-) -> Result<ArpReplyDecision, DropReason> {
-    let arp = validate_arp_request(frame)?;
-    trace.record(TraceEvent::ArpRequestValidated {
-        ingress,
-        sender_protocol: arp.sender_protocol,
-        target_protocol: arp.target_protocol,
-    });
-    if !snapshot
+) -> Result<PacketDecision, DropReason> {
+    let arp = validate_arp(frame)?;
+    match arp.opcode {
+        ArpOpcode::Request => trace.record(TraceEvent::ArpRequestValidated {
+            ingress,
+            sender_protocol: arp.sender_protocol,
+            target_protocol: arp.target_protocol,
+        }),
+        ArpOpcode::Reply => trace.record(TraceEvent::ArpReplyValidated {
+            ingress,
+            sender_protocol: arp.sender_protocol,
+            target_protocol: arp.target_protocol,
+        }),
+    }
+    let sha = arp.sender_hardware.0;
+    if sha == [0; 6] {
+        return Err(ArpSenderHardwareZero);
+    }
+    if sha == [0xff; 6] {
+        return Err(ArpSenderHardwareBroadcast);
+    }
+    if sha[0] & 1 != 0 {
+        return Err(ArpSenderHardwareMulticast);
+    }
+    let target_local = snapshot
         .local_ipv4
         .iter()
-        .any(|binding| binding.interface == ingress && binding.address == arp.target_protocol)
-    {
-        return Err(ArpTargetNotLocal);
+        .any(|binding| binding.interface == ingress && binding.address == arp.target_protocol);
+    let sender_local = snapshot
+        .local_ipv4
+        .iter()
+        .any(|binding| binding.address == arp.sender_protocol);
+    let sender_host = sender_is_host(snapshot, ingress, arp.sender_protocol);
+    let static_key = snapshot
+        .neighbors
+        .iter()
+        .any(|neighbor| neighbor.interface == ingress && neighbor.target == arp.sender_protocol);
+    let has_runtime = resolution.is_some();
+    let disposition = if let Some((runtime, now)) = resolution.as_mut() {
+        if arp.sender_protocol.is_unspecified() {
+            if runtime.observe_control(*now) {
+                ControlDisposition::Probe
+            } else {
+                ControlDisposition::ClockRegression
+            }
+        } else if sender_local {
+            if runtime.observe_control(*now) {
+                ControlDisposition::LocalAddressPreserved
+            } else {
+                ControlDisposition::ClockRegression
+            }
+        } else if !sender_host {
+            if runtime.observe_control(*now) {
+                ControlDisposition::SenderNotHost
+            } else {
+                ControlDisposition::ClockRegression
+            }
+        } else {
+            runtime.merge_dynamic(
+                ingress,
+                arp.sender_protocol,
+                arp.sender_hardware,
+                target_local,
+                static_key,
+                *now,
+            )
+        }
+    } else if static_key {
+        ControlDisposition::StaticPreserved
+    } else {
+        ControlDisposition::Ignored
+    };
+    if has_runtime {
+        trace.record(TraceEvent::ArpControl {
+            ingress,
+            disposition,
+        });
+    }
+    if arp.opcode == ArpOpcode::Reply || !target_local {
+        return Ok(PacketDecision::Consume(disposition));
     }
     let interface = snapshot
         .interfaces
@@ -460,19 +585,34 @@ fn decide_arp<T: TraceSink>(
     if frame.get(0..packet::ARP_FRAME_LEN).is_none() {
         return Err(ArpPacketTruncated);
     }
-    Ok(ArpReplyDecision {
+    Ok(PacketDecision::ArpReply(ArpReplyDecision {
         egress: ingress,
         local_mac: interface.mac.0,
         requester_mac: arp.sender_hardware.0,
         requester_protocol: arp.sender_protocol.octets(),
         local_protocol: arp.target_protocol.octets(),
-    })
+    }))
+}
+
+fn sender_is_host(
+    snapshot: &ForwardingSnapshot<'_>,
+    ingress: IfId,
+    sender: crate::Ipv4Address,
+) -> bool {
+    let octets = sender.octets();
+    octets != [255; 4]
+        && (octets[0] & 0xf0) != 0xe0
+        && !snapshot
+            .routes
+            .iter()
+            .any(|route| route.egress() == ingress && route.is_connected_directed_broadcast(sender))
 }
 
 fn apply_decision(frame: &mut [u8], decision: PacketDecision) -> Result<(), DropReason> {
     match decision {
         PacketDecision::Ipv4(ipv4) => apply_ipv4_rewrite(frame, ipv4),
         PacketDecision::ArpReply(arp) => apply_arp_reply(frame, arp),
+        PacketDecision::Consume(_) => unreachable!("consume decisions are never rewritten"),
     }
 }
 
@@ -541,6 +681,9 @@ mod tests {
             (20, "ARP_REPLY_UNSUPPORTED"),
             (21, "ARP_OPCODE_UNSUPPORTED"),
             (22, "ARP_TARGET_NOT_LOCAL"),
+            (23, "ARP_SENDER_HARDWARE_ZERO"),
+            (24, "ARP_SENDER_HARDWARE_BROADCAST"),
+            (25, "ARP_SENDER_HARDWARE_MULTICAST"),
         ];
         let actual = [
             DropReason::EthernetHeaderTruncated,
@@ -565,6 +708,9 @@ mod tests {
             DropReason::ArpReplyUnsupported,
             DropReason::ArpOpcodeUnsupported,
             DropReason::ArpTargetNotLocal,
+            DropReason::ArpSenderHardwareZero,
+            DropReason::ArpSenderHardwareBroadcast,
+            DropReason::ArpSenderHardwareMulticast,
         ];
         for (reason, &(discriminant, code)) in actual.iter().zip(&expected) {
             assert_eq!(*reason as u16, discriminant);

--- a/crates/core/src/forwarding.rs
+++ b/crates/core/src/forwarding.rs
@@ -527,7 +527,7 @@ fn decide_arp<T: TraceSink>(
     let sender_local = snapshot
         .local_ipv4
         .iter()
-        .any(|binding| binding.address == arp.sender_protocol);
+        .any(|binding| binding.interface == ingress && binding.address == arp.sender_protocol);
     let sender_host = sender_is_host(snapshot, ingress, arp.sender_protocol);
     let static_key = snapshot
         .neighbors
@@ -535,7 +535,16 @@ fn decide_arp<T: TraceSink>(
         .any(|neighbor| neighbor.interface == ingress && neighbor.target == arp.sender_protocol);
     let has_runtime = resolution.is_some();
     let disposition = if let Some((runtime, now)) = resolution.as_mut() {
-        if arp.sender_protocol.is_unspecified() {
+        if static_key {
+            runtime.merge_dynamic(
+                ingress,
+                arp.sender_protocol,
+                arp.sender_hardware,
+                target_local,
+                true,
+                *now,
+            )
+        } else if arp.sender_protocol.is_unspecified() {
             if runtime.observe_control(*now) {
                 ControlDisposition::Probe
             } else {
@@ -559,7 +568,7 @@ fn decide_arp<T: TraceSink>(
                 arp.sender_protocol,
                 arp.sender_hardware,
                 target_local,
-                static_key,
+                false,
                 *now,
             )
         }
@@ -600,12 +609,14 @@ fn sender_is_host(
     sender: crate::Ipv4Address,
 ) -> bool {
     let octets = sender.octets();
-    octets != [255; 4]
-        && (octets[0] & 0xf0) != 0xe0
-        && !snapshot
-            .routes
-            .iter()
-            .any(|route| route.egress() == ingress && route.is_connected_directed_broadcast(sender))
+    octets[0] != 0
+        && octets[0] != 127
+        && octets[0] < 224
+        && !snapshot.routes.iter().any(|route| {
+            route.egress() == ingress
+                && (route.is_connected_directed_broadcast(sender)
+                    || route.is_connected_network_address(sender))
+        })
 }
 
 fn apply_decision(frame: &mut [u8], decision: PacketDecision) -> Result<(), DropReason> {

--- a/crates/core/src/io.rs
+++ b/crates/core/src/io.rs
@@ -39,7 +39,13 @@ pub trait PacketSlot {
 pub enum SlotCompletion {
     Transmit(IfId),
     Recycle(DropReason),
+    Consume(ConsumeReason),
     LeaseAbandoned,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ConsumeReason {
+    ArpControl,
 }
 
 /// A core-owned, worker-local RAII lease.
@@ -75,6 +81,10 @@ impl<S: PacketSlot> PacketLease<S> {
 
     pub fn recycle(mut self, reason: DropReason) {
         self.complete(SlotCompletion::Recycle(reason));
+    }
+
+    pub fn consume(mut self, reason: ConsumeReason) {
+        self.complete(SlotCompletion::Consume(reason));
     }
 
     fn complete(&mut self, completion: SlotCompletion) {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -30,6 +30,6 @@ pub use resolution::{
     DynamicNeighborSlot, ExecuteArpRequestError, GeneratedArpReport, GeneratedArpTrace,
     GeneratedTraceSink, MonotonicMillis, NoGeneratedTrace, ResolutionActionSlot,
     ResolutionCounters, ResolutionPolicy, ResolutionPolicyError, ResolutionResult,
-    ResolutionRuntime, ResolutionStateSlot, ARP_REQUEST_FRAME_LEN,
+    ResolutionRuntime, ResolutionStateSlot, StaticReconcileReport, ARP_REQUEST_FRAME_LEN,
 };
 pub use route::{IfId, Interface, Ipv4Address, LocalIpv4Binding, Neighbor, Route, RouteError};

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -18,15 +18,18 @@ pub use generated::{
     GeneratedAllocationError, GeneratedBatchCompletion, GeneratedPacketBatch, GeneratedPacketIo,
     GeneratedPacketLease, GeneratedPacketSlot, GeneratedSlotCompletion,
 };
-pub use io::{BatchCompletion, PacketBatch, PacketIo, PacketLease, PacketSlot, SlotCompletion};
+pub use io::{
+    BatchCompletion, ConsumeReason, PacketBatch, PacketIo, PacketLease, PacketSlot, SlotCompletion,
+};
 pub use packet::{
-    validate_arp_request, validate_ipv4_frame, MacAddress, ValidatedArpRequest, ValidatedIpv4,
-    ARP_ETHERTYPE, ETHERNET_HEADER_LEN, IPV4_ETHERTYPE,
+    validate_arp, validate_arp_request, validate_ipv4_frame, ArpOpcode, MacAddress, ValidatedArp,
+    ValidatedArpRequest, ValidatedIpv4, ARP_ETHERTYPE, ETHERNET_HEADER_LEN, IPV4_ETHERTYPE,
 };
 pub use resolution::{
-    execute_one_arp_request, ArpRequestAction, ArpRequestBuildError, ExecuteArpRequestError,
-    GeneratedArpReport, GeneratedArpTrace, GeneratedTraceSink, MonotonicMillis, NoGeneratedTrace,
-    ResolutionActionSlot, ResolutionCounters, ResolutionPolicy, ResolutionPolicyError,
-    ResolutionResult, ResolutionRuntime, ResolutionStateSlot, ARP_REQUEST_FRAME_LEN,
+    execute_one_arp_request, ArpRequestAction, ArpRequestBuildError, ControlDisposition,
+    DynamicNeighborSlot, ExecuteArpRequestError, GeneratedArpReport, GeneratedArpTrace,
+    GeneratedTraceSink, MonotonicMillis, NoGeneratedTrace, ResolutionActionSlot,
+    ResolutionCounters, ResolutionPolicy, ResolutionPolicyError, ResolutionResult,
+    ResolutionRuntime, ResolutionStateSlot, ARP_REQUEST_FRAME_LEN,
 };
 pub use route::{IfId, Interface, Ipv4Address, LocalIpv4Binding, Neighbor, Route, RouteError};

--- a/crates/core/src/packet.rs
+++ b/crates/core/src/packet.rs
@@ -23,7 +23,14 @@ pub struct ValidatedIpv4 {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct ValidatedArpRequest {
+pub enum ArpOpcode {
+    Request,
+    Reply,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ValidatedArp {
+    pub opcode: ArpOpcode,
     pub sender_hardware: MacAddress,
     pub sender_protocol: crate::Ipv4Address,
     pub target_protocol: crate::Ipv4Address,
@@ -109,12 +116,12 @@ pub fn validate_ipv4_frame(frame: &[u8]) -> Result<ValidatedIpv4, DropReason> {
     })
 }
 
-/// Validates the Ethernet/IPv4 ARP profile and returns a request view.
+/// Validates the common Ethernet/IPv4 ARP Request/Reply profile.
 ///
 /// The target hardware address is intentionally ignored as required by
 /// RFC 826 request processing. Ethernet source and ARP sender hardware are
 /// also not required to match. No bytes are mutated by this function.
-pub fn validate_arp_request(frame: &[u8]) -> Result<ValidatedArpRequest, DropReason> {
+pub fn validate_arp(frame: &[u8]) -> Result<ValidatedArp, DropReason> {
     if frame.len() < ETHERNET_HEADER_LEN {
         return Err(DropReason::EthernetHeaderTruncated);
     }
@@ -137,14 +144,15 @@ pub fn validate_arp_request(frame: &[u8]) -> Result<ValidatedArpRequest, DropRea
     if frame[19] != 4 {
         return Err(DropReason::ArpProtocolLengthUnsupported);
     }
-    match read_u16(frame, 20) {
-        Some(1) => {}
-        Some(2) => return Err(DropReason::ArpReplyUnsupported),
+    let opcode = match read_u16(frame, 20) {
+        Some(1) => ArpOpcode::Request,
+        Some(2) => ArpOpcode::Reply,
         Some(_) => return Err(DropReason::ArpOpcodeUnsupported),
         None => return Err(DropReason::ArpPacketTruncated),
-    }
+    };
 
-    Ok(ValidatedArpRequest {
+    Ok(ValidatedArp {
+        opcode,
         sender_hardware: MacAddress([
             frame[22], frame[23], frame[24], frame[25], frame[26], frame[27],
         ]),
@@ -156,6 +164,17 @@ pub fn validate_arp_request(frame: &[u8]) -> Result<ValidatedArpRequest, DropRea
         ]),
     })
 }
+
+/// Compatibility validator for callers that require a Request.
+pub fn validate_arp_request(frame: &[u8]) -> Result<ValidatedArp, DropReason> {
+    let arp = validate_arp(frame)?;
+    if arp.opcode == ArpOpcode::Reply {
+        return Err(DropReason::ArpReplyUnsupported);
+    }
+    Ok(arp)
+}
+
+pub type ValidatedArpRequest = ValidatedArp;
 
 pub(crate) fn read_u16(bytes: &[u8], offset: usize) -> Option<u16> {
     let end = offset.checked_add(2)?;

--- a/crates/core/src/resolution.rs
+++ b/crates/core/src/resolution.rs
@@ -14,12 +14,14 @@ pub struct MonotonicMillis(pub u64);
 pub enum ResolutionPolicyError {
     IntervalTooShort,
     StateTtlTooShort,
+    DynamicNeighborTtlZero,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ResolutionPolicy {
     interval_ms: u64,
     state_ttl_ms: u64,
+    dynamic_neighbor_ttl_ms: u64,
 }
 
 impl ResolutionPolicy {
@@ -33,7 +35,21 @@ impl ResolutionPolicy {
         Ok(Self {
             interval_ms,
             state_ttl_ms,
+            dynamic_neighbor_ttl_ms: 60_000,
         })
+    }
+
+    pub fn with_dynamic_neighbor_ttl(
+        interval_ms: u64,
+        state_ttl_ms: u64,
+        dynamic_neighbor_ttl_ms: u64,
+    ) -> Result<Self, ResolutionPolicyError> {
+        let mut policy = Self::new(interval_ms, state_ttl_ms)?;
+        if dynamic_neighbor_ttl_ms == 0 {
+            return Err(ResolutionPolicyError::DynamicNeighborTtlZero);
+        }
+        policy.dynamic_neighbor_ttl_ms = dynamic_neighbor_ttl_ms;
+        Ok(policy)
     }
 }
 
@@ -89,6 +105,45 @@ impl ResolutionStateSlot {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DynamicNeighborSlot {
+    interface: IfId,
+    target: Ipv4Address,
+    mac: MacAddress,
+    refreshed_at: MonotonicMillis,
+    occupied: bool,
+}
+
+impl DynamicNeighborSlot {
+    pub const EMPTY: Self = Self {
+        interface: IfId(0),
+        target: Ipv4Address::from_octets([0; 4]),
+        mac: MacAddress([0; 6]),
+        refreshed_at: MonotonicMillis(0),
+        occupied: false,
+    };
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum DynamicLookup {
+    Hit(MacAddress),
+    Miss,
+    ClockRegression,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ControlDisposition {
+    Inserted,
+    Updated,
+    Ignored,
+    StaticPreserved,
+    CacheFull,
+    Probe,
+    SenderNotHost,
+    LocalAddressPreserved,
+    ClockRegression,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ResolutionResult {
     Queued,
     Suppressed,
@@ -124,6 +179,7 @@ pub struct ResolutionRuntime<'a> {
     policy: ResolutionPolicy,
     states: &'a mut [ResolutionStateSlot],
     actions: &'a mut [ResolutionActionSlot],
+    dynamic_neighbors: &'a mut [DynamicNeighborSlot],
     head: usize,
     len: usize,
     last_now: Option<MonotonicMillis>,
@@ -138,18 +194,38 @@ impl<'a> ResolutionRuntime<'a> {
         states: &'a mut [ResolutionStateSlot],
         action_storage: &'a mut [ResolutionActionSlot],
     ) -> Self {
+        Self::with_dynamic_neighbors(policy, states, action_storage, &mut [])
+    }
+
+    #[must_use]
+    pub fn with_dynamic_neighbors(
+        policy: ResolutionPolicy,
+        states: &'a mut [ResolutionStateSlot],
+        action_storage: &'a mut [ResolutionActionSlot],
+        dynamic_neighbors: &'a mut [DynamicNeighborSlot],
+    ) -> Self {
         states.fill(ResolutionStateSlot::EMPTY);
         action_storage.fill(ResolutionActionSlot::EMPTY);
+        dynamic_neighbors.fill(DynamicNeighborSlot::EMPTY);
         Self {
             policy,
             states,
             actions: action_storage,
+            dynamic_neighbors,
             head: 0,
             len: 0,
             last_now: None,
             counters: ResolutionCounters::default(),
             _worker_local: PhantomData,
         }
+    }
+
+    #[must_use]
+    pub fn dynamic_neighbor_count(&self) -> usize {
+        self.dynamic_neighbors
+            .iter()
+            .filter(|slot| slot.occupied)
+            .count()
     }
 
     #[must_use]
@@ -168,11 +244,9 @@ impl<'a> ResolutionRuntime<'a> {
         now: MonotonicMillis,
         directed_broadcast: bool,
     ) -> ResolutionResult {
-        if self.last_now.is_some_and(|last| now < last) {
-            self.counters.clock_regressions += 1;
+        if !self.observe_now(now) {
             return ResolutionResult::ClockRegression;
         }
-        self.last_now = Some(now);
         if directed_broadcast
             || action.target_ip == action.source_ip
             || forbidden_target(action.target_ip)
@@ -224,6 +298,117 @@ impl<'a> ResolutionRuntime<'a> {
         self.enqueue_at(index, action)
     }
 
+    pub(crate) fn lookup_dynamic(
+        &mut self,
+        interface: IfId,
+        target: Ipv4Address,
+        now: MonotonicMillis,
+    ) -> DynamicLookup {
+        if !self.observe_now(now) {
+            return DynamicLookup::ClockRegression;
+        }
+        let Some(slot) = self
+            .dynamic_neighbors
+            .iter_mut()
+            .find(|slot| slot.occupied && slot.interface == interface && slot.target == target)
+        else {
+            return DynamicLookup::Miss;
+        };
+        if now.0 - slot.refreshed_at.0 >= self.policy.dynamic_neighbor_ttl_ms {
+            *slot = DynamicNeighborSlot::EMPTY;
+            DynamicLookup::Miss
+        } else {
+            DynamicLookup::Hit(slot.mac)
+        }
+    }
+
+    pub(crate) fn merge_dynamic(
+        &mut self,
+        interface: IfId,
+        sender: Ipv4Address,
+        mac: MacAddress,
+        allow_insert: bool,
+        static_key: bool,
+        now: MonotonicMillis,
+    ) -> ControlDisposition {
+        if !self.observe_now(now) {
+            return ControlDisposition::ClockRegression;
+        }
+        if static_key {
+            return ControlDisposition::StaticPreserved;
+        }
+        if let Some(index) = self
+            .dynamic_neighbors
+            .iter()
+            .position(|slot| slot.occupied && slot.interface == interface && slot.target == sender)
+        {
+            if now.0 - self.dynamic_neighbors[index].refreshed_at.0
+                < self.policy.dynamic_neighbor_ttl_ms
+            {
+                self.dynamic_neighbors[index].mac = mac;
+                self.dynamic_neighbors[index].refreshed_at = now;
+                self.clear_resolution(interface, sender);
+                return ControlDisposition::Updated;
+            }
+            self.dynamic_neighbors[index] = DynamicNeighborSlot::EMPTY;
+        }
+        if !allow_insert {
+            return ControlDisposition::Ignored;
+        }
+        let reusable = self.dynamic_neighbors.iter().position(|slot| {
+            !slot.occupied || now.0 - slot.refreshed_at.0 >= self.policy.dynamic_neighbor_ttl_ms
+        });
+        let Some(index) = reusable else {
+            return ControlDisposition::CacheFull;
+        };
+        self.dynamic_neighbors[index] = DynamicNeighborSlot {
+            interface,
+            target: sender,
+            mac,
+            refreshed_at: now,
+            occupied: true,
+        };
+        self.clear_resolution(interface, sender);
+        ControlDisposition::Inserted
+    }
+
+    fn observe_now(&mut self, now: MonotonicMillis) -> bool {
+        if self.last_now.is_some_and(|last| now < last) {
+            self.counters.clock_regressions += 1;
+            return false;
+        }
+        self.last_now = Some(now);
+        true
+    }
+
+    pub(crate) fn observe_control(&mut self, now: MonotonicMillis) -> bool {
+        self.observe_now(now)
+    }
+
+    fn clear_resolution(&mut self, interface: IfId, target: Ipv4Address) {
+        for state in &mut *self.states {
+            if state.occupied && state.key.egress == interface && state.key.target == target {
+                *state = ResolutionStateSlot::EMPTY;
+            }
+        }
+        if self.actions.is_empty() {
+            return;
+        }
+        let old_len = self.len;
+        let mut retained = 0;
+        for read in 0..old_len {
+            let read_index = (self.head + read) % self.actions.len();
+            let queued = self.actions[read_index].0.take().expect("queued action");
+            if queued.action.egress == interface && queued.action.target_ip == target {
+                continue;
+            }
+            let write_index = (self.head + retained) % self.actions.len();
+            self.actions[write_index].0 = Some(queued);
+            retained += 1;
+        }
+        self.len = retained;
+    }
+
     fn enqueue_at(&mut self, index: usize, action: ArpRequestAction) -> ResolutionResult {
         if self.len == self.actions.len() {
             self.counters.action_full += 1;
@@ -244,12 +429,7 @@ impl<'a> ResolutionRuntime<'a> {
     }
 
     fn execution_time_valid(&mut self, now: MonotonicMillis) -> bool {
-        if self.last_now.is_some_and(|last| now < last) {
-            self.counters.clock_regressions += 1;
-            return false;
-        }
-        self.last_now = Some(now);
-        true
+        self.observe_now(now)
     }
 
     fn committed(&mut self, queued: QueuedAction, now: MonotonicMillis) {

--- a/crates/core/src/resolution.rs
+++ b/crates/core/src/resolution.rs
@@ -143,6 +143,13 @@ pub enum ControlDisposition {
     ClockRegression,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct StaticReconcileReport {
+    pub dynamic_removed: usize,
+    pub states_removed: usize,
+    pub actions_removed: usize,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ResolutionResult {
     Queued,
@@ -226,6 +233,41 @@ impl<'a> ResolutionRuntime<'a> {
             .iter()
             .filter(|slot| slot.occupied)
             .count()
+    }
+
+    /// Removes worker-local state shadowed by a newly published static set.
+    ///
+    /// The owner must call this on the same worker tick that publishes the
+    /// corresponding immutable forwarding snapshot, before processing another
+    /// packet with that snapshot.
+    pub fn reconcile_static(&mut self, neighbors: &[crate::Neighbor]) -> StaticReconcileReport {
+        let mut report = StaticReconcileReport::default();
+        for slot in &mut *self.dynamic_neighbors {
+            if slot.occupied
+                && neighbors.iter().any(|neighbor| {
+                    neighbor.interface == slot.interface && neighbor.target == slot.target
+                })
+            {
+                *slot = DynamicNeighborSlot::EMPTY;
+                report.dynamic_removed += 1;
+            }
+        }
+        for state in &mut *self.states {
+            if state.occupied
+                && neighbors.iter().any(|neighbor| {
+                    neighbor.interface == state.key.egress && neighbor.target == state.key.target
+                })
+            {
+                *state = ResolutionStateSlot::EMPTY;
+                report.states_removed += 1;
+            }
+        }
+        report.actions_removed = self.compact_actions(|action| {
+            neighbors.iter().any(|neighbor| {
+                neighbor.interface == action.egress && neighbor.target == action.target_ip
+            })
+        });
+        report
     }
 
     #[must_use]
@@ -335,6 +377,7 @@ impl<'a> ResolutionRuntime<'a> {
             return ControlDisposition::ClockRegression;
         }
         if static_key {
+            self.reconcile_static_key(interface, sender);
             return ControlDisposition::StaticPreserved;
         }
         if let Some(index) = self
@@ -391,15 +434,28 @@ impl<'a> ResolutionRuntime<'a> {
                 *state = ResolutionStateSlot::EMPTY;
             }
         }
+        self.compact_actions(|action| action.egress == interface && action.target_ip == target);
+    }
+
+    fn reconcile_static_key(&mut self, interface: IfId, target: Ipv4Address) {
+        for slot in &mut *self.dynamic_neighbors {
+            if slot.occupied && slot.interface == interface && slot.target == target {
+                *slot = DynamicNeighborSlot::EMPTY;
+            }
+        }
+        self.clear_resolution(interface, target);
+    }
+
+    fn compact_actions(&mut self, remove: impl Fn(ArpRequestAction) -> bool) -> usize {
         if self.actions.is_empty() {
-            return;
+            return 0;
         }
         let old_len = self.len;
         let mut retained = 0;
         for read in 0..old_len {
             let read_index = (self.head + read) % self.actions.len();
             let queued = self.actions[read_index].0.take().expect("queued action");
-            if queued.action.egress == interface && queued.action.target_ip == target {
+            if remove(queued.action) {
                 continue;
             }
             let write_index = (self.head + retained) % self.actions.len();
@@ -407,6 +463,7 @@ impl<'a> ResolutionRuntime<'a> {
             retained += 1;
         }
         self.len = retained;
+        old_len - retained
     }
 
     fn enqueue_at(&mut self, index: usize, action: ArpRequestAction) -> ResolutionResult {

--- a/crates/core/src/route.rs
+++ b/crates/core/src/route.rs
@@ -113,6 +113,13 @@ impl Route {
         let mask = prefix_mask(self.prefix_len).expect("Route::new validates prefix length");
         address.0 == self.prefix.0 | !mask
     }
+
+    pub(crate) fn is_connected_network_address(self, address: Ipv4Address) -> bool {
+        self.next_hop.is_none()
+            && self.prefix_len <= 30
+            && self.matches(address)
+            && address == self.prefix
+    }
 }
 
 pub(crate) fn lookup(routes: &[Route], destination: Ipv4Address) -> Option<Route> {

--- a/crates/io-sim/src/lib.rs
+++ b/crates/io-sim/src/lib.rs
@@ -4,7 +4,7 @@
 use std::{collections::VecDeque, convert::Infallible};
 
 use ruster_core::{
-    forward_batch, BatchCompletion, BatchReport, DropReason, ForwardingSnapshot,
+    forward_batch, BatchCompletion, BatchReport, ConsumeReason, DropReason, ForwardingSnapshot,
     GeneratedAllocationError, GeneratedArpTrace, GeneratedBatchCompletion, GeneratedPacketBatch,
     GeneratedPacketIo, GeneratedPacketLease, GeneratedPacketSlot, GeneratedSlotCompletion,
     GeneratedTraceSink, IfId, PacketBatch, PacketIo, PacketLease, PacketSlot, SlotCompletion,
@@ -36,6 +36,7 @@ pub enum FrameOrigin {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RecycleCause {
     Forwarding(DropReason),
+    Consumed(ConsumeReason),
     LeaseAbandoned,
 }
 
@@ -264,6 +265,9 @@ impl PacketSlot for SimSlot<'_> {
             }
             SlotCompletion::Recycle(reason) => {
                 self.recycle(slot, RecycleCause::Forwarding(reason));
+            }
+            SlotCompletion::Consume(reason) => {
+                self.recycle(slot, RecycleCause::Consumed(reason));
             }
             SlotCompletion::LeaseAbandoned => {
                 self.recycle(slot, RecycleCause::LeaseAbandoned);

--- a/crates/io-sim/tests/acceptance.rs
+++ b/crates/io-sim/tests/acceptance.rs
@@ -1,8 +1,8 @@
 use ruster_core::{
-    forward_batch, ipv4_header_checksum, validate_ipv4_frame, BatchCompletion, DropReason,
-    ForwardingSnapshot, IfId, Interface, Ipv4Address, LocalIpv4Binding, MacAddress, Neighbor,
-    NoTrace, PacketBatch, PacketIo, PacketLease, PacketSlot, Route, SlotCompletion, SnapshotError,
-    TraceEvent, ETHERNET_HEADER_LEN,
+    forward_batch, ipv4_header_checksum, validate_ipv4_frame, BatchCompletion, ConsumeReason,
+    DropReason, ForwardingSnapshot, IfId, Interface, Ipv4Address, LocalIpv4Binding, MacAddress,
+    Neighbor, NoTrace, PacketBatch, PacketIo, PacketLease, PacketSlot, Route, SlotCompletion,
+    SnapshotError, TraceEvent, ETHERNET_HEADER_LEN,
 };
 use ruster_io_sim::{RecycleCause, SimIo, VecTrace};
 
@@ -145,6 +145,21 @@ fn assert_forwarding_drop(
     let recycled = io.pop_recycled().unwrap();
     assert_eq!(recycled.cause, RecycleCause::Forwarding(expected));
     assert_eq!(recycled.bytes, original, "drop must not mutate bytes");
+}
+
+fn assert_arp_control_consumed(packet: Vec<u8>, snapshot: &ForwardingSnapshot<'_>) {
+    let original = packet.clone();
+    let mut io = SimIo::new();
+    io.inject(LAN, packet);
+    let report = io.run_once(1, snapshot, &mut NoTrace).unwrap();
+    assert_eq!(report.dropped, 0);
+    assert_eq!(report.consumed, 1);
+    let recycled = io.pop_recycled().unwrap();
+    assert_eq!(
+        recycled.cause,
+        RecycleCause::Consumed(ConsumeReason::ArpControl)
+    );
+    assert_eq!(recycled.bytes, original);
 }
 
 #[test]
@@ -706,8 +721,6 @@ fn arp_profile_validation_drops_are_granular_and_atomic() {
     hardware_length[18] = 8;
     let mut protocol_length = request();
     protocol_length[19] = 16;
-    let mut reply = request();
-    reply[20..22].copy_from_slice(&2_u16.to_be_bytes());
     let mut unknown_opcode = request();
     unknown_opcode[20..22].copy_from_slice(&99_u16.to_be_bytes());
 
@@ -717,7 +730,6 @@ fn arp_profile_validation_drops_are_granular_and_atomic() {
         (protocol_type, DropReason::ArpProtocolTypeUnsupported),
         (hardware_length, DropReason::ArpHardwareLengthUnsupported),
         (protocol_length, DropReason::ArpProtocolLengthUnsupported),
-        (reply, DropReason::ArpReplyUnsupported),
         (unknown_opcode, DropReason::ArpOpcodeUnsupported),
     ];
     for (packet, reason) in cases {
@@ -764,7 +776,7 @@ fn arp_nonlocal_and_reply_are_recycled_without_mutation() {
         [0; 6],
         &[],
     );
-    assert_forwarding_drop(nonlocal, &snapshot, DropReason::ArpTargetNotLocal);
+    assert_arp_control_consumed(nonlocal, &snapshot);
     let reply = arp_frame(
         2,
         REQUESTER_IPV4,
@@ -774,7 +786,7 @@ fn arp_nonlocal_and_reply_are_recycled_without_mutation() {
         LAN_MAC.0,
         &[],
     );
-    assert_forwarding_drop(reply, &snapshot, DropReason::ArpReplyUnsupported);
+    assert_arp_control_consumed(reply, &snapshot);
     let unknown_opcode = arp_frame(
         77,
         REQUESTER_IPV4,
@@ -801,11 +813,7 @@ fn arp_nonlocal_and_reply_are_recycled_without_mutation() {
         [0; 6],
         &[],
     );
-    assert_forwarding_drop(
-        wrong_ingress,
-        &wrong_ingress_snapshot,
-        DropReason::ArpTargetNotLocal,
-    );
+    assert_arp_control_consumed(wrong_ingress, &wrong_ingress_snapshot);
 }
 
 #[test]

--- a/crates/io-sim/tests/dynamic_arp.rs
+++ b/crates/io-sim/tests/dynamic_arp.rs
@@ -1,0 +1,607 @@
+use ruster_core::{
+    execute_one_arp_request, forward_batch_with_resolution, ipv4_header_checksum, BatchReport,
+    ConsumeReason, ControlDisposition, DropReason, DynamicNeighborSlot, ForwardingSnapshot, IfId,
+    Interface, Ipv4Address, LocalIpv4Binding, MacAddress, MonotonicMillis, Neighbor,
+    NoGeneratedTrace, PacketIo, ResolutionActionSlot, ResolutionPolicy, ResolutionPolicyError,
+    ResolutionRuntime, ResolutionStateSlot, Route, TraceEvent,
+};
+use ruster_io_sim::{RecycleCause, SimIo, VecTrace};
+
+const IFACE: IfId = IfId(1);
+const LOCAL: Ipv4Address = Ipv4Address::from_octets([192, 0, 2, 1]);
+const PEER: Ipv4Address = Ipv4Address::from_octets([192, 0, 2, 20]);
+const OTHER: Ipv4Address = Ipv4Address::from_octets([192, 0, 2, 21]);
+const THIRD: Ipv4Address = Ipv4Address::from_octets([192, 0, 2, 22]);
+const LOCAL_MAC: MacAddress = MacAddress([2, 0, 0, 0, 0, 1]);
+const PEER_MAC: MacAddress = MacAddress([2, 0, 0, 0, 0, 20]);
+const NEW_MAC: MacAddress = MacAddress([2, 0, 0, 0, 0, 30]);
+
+fn snapshot<'a>(
+    routes: &'a [Route],
+    interfaces: &'a [Interface],
+    neighbors: &'a [Neighbor],
+    bindings: &'a [LocalIpv4Binding],
+) -> ForwardingSnapshot<'a> {
+    ForwardingSnapshot::new(routes, interfaces, neighbors, bindings).unwrap()
+}
+
+fn base() -> ([Route; 1], [Interface; 1], [LocalIpv4Binding; 1]) {
+    (
+        [Route::new(Ipv4Address::from_octets([192, 0, 2, 0]), 24, IFACE, None).unwrap()],
+        [Interface {
+            id: IFACE,
+            mac: LOCAL_MAC,
+        }],
+        [LocalIpv4Binding {
+            interface: IFACE,
+            address: LOCAL,
+        }],
+    )
+}
+
+fn arp(
+    opcode: u16,
+    spa: Ipv4Address,
+    tpa: Ipv4Address,
+    sha: MacAddress,
+    ethernet_source: MacAddress,
+) -> Vec<u8> {
+    let mut bytes = vec![0; 60];
+    bytes[0..6].copy_from_slice(&LOCAL_MAC.0);
+    bytes[6..12].copy_from_slice(&ethernet_source.0);
+    bytes[12..14].copy_from_slice(&0x0806_u16.to_be_bytes());
+    bytes[14..16].copy_from_slice(&1_u16.to_be_bytes());
+    bytes[16..18].copy_from_slice(&0x0800_u16.to_be_bytes());
+    bytes[18..22].copy_from_slice(&[6, 4, (opcode >> 8) as u8, opcode as u8]);
+    bytes[22..28].copy_from_slice(&sha.0);
+    bytes[28..32].copy_from_slice(&spa.octets());
+    bytes[38..42].copy_from_slice(&tpa.octets());
+    bytes
+}
+
+fn ipv4(destination: Ipv4Address) -> Vec<u8> {
+    let mut bytes = vec![0; 34];
+    bytes[0..6].copy_from_slice(&LOCAL_MAC.0);
+    bytes[6..12].copy_from_slice(&[8; 6]);
+    bytes[12..14].copy_from_slice(&0x0800_u16.to_be_bytes());
+    bytes[14] = 0x45;
+    bytes[16..18].copy_from_slice(&20_u16.to_be_bytes());
+    bytes[22] = 64;
+    bytes[23] = 17;
+    bytes[26..30].copy_from_slice(&[198, 51, 100, 1]);
+    bytes[30..34].copy_from_slice(&destination.octets());
+    let checksum = ipv4_header_checksum(&bytes[14..34]);
+    bytes[24..26].copy_from_slice(&checksum.to_be_bytes());
+    bytes
+}
+
+fn run<'a>(
+    io: &mut SimIo,
+    runtime: &mut ResolutionRuntime<'a>,
+    snapshot: &ForwardingSnapshot<'_>,
+    now: u64,
+    budget: usize,
+    trace: &mut VecTrace,
+) -> BatchReport<std::convert::Infallible> {
+    let batch = io.receive(budget).unwrap();
+    forward_batch_with_resolution(batch, snapshot, runtime, MonotonicMillis(now), trace)
+}
+
+macro_rules! runtime {
+    ($policy:expr, $states:ident, $actions:ident, $cache:ident) => {
+        ResolutionRuntime::with_dynamic_neighbors($policy, &mut $states, &mut $actions, &mut $cache)
+    };
+}
+
+#[test]
+fn miss_request_reply_consume_then_reinjected_ipv4_forwards() {
+    let (routes, interfaces, bindings) = base();
+    let s = snapshot(&routes, &interfaces, &[], &bindings);
+    let mut states = [ResolutionStateSlot::EMPTY; 2];
+    let mut actions = [ResolutionActionSlot::EMPTY; 2];
+    let mut cache = [DynamicNeighborSlot::EMPTY; 2];
+    let mut rt = runtime!(
+        ResolutionPolicy::new(1_000, 2_000).unwrap(),
+        states,
+        actions,
+        cache
+    );
+    let mut io = SimIo::new();
+    io.inject(IFACE, ipv4(PEER));
+    assert_eq!(
+        run(&mut io, &mut rt, &s, 0, 1, &mut VecTrace::default()).dropped,
+        1
+    );
+    io.pop_recycled();
+    execute_one_arp_request(&mut io, &mut rt, MonotonicMillis(0), &mut NoGeneratedTrace)
+        .unwrap()
+        .unwrap();
+    io.pop_tx().unwrap();
+    io.inject(IFACE, arp(2, PEER, LOCAL, PEER_MAC, PEER_MAC));
+    let reply = run(&mut io, &mut rt, &s, 1, 1, &mut VecTrace::default());
+    assert_eq!((reply.consumed, reply.dropped), (1, 0));
+    assert_eq!(
+        io.pop_recycled().unwrap().cause,
+        RecycleCause::Consumed(ConsumeReason::ArpControl)
+    );
+    io.inject(IFACE, ipv4(PEER));
+    assert_eq!(
+        run(&mut io, &mut rt, &s, 1, 1, &mut VecTrace::default()).tx_requested,
+        1
+    );
+    assert_eq!(&io.pop_tx().unwrap().bytes[0..6], &PEER_MAC.0);
+}
+
+#[test]
+fn unsolicited_local_reply_learns_while_nonlocal_absent_is_ignored() {
+    let (routes, interfaces, bindings) = base();
+    let s = snapshot(&routes, &interfaces, &[], &bindings);
+    let mut states = [ResolutionStateSlot::EMPTY; 1];
+    let mut actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut cache = [DynamicNeighborSlot::EMPTY; 1];
+    let mut rt = runtime!(
+        ResolutionPolicy::new(1_000, 2_000).unwrap(),
+        states,
+        actions,
+        cache
+    );
+    let mut io = SimIo::new();
+    io.inject(IFACE, arp(2, PEER, OTHER, PEER_MAC, PEER_MAC));
+    let mut trace = VecTrace::default();
+    let ignored = run(&mut io, &mut rt, &s, 0, 1, &mut trace);
+    assert_eq!((ignored.consumed, ignored.dropped), (1, 0));
+    assert!(trace.events().iter().any(|event| matches!(
+        event,
+        TraceEvent::ArpControl {
+            disposition: ControlDisposition::Ignored,
+            ..
+        }
+    )));
+    io.inject(IFACE, arp(1, OTHER, OTHER, NEW_MAC, NEW_MAC));
+    run(&mut io, &mut rt, &s, 0, 1, &mut VecTrace::default());
+    assert_eq!(rt.dynamic_neighbor_count(), 0);
+    io.inject(IFACE, arp(2, PEER, LOCAL, PEER_MAC, PEER_MAC));
+    let report = run(&mut io, &mut rt, &s, 0, 1, &mut VecTrace::default());
+    assert_eq!((report.tx_requested, report.consumed), (0, 1));
+    assert_eq!(rt.dynamic_neighbor_count(), 1);
+}
+
+#[test]
+fn existing_mapping_merge_precedes_target_and_opcode_and_garp_refreshes() {
+    let (routes, interfaces, bindings) = base();
+    let s = snapshot(&routes, &interfaces, &[], &bindings);
+    let policy = ResolutionPolicy::with_dynamic_neighbor_ttl(1_000, 2_000, 100).unwrap();
+    let mut states = [ResolutionStateSlot::EMPTY; 1];
+    let mut actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut cache = [DynamicNeighborSlot::EMPTY; 1];
+    let mut rt = runtime!(policy, states, actions, cache);
+    let mut io = SimIo::new();
+    for (now, opcode, tpa, mac) in [
+        (0, 2, LOCAL, PEER_MAC),
+        (40, 2, OTHER, NEW_MAC),
+        (80, 1, OTHER, PEER_MAC),
+        (120, 1, PEER, NEW_MAC),
+    ] {
+        io.inject(IFACE, arp(opcode, PEER, tpa, mac, MacAddress([9; 6])));
+        run(&mut io, &mut rt, &s, now, 1, &mut VecTrace::default());
+        io.pop_recycled();
+        io.inject(IFACE, ipv4(PEER));
+        run(&mut io, &mut rt, &s, now, 1, &mut VecTrace::default());
+        assert_eq!(&io.pop_tx().unwrap().bytes[0..6], &mac.0);
+    }
+    io.inject(IFACE, ipv4(PEER));
+    run(&mut io, &mut rt, &s, 219, 1, &mut VecTrace::default());
+    assert_eq!(&io.pop_tx().unwrap().bytes[0..6], &NEW_MAC.0);
+}
+
+#[test]
+fn local_request_learns_sha_even_when_ethernet_source_differs_and_probe_does_not() {
+    let (routes, interfaces, bindings) = base();
+    let s = snapshot(&routes, &interfaces, &[], &bindings);
+    let mut states = [ResolutionStateSlot::EMPTY; 1];
+    let mut actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut cache = [DynamicNeighborSlot::EMPTY; 1];
+    let mut rt = runtime!(
+        ResolutionPolicy::new(1_000, 2_000).unwrap(),
+        states,
+        actions,
+        cache
+    );
+    let mut io = SimIo::new();
+    io.inject(
+        IFACE,
+        arp(1, PEER, LOCAL, PEER_MAC, MacAddress([2, 9, 9, 9, 9, 9])),
+    );
+    let learned = run(&mut io, &mut rt, &s, 0, 1, &mut VecTrace::default());
+    assert_eq!((learned.tx_requested, learned.consumed), (1, 0));
+    io.pop_tx();
+    io.inject(
+        IFACE,
+        arp(1, Ipv4Address::from_octets([0; 4]), LOCAL, NEW_MAC, NEW_MAC),
+    );
+    assert_eq!(
+        run(&mut io, &mut rt, &s, 0, 1, &mut VecTrace::default()).tx_requested,
+        1
+    );
+    assert_eq!(rt.dynamic_neighbor_count(), 1);
+    io.pop_tx();
+    io.inject(IFACE, ipv4(PEER));
+    run(&mut io, &mut rt, &s, 0, 1, &mut VecTrace::default());
+    assert_eq!(&io.pop_tx().unwrap().bytes[0..6], &PEER_MAC.0);
+}
+
+#[test]
+fn invalid_sender_hardware_drops_atomically_without_cache_or_action_mutation() {
+    let (routes, interfaces, bindings) = base();
+    let s = snapshot(&routes, &interfaces, &[], &bindings);
+    let mut states = [ResolutionStateSlot::EMPTY; 1];
+    let mut actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut cache = [DynamicNeighborSlot::EMPTY; 1];
+    let mut rt = runtime!(
+        ResolutionPolicy::new(1_000, 2_000).unwrap(),
+        states,
+        actions,
+        cache
+    );
+    let mut io = SimIo::new();
+    io.inject(IFACE, ipv4(PEER));
+    run(&mut io, &mut rt, &s, 0, 1, &mut VecTrace::default());
+    io.pop_recycled();
+    for (sha, reason) in [
+        (MacAddress([0; 6]), DropReason::ArpSenderHardwareZero),
+        (
+            MacAddress([0xff; 6]),
+            DropReason::ArpSenderHardwareBroadcast,
+        ),
+        (
+            MacAddress([1, 0, 0, 0, 0, 1]),
+            DropReason::ArpSenderHardwareMulticast,
+        ),
+    ] {
+        let packet = arp(2, PEER, LOCAL, sha, PEER_MAC);
+        io.inject(IFACE, packet.clone());
+        let report = run(&mut io, &mut rt, &s, 0, 1, &mut VecTrace::default());
+        assert_eq!((report.dropped, report.consumed), (1, 0));
+        let recycled = io.pop_recycled().unwrap();
+        assert_eq!(recycled.cause, RecycleCause::Forwarding(reason));
+        assert_eq!(recycled.bytes, packet);
+        assert_eq!((rt.dynamic_neighbor_count(), rt.pending_actions()), (0, 1));
+    }
+}
+
+#[test]
+fn non_host_sender_protocol_addresses_are_consumed_without_learning() {
+    let (routes, interfaces, bindings) = base();
+    let s = snapshot(&routes, &interfaces, &[], &bindings);
+    let mut states = [ResolutionStateSlot::EMPTY; 1];
+    let mut actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut cache = [DynamicNeighborSlot::EMPTY; 1];
+    let mut rt = runtime!(
+        ResolutionPolicy::new(1_000, 2_000).unwrap(),
+        states,
+        actions,
+        cache
+    );
+    let mut io = SimIo::new();
+    for sender in [
+        Ipv4Address::from_octets([224, 0, 0, 1]),
+        Ipv4Address::from_octets([255; 4]),
+        Ipv4Address::from_octets([192, 0, 2, 255]),
+    ] {
+        io.inject(IFACE, arp(2, sender, LOCAL, PEER_MAC, PEER_MAC));
+    }
+    let mut trace = VecTrace::default();
+    let report = run(&mut io, &mut rt, &s, 0, 3, &mut trace);
+    assert_eq!((report.consumed, report.dropped), (3, 0));
+    assert_eq!(rt.dynamic_neighbor_count(), 0);
+    assert_eq!(
+        trace
+            .events()
+            .iter()
+            .filter(|event| matches!(
+                event,
+                TraceEvent::ArpControl {
+                    disposition: ControlDisposition::SenderNotHost,
+                    ..
+                }
+            ))
+            .count(),
+        3
+    );
+}
+
+#[test]
+fn foreign_local_spa_cannot_poison_and_static_mapping_has_priority() {
+    let (routes, interfaces, bindings) = base();
+    let static_mac = MacAddress([2, 7, 7, 7, 7, 7]);
+    let neighbor = Neighbor {
+        interface: IFACE,
+        target: PEER,
+        mac: static_mac,
+    };
+    let neighbors = [neighbor];
+    let s = snapshot(&routes, &interfaces, &neighbors, &bindings);
+    let mut states = [ResolutionStateSlot::EMPTY; 1];
+    let mut actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut cache = [DynamicNeighborSlot::EMPTY; 1];
+    let mut rt = runtime!(
+        ResolutionPolicy::new(1_000, 2_000).unwrap(),
+        states,
+        actions,
+        cache
+    );
+    let mut io = SimIo::new();
+    io.inject(IFACE, arp(1, LOCAL, LOCAL, NEW_MAC, NEW_MAC));
+    assert_eq!(
+        run(&mut io, &mut rt, &s, 0, 1, &mut VecTrace::default()).tx_requested,
+        1
+    );
+    io.pop_tx();
+    io.inject(IFACE, arp(2, PEER, LOCAL, NEW_MAC, NEW_MAC));
+    let mut trace = VecTrace::default();
+    let static_reply = run(&mut io, &mut rt, &s, 0, 1, &mut trace);
+    assert_eq!((static_reply.consumed, static_reply.dropped), (1, 0));
+    assert!(trace.events().iter().any(|event| matches!(
+        event,
+        TraceEvent::ArpControl {
+            disposition: ControlDisposition::StaticPreserved,
+            ..
+        }
+    )));
+    assert_eq!(rt.dynamic_neighbor_count(), 0);
+    io.inject(IFACE, ipv4(PEER));
+    run(&mut io, &mut rt, &s, 0, 1, &mut VecTrace::default());
+    assert_eq!(&io.pop_tx().unwrap().bytes[0..6], &static_mac.0);
+}
+
+#[test]
+fn ttl_boundary_refresh_expired_reuse_and_cache_full_are_exact() {
+    let (routes, interfaces, bindings) = base();
+    let s = snapshot(&routes, &interfaces, &[], &bindings);
+    let policy = ResolutionPolicy::with_dynamic_neighbor_ttl(1_000, 2_000, 100).unwrap();
+    let mut states = [ResolutionStateSlot::EMPTY; 2];
+    let mut actions = [ResolutionActionSlot::EMPTY; 2];
+    let mut cache = [DynamicNeighborSlot::EMPTY; 1];
+    let mut rt = runtime!(policy, states, actions, cache);
+    let mut io = SimIo::new();
+    io.inject(IFACE, ipv4(OTHER));
+    run(&mut io, &mut rt, &s, 0, 1, &mut VecTrace::default());
+    io.pop_recycled();
+    io.inject(IFACE, arp(2, PEER, LOCAL, PEER_MAC, PEER_MAC));
+    run(&mut io, &mut rt, &s, 0, 1, &mut VecTrace::default());
+    io.inject(IFACE, arp(2, OTHER, LOCAL, NEW_MAC, NEW_MAC));
+    let mut trace = VecTrace::default();
+    let full = run(&mut io, &mut rt, &s, 99, 1, &mut trace);
+    assert_eq!((full.consumed, full.dropped), (1, 0));
+    assert_eq!(rt.pending_actions(), 1);
+    assert!(trace.events().iter().any(|event| matches!(
+        event,
+        TraceEvent::ArpControl {
+            disposition: ControlDisposition::CacheFull,
+            ..
+        }
+    )));
+    io.inject(IFACE, ipv4(PEER));
+    assert_eq!(
+        run(&mut io, &mut rt, &s, 99, 1, &mut VecTrace::default()).tx_requested,
+        1
+    );
+    io.pop_tx();
+    io.inject(IFACE, ipv4(PEER));
+    assert_eq!(
+        run(&mut io, &mut rt, &s, 100, 1, &mut VecTrace::default()).dropped,
+        1
+    );
+    io.inject(IFACE, arp(2, OTHER, LOCAL, NEW_MAC, NEW_MAC));
+    run(&mut io, &mut rt, &s, 100, 1, &mut VecTrace::default());
+    assert_eq!(rt.dynamic_neighbor_count(), 1);
+    assert_eq!(
+        rt.pending_actions(),
+        1,
+        "only the expired peer miss remains"
+    );
+}
+
+#[test]
+fn clock_regression_does_not_mutate_cache_and_later_equal_time_recovers() {
+    let (routes, interfaces, bindings) = base();
+    let s = snapshot(&routes, &interfaces, &[], &bindings);
+    let mut states = [ResolutionStateSlot::EMPTY; 1];
+    let mut actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut cache = [DynamicNeighborSlot::EMPTY; 1];
+    let mut rt = runtime!(
+        ResolutionPolicy::new(1_000, 2_000).unwrap(),
+        states,
+        actions,
+        cache
+    );
+    let mut io = SimIo::new();
+    io.inject(IFACE, ipv4(OTHER));
+    run(&mut io, &mut rt, &s, 100, 1, &mut VecTrace::default());
+    io.pop_recycled();
+    io.inject(IFACE, arp(2, PEER, LOCAL, PEER_MAC, PEER_MAC));
+    run(&mut io, &mut rt, &s, 100, 1, &mut VecTrace::default());
+    io.inject(IFACE, arp(2, PEER, LOCAL, NEW_MAC, NEW_MAC));
+    let mut trace = VecTrace::default();
+    run(&mut io, &mut rt, &s, 99, 1, &mut trace);
+    assert_eq!(rt.pending_actions(), 1);
+    assert!(trace.events().iter().any(|event| matches!(
+        event,
+        TraceEvent::ArpControl {
+            disposition: ControlDisposition::ClockRegression,
+            ..
+        }
+    )));
+    io.inject(IFACE, ipv4(PEER));
+    run(&mut io, &mut rt, &s, 100, 1, &mut VecTrace::default());
+    assert_eq!(&io.pop_tx().unwrap().bytes[0..6], &PEER_MAC.0);
+}
+
+#[test]
+fn reply_before_generated_execution_cancels_only_matching_fifo_action() {
+    let (routes, interfaces, bindings) = base();
+    let s = snapshot(&routes, &interfaces, &[], &bindings);
+    let second_if = IfId(2);
+    let second_routes = [Route::new(
+        Ipv4Address::from_octets([192, 0, 2, 20]),
+        32,
+        second_if,
+        None,
+    )
+    .unwrap()];
+    let second_interfaces = [Interface {
+        id: second_if,
+        mac: NEW_MAC,
+    }];
+    let second_bindings = [LocalIpv4Binding {
+        interface: second_if,
+        address: Ipv4Address::from_octets([198, 51, 100, 2]),
+    }];
+    let second = snapshot(&second_routes, &second_interfaces, &[], &second_bindings);
+    let mut states = [ResolutionStateSlot::EMPTY; 3];
+    let mut actions = [ResolutionActionSlot::EMPTY; 3];
+    let mut cache = [DynamicNeighborSlot::EMPTY; 3];
+    let mut rt = runtime!(
+        ResolutionPolicy::new(1_000, 2_000).unwrap(),
+        states,
+        actions,
+        cache
+    );
+    let mut io = SimIo::new();
+    for target in [PEER, OTHER] {
+        io.inject(IFACE, ipv4(target));
+    }
+    run(&mut io, &mut rt, &s, 0, 2, &mut VecTrace::default());
+    io.inject(second_if, ipv4(PEER));
+    run(&mut io, &mut rt, &second, 0, 1, &mut VecTrace::default());
+    assert_eq!(rt.pending_actions(), 3);
+    io.inject(IFACE, arp(2, PEER, LOCAL, PEER_MAC, PEER_MAC));
+    run(&mut io, &mut rt, &s, 0, 1, &mut VecTrace::default());
+    assert_eq!(rt.pending_actions(), 2);
+    io.inject(IFACE, ipv4(THIRD));
+    run(&mut io, &mut rt, &s, 0, 1, &mut VecTrace::default());
+    assert_eq!(rt.pending_actions(), 3, "cancelled capacity is reusable");
+    execute_one_arp_request(&mut io, &mut rt, MonotonicMillis(0), &mut NoGeneratedTrace)
+        .unwrap()
+        .unwrap();
+    let request = io.pop_tx().unwrap();
+    assert_eq!(&request.bytes[38..42], &OTHER.octets());
+    execute_one_arp_request(&mut io, &mut rt, MonotonicMillis(0), &mut NoGeneratedTrace)
+        .unwrap()
+        .unwrap();
+    assert_eq!(io.pop_tx().unwrap().egress, second_if);
+}
+
+#[test]
+fn mixed_reply_then_ipv4_uses_dynamic_mapping_in_same_batch() {
+    let (routes, interfaces, bindings) = base();
+    let s = snapshot(&routes, &interfaces, &[], &bindings);
+    let mut states = [ResolutionStateSlot::EMPTY; 1];
+    let mut actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut cache = [DynamicNeighborSlot::EMPTY; 1];
+    let mut rt = runtime!(
+        ResolutionPolicy::new(1_000, 2_000).unwrap(),
+        states,
+        actions,
+        cache
+    );
+    let mut io = SimIo::new();
+    io.inject(IFACE, arp(2, PEER, LOCAL, PEER_MAC, PEER_MAC));
+    io.inject(IFACE, ipv4(PEER));
+    let mut trace = VecTrace::default();
+    let report = run(&mut io, &mut rt, &s, 0, 2, &mut trace);
+    assert_eq!(
+        (
+            report.received,
+            report.consumed,
+            report.tx_requested,
+            report.dropped
+        ),
+        (2, 1, 1, 0)
+    );
+    assert_eq!(report.completion.recycled, 1);
+    assert_eq!(&io.pop_tx().unwrap().bytes[0..6], &PEER_MAC.0);
+    assert_eq!(
+        io.pop_recycled().unwrap().cause,
+        RecycleCause::Consumed(ConsumeReason::ArpControl)
+    );
+    assert!(matches!(
+        trace.events(),
+        [
+            TraceEvent::ArpReplyValidated { .. },
+            TraceEvent::ArpControl {
+                disposition: ControlDisposition::Inserted,
+                ..
+            },
+            TraceEvent::Consumed {
+                reason: ConsumeReason::ArpControl,
+                disposition: ControlDisposition::Inserted,
+                ..
+            },
+            TraceEvent::Ipv4Validated { .. },
+            TraceEvent::Routed { .. },
+            TraceEvent::TxRequested { .. },
+            TraceEvent::BatchCompleted {
+                tx_accepted: 1,
+                tx_rejected: 0
+            }
+        ]
+    ));
+}
+
+#[test]
+fn zero_capacity_and_runtime_recreation_are_safe() {
+    assert_eq!(
+        ResolutionPolicy::with_dynamic_neighbor_ttl(1_000, 2_000, 0),
+        Err(ResolutionPolicyError::DynamicNeighborTtlZero)
+    );
+    let (routes, interfaces, bindings) = base();
+    let s = snapshot(&routes, &interfaces, &[], &bindings);
+    let mut states = [];
+    let mut actions = [];
+    let mut cache = [];
+    let mut io = SimIo::new();
+    {
+        let mut rt = runtime!(
+            ResolutionPolicy::new(1_000, 2_000).unwrap(),
+            states,
+            actions,
+            cache
+        );
+        io.inject(IFACE, arp(2, PEER, LOCAL, PEER_MAC, PEER_MAC));
+        assert_eq!(
+            run(&mut io, &mut rt, &s, 0, 1, &mut VecTrace::default()).consumed,
+            1
+        );
+        assert_eq!(rt.dynamic_neighbor_count(), 0);
+    }
+    let rt = runtime!(
+        ResolutionPolicy::new(1_000, 2_000).unwrap(),
+        states,
+        actions,
+        cache
+    );
+    assert_eq!((rt.dynamic_neighbor_count(), rt.pending_actions()), (0, 0));
+
+    let mut states = [ResolutionStateSlot::EMPTY; 1];
+    let mut actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut cache = [DynamicNeighborSlot::EMPTY; 1];
+    {
+        let mut rt = runtime!(
+            ResolutionPolicy::new(1_000, 2_000).unwrap(),
+            states,
+            actions,
+            cache
+        );
+        io.inject(IFACE, arp(2, PEER, LOCAL, PEER_MAC, PEER_MAC));
+        run(&mut io, &mut rt, &s, 1, 1, &mut VecTrace::default());
+        assert_eq!(rt.dynamic_neighbor_count(), 1);
+    }
+    let rt = runtime!(
+        ResolutionPolicy::new(1_000, 2_000).unwrap(),
+        states,
+        actions,
+        cache
+    );
+    assert_eq!(rt.dynamic_neighbor_count(), 0);
+}

--- a/crates/io-sim/tests/dynamic_arp.rs
+++ b/crates/io-sim/tests/dynamic_arp.rs
@@ -673,7 +673,7 @@ fn reconcile_static_clears_stale_cache_and_wrapped_middle_action_fifo() {
         },
         Neighbor {
             interface: IFACE,
-            target: THIRD,
+            target: FOURTH,
             mac: MacAddress([2, 7, 7, 7, 7, 8]),
         },
     ];
@@ -728,7 +728,7 @@ fn reconcile_static_clears_stale_cache_and_wrapped_middle_action_fifo() {
     io.pop_recycled();
     assert_eq!(rt.pending_actions(), 3, "removed capacity is reusable");
 
-    for (expected_egress, expected_target) in [(IFACE, FOURTH), (second_if, PEER), (IFACE, FIFTH)] {
+    for (expected_egress, expected_target) in [(IFACE, THIRD), (second_if, PEER), (IFACE, FIFTH)] {
         execute_one_arp_request(&mut io, &mut rt, MonotonicMillis(0), &mut NoGeneratedTrace)
             .unwrap()
             .unwrap();

--- a/crates/io-sim/tests/dynamic_arp.rs
+++ b/crates/io-sim/tests/dynamic_arp.rs
@@ -12,6 +12,9 @@ const LOCAL: Ipv4Address = Ipv4Address::from_octets([192, 0, 2, 1]);
 const PEER: Ipv4Address = Ipv4Address::from_octets([192, 0, 2, 20]);
 const OTHER: Ipv4Address = Ipv4Address::from_octets([192, 0, 2, 21]);
 const THIRD: Ipv4Address = Ipv4Address::from_octets([192, 0, 2, 22]);
+const FOURTH: Ipv4Address = Ipv4Address::from_octets([192, 0, 2, 23]);
+const FIFTH: Ipv4Address = Ipv4Address::from_octets([192, 0, 2, 24]);
+const SIXTH: Ipv4Address = Ipv4Address::from_octets([192, 0, 2, 25]);
 const LOCAL_MAC: MacAddress = MacAddress([2, 0, 0, 0, 0, 1]);
 const PEER_MAC: MacAddress = MacAddress([2, 0, 0, 0, 0, 20]);
 const NEW_MAC: MacAddress = MacAddress([2, 0, 0, 0, 0, 30]);
@@ -195,6 +198,46 @@ fn existing_mapping_merge_precedes_target_and_opcode_and_garp_refreshes() {
 }
 
 #[test]
+fn unknown_opcode_drops_before_merge_without_mutating_cache_or_pending() {
+    let (routes, interfaces, bindings) = base();
+    let s = snapshot(&routes, &interfaces, &[], &bindings);
+    let policy = ResolutionPolicy::with_dynamic_neighbor_ttl(1_000, 2_000, 100).unwrap();
+    let mut states = [ResolutionStateSlot::EMPTY; 2];
+    let mut actions = [ResolutionActionSlot::EMPTY; 2];
+    let mut cache = [DynamicNeighborSlot::EMPTY; 1];
+    let mut rt = runtime!(policy, states, actions, cache);
+    let mut io = SimIo::new();
+
+    io.inject(IFACE, arp(2, PEER, LOCAL, PEER_MAC, PEER_MAC));
+    run(&mut io, &mut rt, &s, 100, 1, &mut VecTrace::default());
+    io.pop_recycled();
+    io.inject(IFACE, ipv4(OTHER));
+    run(&mut io, &mut rt, &s, 100, 1, &mut VecTrace::default());
+    io.pop_recycled();
+
+    let packet = arp(77, PEER, LOCAL, NEW_MAC, NEW_MAC);
+    io.inject(IFACE, packet.clone());
+    let report = run(&mut io, &mut rt, &s, 150, 1, &mut VecTrace::default());
+    assert_eq!((report.dropped, report.consumed), (1, 0));
+    let recycled = io.pop_recycled().unwrap();
+    assert_eq!(
+        recycled.cause,
+        RecycleCause::Forwarding(DropReason::ArpOpcodeUnsupported)
+    );
+    assert_eq!(recycled.bytes, packet);
+    assert_eq!((rt.dynamic_neighbor_count(), rt.pending_actions()), (1, 1));
+
+    io.inject(IFACE, ipv4(PEER));
+    run(&mut io, &mut rt, &s, 199, 1, &mut VecTrace::default());
+    assert_eq!(&io.pop_tx().unwrap().bytes[0..6], &PEER_MAC.0);
+    io.inject(IFACE, ipv4(PEER));
+    assert_eq!(
+        run(&mut io, &mut rt, &s, 200, 1, &mut VecTrace::default()).dropped,
+        1
+    );
+}
+
+#[test]
 fn local_request_learns_sha_even_when_ethernet_source_differs_and_probe_does_not() {
     let (routes, interfaces, bindings) = base();
     let s = snapshot(&routes, &interfaces, &[], &bindings);
@@ -283,17 +326,26 @@ fn non_host_sender_protocol_addresses_are_consumed_without_learning() {
         cache
     );
     let mut io = SimIo::new();
-    for sender in [
+    io.inject(IFACE, ipv4(OTHER));
+    run(&mut io, &mut rt, &s, 0, 1, &mut VecTrace::default());
+    io.pop_recycled();
+    let senders = [
+        Ipv4Address::from_octets([0, 0, 0, 1]),
+        Ipv4Address::from_octets([127, 0, 0, 1]),
         Ipv4Address::from_octets([224, 0, 0, 1]),
+        Ipv4Address::from_octets([240, 0, 0, 1]),
         Ipv4Address::from_octets([255; 4]),
+        Ipv4Address::from_octets([192, 0, 2, 0]),
         Ipv4Address::from_octets([192, 0, 2, 255]),
-    ] {
+    ];
+    for sender in senders {
         io.inject(IFACE, arp(2, sender, LOCAL, PEER_MAC, PEER_MAC));
     }
     let mut trace = VecTrace::default();
-    let report = run(&mut io, &mut rt, &s, 0, 3, &mut trace);
-    assert_eq!((report.consumed, report.dropped), (3, 0));
+    let report = run(&mut io, &mut rt, &s, 0, senders.len(), &mut trace);
+    assert_eq!((report.consumed, report.dropped), (senders.len(), 0));
     assert_eq!(rt.dynamic_neighbor_count(), 0);
+    assert_eq!(rt.pending_actions(), 1);
     assert_eq!(
         trace
             .events()
@@ -306,13 +358,92 @@ fn non_host_sender_protocol_addresses_are_consumed_without_learning() {
                 }
             ))
             .count(),
-        3
+        senders.len()
     );
+}
+
+#[test]
+fn point_to_point_prefix_endpoints_are_learnable() {
+    let routes = [
+        Route::new(Ipv4Address::from_octets([198, 51, 100, 0]), 31, IFACE, None).unwrap(),
+        Route::new(Ipv4Address::from_octets([203, 0, 113, 9]), 32, IFACE, None).unwrap(),
+    ];
+    let interfaces = [Interface {
+        id: IFACE,
+        mac: LOCAL_MAC,
+    }];
+    let bindings = [LocalIpv4Binding {
+        interface: IFACE,
+        address: LOCAL,
+    }];
+    let s = snapshot(&routes, &interfaces, &[], &bindings);
+    let mut states = [ResolutionStateSlot::EMPTY; 2];
+    let mut actions = [ResolutionActionSlot::EMPTY; 2];
+    let mut cache = [DynamicNeighborSlot::EMPTY; 2];
+    let mut rt = runtime!(
+        ResolutionPolicy::new(1_000, 2_000).unwrap(),
+        states,
+        actions,
+        cache
+    );
+    let mut io = SimIo::new();
+    for sender in [
+        Ipv4Address::from_octets([198, 51, 100, 0]),
+        Ipv4Address::from_octets([203, 0, 113, 9]),
+    ] {
+        io.inject(IFACE, arp(2, sender, LOCAL, PEER_MAC, PEER_MAC));
+    }
+    let report = run(&mut io, &mut rt, &s, 0, 2, &mut VecTrace::default());
+    assert_eq!((report.consumed, report.dropped), (2, 0));
+    assert_eq!(rt.dynamic_neighbor_count(), 2);
+}
+
+#[test]
+fn local_address_value_on_another_interface_is_learnable_on_ingress() {
+    let (routes, _, _) = base();
+    let interfaces = [
+        Interface {
+            id: IFACE,
+            mac: LOCAL_MAC,
+        },
+        Interface {
+            id: IfId(2),
+            mac: NEW_MAC,
+        },
+    ];
+    let bindings = [
+        LocalIpv4Binding {
+            interface: IFACE,
+            address: LOCAL,
+        },
+        LocalIpv4Binding {
+            interface: IfId(2),
+            address: PEER,
+        },
+    ];
+    let s = snapshot(&routes, &interfaces, &[], &bindings);
+    let mut states = [ResolutionStateSlot::EMPTY; 1];
+    let mut actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut cache = [DynamicNeighborSlot::EMPTY; 1];
+    let mut rt = runtime!(
+        ResolutionPolicy::new(1_000, 2_000).unwrap(),
+        states,
+        actions,
+        cache
+    );
+    let mut io = SimIo::new();
+    io.inject(IFACE, arp(2, PEER, LOCAL, PEER_MAC, PEER_MAC));
+    run(&mut io, &mut rt, &s, 0, 1, &mut VecTrace::default());
+    assert_eq!(rt.dynamic_neighbor_count(), 1);
+    io.inject(IFACE, ipv4(PEER));
+    run(&mut io, &mut rt, &s, 0, 1, &mut VecTrace::default());
+    assert_eq!(&io.pop_tx().unwrap().bytes[0..6], &PEER_MAC.0);
 }
 
 #[test]
 fn foreign_local_spa_cannot_poison_and_static_mapping_has_priority() {
     let (routes, interfaces, bindings) = base();
+    let dynamic = snapshot(&routes, &interfaces, &[], &bindings);
     let static_mac = MacAddress([2, 7, 7, 7, 7, 7]);
     let neighbor = Neighbor {
         interface: IFACE,
@@ -320,7 +451,7 @@ fn foreign_local_spa_cannot_poison_and_static_mapping_has_priority() {
         mac: static_mac,
     };
     let neighbors = [neighbor];
-    let s = snapshot(&routes, &interfaces, &neighbors, &bindings);
+    let with_static = snapshot(&routes, &interfaces, &neighbors, &bindings);
     let mut states = [ResolutionStateSlot::EMPTY; 1];
     let mut actions = [ResolutionActionSlot::EMPTY; 1];
     let mut cache = [DynamicNeighborSlot::EMPTY; 1];
@@ -333,13 +464,16 @@ fn foreign_local_spa_cannot_poison_and_static_mapping_has_priority() {
     let mut io = SimIo::new();
     io.inject(IFACE, arp(1, LOCAL, LOCAL, NEW_MAC, NEW_MAC));
     assert_eq!(
-        run(&mut io, &mut rt, &s, 0, 1, &mut VecTrace::default()).tx_requested,
+        run(&mut io, &mut rt, &dynamic, 0, 1, &mut VecTrace::default()).tx_requested,
         1
     );
     io.pop_tx();
+    io.inject(IFACE, arp(2, PEER, LOCAL, PEER_MAC, PEER_MAC));
+    run(&mut io, &mut rt, &dynamic, 0, 1, &mut VecTrace::default());
+    assert_eq!(rt.dynamic_neighbor_count(), 1);
     io.inject(IFACE, arp(2, PEER, LOCAL, NEW_MAC, NEW_MAC));
     let mut trace = VecTrace::default();
-    let static_reply = run(&mut io, &mut rt, &s, 0, 1, &mut trace);
+    let static_reply = run(&mut io, &mut rt, &with_static, 0, 1, &mut trace);
     assert_eq!((static_reply.consumed, static_reply.dropped), (1, 0));
     assert!(trace.events().iter().any(|event| matches!(
         event,
@@ -350,7 +484,29 @@ fn foreign_local_spa_cannot_poison_and_static_mapping_has_priority() {
     )));
     assert_eq!(rt.dynamic_neighbor_count(), 0);
     io.inject(IFACE, ipv4(PEER));
-    run(&mut io, &mut rt, &s, 0, 1, &mut VecTrace::default());
+    run(&mut io, &mut rt, &dynamic, 0, 1, &mut VecTrace::default());
+    io.pop_recycled();
+    assert_eq!(rt.pending_actions(), 1);
+    io.inject(IFACE, arp(2, PEER, LOCAL, NEW_MAC, NEW_MAC));
+    run(
+        &mut io,
+        &mut rt,
+        &with_static,
+        0,
+        1,
+        &mut VecTrace::default(),
+    );
+    io.pop_recycled();
+    assert_eq!(rt.pending_actions(), 0);
+    io.inject(IFACE, ipv4(PEER));
+    run(
+        &mut io,
+        &mut rt,
+        &with_static,
+        0,
+        1,
+        &mut VecTrace::default(),
+    );
     assert_eq!(&io.pop_tx().unwrap().bytes[0..6], &static_mac.0);
 }
 
@@ -490,6 +646,121 @@ fn reply_before_generated_execution_cancels_only_matching_fifo_action() {
         .unwrap()
         .unwrap();
     assert_eq!(io.pop_tx().unwrap().egress, second_if);
+}
+
+#[test]
+fn reconcile_static_clears_stale_cache_and_wrapped_middle_action_fifo() {
+    let (routes, interfaces, bindings) = base();
+    let dynamic = snapshot(&routes, &interfaces, &[], &bindings);
+    let second_if = IfId(2);
+    let second_routes =
+        [Route::new(PEER, 32, second_if, None).expect("canonical host route is valid")];
+    let second_interfaces = [Interface {
+        id: second_if,
+        mac: NEW_MAC,
+    }];
+    let second_bindings = [LocalIpv4Binding {
+        interface: second_if,
+        address: Ipv4Address::from_octets([198, 51, 100, 2]),
+    }];
+    let second = snapshot(&second_routes, &second_interfaces, &[], &second_bindings);
+    let static_mac = MacAddress([2, 7, 7, 7, 7, 7]);
+    let neighbors = [
+        Neighbor {
+            interface: IFACE,
+            target: PEER,
+            mac: static_mac,
+        },
+        Neighbor {
+            interface: IFACE,
+            target: THIRD,
+            mac: MacAddress([2, 7, 7, 7, 7, 8]),
+        },
+    ];
+    let with_static = snapshot(&routes, &interfaces, &neighbors, &bindings);
+    let mut states = [ResolutionStateSlot::EMPTY; 4];
+    let mut actions = [ResolutionActionSlot::EMPTY; 3];
+    let mut cache = [DynamicNeighborSlot::EMPTY; 1];
+    let mut rt = runtime!(
+        ResolutionPolicy::new(1_000, 2_000).unwrap(),
+        states,
+        actions,
+        cache
+    );
+    let mut io = SimIo::new();
+
+    io.inject(IFACE, arp(2, PEER, LOCAL, PEER_MAC, PEER_MAC));
+    run(&mut io, &mut rt, &dynamic, 0, 1, &mut VecTrace::default());
+    io.pop_recycled();
+    for target in [OTHER, THIRD, FOURTH] {
+        io.inject(IFACE, ipv4(target));
+    }
+    run(&mut io, &mut rt, &dynamic, 0, 3, &mut VecTrace::default());
+    assert_eq!(rt.pending_actions(), 3);
+    for _ in 0..3 {
+        io.pop_recycled();
+    }
+    execute_one_arp_request(&mut io, &mut rt, MonotonicMillis(0), &mut NoGeneratedTrace)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        &io.pop_tx().unwrap().bytes[38..42],
+        &OTHER.octets(),
+        "advance the ring head before wrapping the tail"
+    );
+    io.inject(second_if, ipv4(PEER));
+    run(&mut io, &mut rt, &second, 0, 1, &mut VecTrace::default());
+    io.pop_recycled();
+    assert_eq!(rt.pending_actions(), 3);
+
+    let report = rt.reconcile_static(&neighbors);
+    assert_eq!(
+        (
+            report.dynamic_removed,
+            report.states_removed,
+            report.actions_removed
+        ),
+        (1, 1, 1)
+    );
+    assert_eq!(rt.pending_actions(), 2);
+    io.inject(IFACE, ipv4(FIFTH));
+    run(&mut io, &mut rt, &dynamic, 0, 1, &mut VecTrace::default());
+    io.pop_recycled();
+    assert_eq!(rt.pending_actions(), 3, "removed capacity is reusable");
+
+    for (expected_egress, expected_target) in [(IFACE, FOURTH), (second_if, PEER), (IFACE, FIFTH)] {
+        execute_one_arp_request(&mut io, &mut rt, MonotonicMillis(0), &mut NoGeneratedTrace)
+            .unwrap()
+            .unwrap();
+        let request = io.pop_tx().unwrap();
+        assert_eq!(request.egress, expected_egress);
+        assert_eq!(&request.bytes[38..42], &expected_target.octets());
+    }
+
+    io.inject(IFACE, ipv4(PEER));
+    run(
+        &mut io,
+        &mut rt,
+        &with_static,
+        1,
+        1,
+        &mut VecTrace::default(),
+    );
+    assert_eq!(&io.pop_tx().unwrap().bytes[0..6], &static_mac.0);
+    io.inject(IFACE, arp(2, SIXTH, LOCAL, NEW_MAC, NEW_MAC));
+    run(
+        &mut io,
+        &mut rt,
+        &with_static,
+        1,
+        1,
+        &mut VecTrace::default(),
+    );
+    assert_eq!(
+        rt.dynamic_neighbor_count(),
+        1,
+        "reconcile freed the sole dynamic slot"
+    );
 }
 
 #[test]

--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -18,6 +18,10 @@ leaseを未完了のままdropした場合、coreのRAII実装が`LeaseAbandoned
 leaseしていないslotはRX backendの所有下に残ります。coreからUMEM、mbuf、simの`Vec`
 は見えません。
 
+`consume`はforwarding上の論理終端です。backendはそのRX bufferを物理的にはrecycleし、
+simの`BatchCompletion.recycled`にはdropとconsumeの両方を数えます。両者の区別は
+`BatchReport.consumed`、typed `RecycleCause`、terminal traceで保持します。
+
 `receive`はbackend固有errorを返せます。`finish`はerror時にも失われないcompletionを
 必ず返し、TX requested/accepted/rejectedを分けます。常に
 `accepted + rejected == requested`で、reject slotはbackendがreturn前にrecycle/free
@@ -92,6 +96,12 @@ exact boundaryではlazy expiryして転送に使いません。insert時もempt
 reuseし、liveな別keyをevictしません。既存keyのMAC/refresh時刻更新は追加capacity不要です。
 periodic scanはなく、lookup/insert時のbounded linear lazy maintenanceです。
 
+control planeがstatic neighbor snapshotを公開する同じworker tickでは、次のpacketを処理
+する前に、そのsnapshotのneighbor sliceを`ResolutionRuntime::reconcile_static`へ渡します。
+これによりstatic keyと一致するdynamic slot、resolution state、queued actionを削除し、
+wrapped action ringのunrelated FIFOを維持します。static公開後に同keyのARPを受けた場合も
+merge pathが同じcleanupを行います。
+
 同じkeyのactionは一つだけqueueできます。抑制deadlineはenqueue時でなく、generated
 leaseをcommitしてTX requestedになった注入時刻から開始します。allocation/build失敗時は
 actionを保持しdeadlineを開始しません。backendのpartial rejectでもcommit済みなので
@@ -127,10 +137,12 @@ v0.2 bootstrapはEthernet II上のIPv4 datagramを転送します。
 ## ARP control scope
 
 Ethernet II / IPv4 profile（HTYPE 1、PTYPE 0x0800、HLEN 6、PLEN 4）のRequest/Replyを
-扱います。RFC 826の順序どおり、valid senderの既存dynamic entryはTPA/opcode非依存で
-mergeし、entryが無い場合はTPAがingress localのときだけinsertします。その後local
+扱います。RFC 826の順序どおり、supported opcodeかつvalid senderの既存dynamic entryは
+TPA非依存でmergeし、entryが無い場合はTPAがingress localのときだけinsertします。その後local
 Requestは同じRX bufferをReplyへ書き換えてingressへcommitし、Replyとnonlocal Requestは
 byte不変でlocal consumeします。`received == tx_requested + dropped + consumed`です。
+unknown opcodeはhardening deviationとしてprofile validationでdropし、既存entryの
+MAC/refresh時刻やpending resolutionを変更しません。
 
 - Ethernet destinationとTHAはrequest SHA、Ethernet sourceとSHAはlocal interface MAC。
 - SPAはrequest TPA、TPAはrequest SPA。ARP ProbeのSPA `0.0.0.0`にもTPA zeroでreplyする。
@@ -140,16 +152,21 @@ byte不変でlocal consumeします。`received == tx_requested + dropped + cons
 - 42 byte以後はpadding/tailとして長さと内容を保存する。
 - static mappingはdynamicより常に優先し、ARPで上書きもdynamic slot消費もしないlocal policy。
 - zero/broadcast/multicast SHAはRFC 1812 group-address prohibitionとlocal zero policyにより
-  stable security reasonでdropする。SPA multicast/limited/directed broadcastはconsumeするが
-  学習しない。
+  stable security reasonでdropする。RFC 1122 §3.2.1.3とlocal safety policyにより、SPAの
+  `0/8`（exact zeroはProbe）、`127/8`、multicast、`240/4`、limited broadcast、connected
+  `/0`から`/30`のnetwork/directed broadcast addressはconsumeするが学習しない。`/31`と
+  `/32`にはnetwork/broadcast endpoint除外を適用しない。
+- local SPA claimの保護はlink scopedで、`(ingress IfId, SPA)`がlocal bindingと一致する場合
+  だけ学習しない。同じIPv4値が別interfaceのlocal bindingでも、ingress上では通常peerとして
+  学習できる。
 - 学習成功時だけmatching resolution state/actionをcancelし、unrelated FIFOを維持する。
 
 Reply admissionへsolicited-only制約は追加しません。`ArpReplyUnsupported`と
 `ArpTargetNotLocal`のstable reason番号は互換性のためretired/reservedとして維持します。
 
-RFC 5227 §2.4のaddress conflict detection/defenseは未実装です。foreign SHAがlocal SPAを
-名乗り、同じlocal addressをTPAにしたrequestも通常requestとしてdirected replyするだけで、
-conflict状態やdefensive announcementを生成しません。正常なlocal target requestを
+RFC 5227 §2.4のaddress conflict detection/defenseは未実装です。foreign SHAが同じingressの
+local SPAを名乗り、そのlocal addressをTPAにしたrequestも通常requestとしてdirected reply
+するだけで、conflict状態やdefensive announcementを生成しません。正常なlocal target requestを
 追加policyでdropしないことを優先した明示deviationです。
 
 eager cache scan/flush、timer retry、unresolved packet hold queue、gratuitous ARP生成、

--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -7,10 +7,11 @@ GATでbatchを借用し、batchから一度に一つのcore所有`PacketLease`�
 raw `PacketSlot`はcallerへ返りません。leaseはzero-sizeな`Rc` markerで`!Send + !Sync`
 となり、live slotをworker間で移動できません。
 
-packet leaseには二つの正常な終端があります。
+packet leaseには三つの正常な終端があります。
 
 1. forwardするslotは、in-place rewrite後にegress `IfId`を付けて`commit`する。
 2. dropするslotは、stableな`DropReason`を付けて`recycle`する。
+3. router自身が処理したcontrol packetは、typed `ConsumeReason`で`consume`する。
 
 leaseを未完了のままdropした場合、coreのRAII実装が`LeaseAbandoned` lifecycle completion
 をbackendへ必ず返します。これはforwardingの`DropReason`とは別です。batchからまだ
@@ -32,7 +33,7 @@ Ethernet validate
   │    → options policy → TTL check → LPM → typed neighbor/interface lookup
   │    → TTL/checksum/MAC rewrite → commit
   └─ Ethernet/IPv4 ARP profile validate → ingress local target lookup
-       → request bufferをARP replyへrewrite → ingressへcommit
+       → RFC 826 merge → Request localならin-place Reply、それ以外はlocal consume
 ```
 
 leaseからmutable sliceを一度だけ取得し、同じsliceをimmutable reborrowして全判断を
@@ -76,13 +77,20 @@ buffer unavailableを区別し、失敗時はownershipを移しません。finis
 `attempts=allocated+failed`、`allocated=requested+cancelled+abandoned`、
 `accepted+rejected=requested`のaccountingを返し、rejectをreturn前にrecycleします。
 
-resolution runtimeも`!Send + !Sync`で、caller提供のlinear fixed tableとaction ringだけを
-借用します。keyは`(IfId,target IPv4)`です。intervalは1000ms以上、state TTLはinterval
+resolution runtimeも`!Send + !Sync`で、caller提供のlinear fixed resolution table、
+action ring、dynamic neighbor tableを借用します。すべてのkeyは`(IfId,target IPv4)`です。
+intervalは1000ms以上、state TTLはinterval
 以上とし、batch単位で注入された`MonotonicMillis`だけを使います。加算deadlineを作らず
 順序確認後の差分で判定するため`u64` overflowはありません。逆行はtyped resultとして
 action/stateを変更しません。live entryはevictせず、TTL後だけreuseします。runtimeの
-生成時はcaller storageをすべてemptyへ初期化します。processをまたぐstate永続化/resumeは
+生成時は三storageをすべてemptyへ初期化します。processをまたぐstate永続化/resumeは
 未実装です。
+
+dynamic neighbor TTLはzeroを拒否するconfigurable policyです。static neighborを最初に
+lookupし、static missだけdynamicを参照します。dynamic slotは`elapsed < TTL`だけliveで、
+exact boundaryではlazy expiryして転送に使いません。insert時もempty/expired slotだけを
+reuseし、liveな別keyをevictしません。既存keyのMAC/refresh時刻更新は追加capacity不要です。
+periodic scanはなく、lookup/insert時のbounded linear lazy maintenanceです。
 
 同じkeyのactionは一つだけqueueできます。抑制deadlineはenqueue時でなく、generated
 leaseをcommitしてTX requestedになった注入時刻から開始します。allocation/build失敗時は
@@ -101,8 +109,8 @@ Ethernet/IPv4 ARP（Ethernet destination broadcast、SHA/source MACはlocal、SP
 local IPv4、THA zero、TPA target）として書き、残り18 bytesを必ずzero paddingします。
 THA zeroは決定的なlocal profile choiceであり、RFCのMUSTとは主張しません。
 
-これはRFC 826の通常ARP Request生成とRFC 1122 §2.3.2.1のflood preventionまでです。
-reply learning/cache/aging/flush、timer-only retry/max attempts/Failed、unresolved packet
+これはRFC 826の通常ARP Request生成/mergeとRFC 1122 §2.3.2.1のflood prevention/stale
+entry TTLまでです。timer-only retry/max attempts/Failed、unresolved packet
 hold/replay（RFC 1122 §2.3.2.2、RFC 1812 §3.3.2）、multi-worker resolution ownership/
 SPSCは未実装です。最初のpacketは解決後に自動再送されません。
 
@@ -116,27 +124,36 @@ v0.2 bootstrapはEthernet II上のIPv4 datagramを転送します。
 - fragment offsetやMFに関係なく、このsliceはL4を参照しないためdatagramとして転送する。
 - TTLは1減算し、header checksumはRFC 1624のincremental updateで更新する。
 
-## ARP responder scope
+## ARP control scope
 
-Ethernet II / IPv4 profile（HTYPE 1、PTYPE 0x0800、HLEN 6、PLEN 4）のARP Requestだけを
-扱います。opcode profileはRFC 826に加えてRFC 5494/IANA ARP Parameters registryに
-基づき、Replyと未対応opcodeを別reasonにします。TPAがingress interfaceのlocal IPv4と
-一致するとき、同じRX bufferを次のreplyへ書き換えてingressへcommitします。
+Ethernet II / IPv4 profile（HTYPE 1、PTYPE 0x0800、HLEN 6、PLEN 4）のRequest/Replyを
+扱います。RFC 826の順序どおり、valid senderの既存dynamic entryはTPA/opcode非依存で
+mergeし、entryが無い場合はTPAがingress localのときだけinsertします。その後local
+Requestは同じRX bufferをReplyへ書き換えてingressへcommitし、Replyとnonlocal Requestは
+byte不変でlocal consumeします。`received == tx_requested + dropped + consumed`です。
 
 - Ethernet destinationとTHAはrequest SHA、Ethernet sourceとSHAはlocal interface MAC。
 - SPAはrequest TPA、TPAはrequest SPA。ARP ProbeのSPA `0.0.0.0`にもTPA zeroでreplyする。
-- request THAは無視し、Ethernet sourceとrequest SHAの一致も要求しない。
+- Probeは学習しない。GARP/Announcementは既存entryだけ更新し、absent keyをinsertしない。
+- request THAは無視し、Ethernet sourceとrequest SHAの一致も要求しない。mapping authorityは
+  ARP SHAであり、ARP自体にはspoofingを認証する仕組みがないことが残余riskです。
 - 42 byte以後はpadding/tailとして長さと内容を保存する。
-- ARP Reply、unknown opcode、nonlocal targetはstable reasonでbytes不変recycleする。
-- 学習やneighbor snapshot更新は一切行わない。
+- static mappingはdynamicより常に優先し、ARPで上書きもdynamic slot消費もしないlocal policy。
+- zero/broadcast/multicast SHAはRFC 1812 group-address prohibitionとlocal zero policyにより
+  stable security reasonでdropする。SPA multicast/limited/directed broadcastはconsumeするが
+  学習しない。
+- 学習成功時だけmatching resolution state/actionをcancelし、unrelated FIFOを維持する。
+
+Reply admissionへsolicited-only制約は追加しません。`ArpReplyUnsupported`と
+`ArpTargetNotLocal`のstable reason番号は互換性のためretired/reservedとして維持します。
 
 RFC 5227 §2.4のaddress conflict detection/defenseは未実装です。foreign SHAがlocal SPAを
 名乗り、同じlocal addressをTPAにしたrequestも通常requestとしてdirected replyするだけで、
 conflict状態やdefensive announcementを生成しません。正常なlocal target requestを
 追加policyでdropしないことを優先した明示deviationです。
 
-ARP learning/cache/aging/flush、timer retry、unresolved packet hold queue、gratuitous
-ARP、ARP Probe/Announcement生成、proxy ARP、VLAN、Address Conflict Detection、ICMP生成、
+eager cache scan/flush、timer retry、unresolved packet hold queue、gratuitous ARP生成、
+ARP Probe/Announcement生成、proxy ARP、VLAN、Address Conflict Detection、ICMP生成、
 NAT、firewall、config parser、pcap、AF_XDP、DPDK、binary、thread、benchmarkはこの
 sliceのscope外です。
 

--- a/docs/requirements-v0.2.md
+++ b/docs/requirements-v0.2.md
@@ -15,7 +15,7 @@ Statusは`implemented`、`deferred`、`deviation`のいずれかです。test名
 | IO-007 generated partial/error completion | architecture contract | `generated_partial_tx_error_preserves_invariants_and_recycles_rejects` | implemented | 三つのaccounting不変条件を保持しrejectをreturn前にrecycle |
 | IO-008 generated builder failure isolation | defensive backend boundary | `builder_failure_cancels_lease_and_retains_action` | implemented | exact-length契約違反bufferをcancelしactionを保持 |
 | IO-009 real generated backend | backend roadmap | — | deferred | AF_XDP/DPDK generated allocator/TXは未実装 |
-| IO-010 ARP control consume lifecycle/accounting | architecture contract | `mixed_reply_then_ipv4_uses_dynamic_mapping_in_same_batch` | implemented | logical consumedとphysical recycleを区別し、received=TX+drop+consume |
+| IO-010 ARP control consume lifecycle/accounting | architecture contract | `mixed_reply_then_ipv4_uses_dynamic_mapping_in_same_batch` | implemented | `BatchReport`/`RecycleCause`でlogical consumeを区別。physical recycle countはdrop+consumeを含み、received=TX+drop+consume |
 | ETH-001 Ethernet II framing | RFC 894 | `all_validation_and_decision_drops_are_granular_and_atomic` | implemented | 802.3 LLC/VLANはdeferred |
 | IP4-001 Version/IHL/Total Length validation | RFC 791 §3.1 | `all_validation_and_decision_drops_are_granular_and_atomic` | implemented | なし |
 | IP4-002 Total Length後のpadding無視 | RFC 791 §3.1 | `padding_is_ignored_but_preserved` | implemented | なし |
@@ -62,10 +62,14 @@ Statusは`implemented`、`deferred`、`deviation`のいずれかです。test名
 | ARP-016 Probe/Announcement/GARP/ACD generation | RFC 5227 | — | deferred | generated pathは通常ARP Requestだけ。Probe/Announcement/GARP/ACDは未実装 |
 | ARP-017 target-local unsolicited admission/nonlocal ignore | RFC 826 | `unsolicited_local_reply_learns_while_nonlocal_absent_is_ignored` | implemented | solicited-only制限なし。target-local Replyはinsert、nonlocal absentはconsume-ignore |
 | ARP-018 merge precedes opcode/target and GARP refresh | RFC 826 | `existing_mapping_merge_precedes_target_and_opcode_and_garp_refreshes` | implemented | existing keyはReply/Request/Announcement、local/nonlocal TPAに依らずSHAへmerge |
+| ARP-018A unknown opcode atomic hardening drop | RFC 826 merge orderからのhardening deviation | `unknown_opcode_drops_before_merge_without_mutating_cache_or_pending` | deviation | unsupported opcodeはprofile validationで先にdropし、MAC/TTL/pending/bytesを変更しない |
 | ARP-019 local Request/Probe/SHA authority | RFC 826, RFC 5227 | `local_request_learns_sha_even_when_ethernet_source_differs_and_probe_does_not` | implemented | Requestはlearn後reply、Probeはno-learn、Ethernet source≠SHAでもSHAを採用 |
 | ARP-020 invalid sender hardware security drop | RFC 1812 §3.3.2, local zero policy | `invalid_sender_hardware_drops_atomically_without_cache_or_action_mutation` | implemented | zero/broadcast/multicast SHAはbyte/cache/action atomic drop |
-| ARP-021 non-host sender protocol no-learn | RFC 1812 §3.3.2, local policy | `non_host_sender_protocol_addresses_are_consumed_without_learning` | implemented | multicast/limited/directed broadcast SPAはconsumeするが学習しない |
-| ARP-022 static authority over dynamic | local authority policy | `foreign_local_spa_cannot_poison_and_static_mapping_has_priority` | deviation | staticはARPで上書き/slot消費せず常にforward優先 |
+| ARP-021 non-host sender protocol no-learn | RFC 1122 §3.2.1.3, local safety policy | `non_host_sender_protocol_addresses_are_consumed_without_learning` | implemented | nonzero `0/8`、`127/8`、multicast、`240/4`、limited broadcast、connected network/directed broadcast SPAはconsume/no-learn、cache/action不変 |
+| ARP-021A point-to-point endpoint learning | RFC 3021, host-route semantics | `point_to_point_prefix_endpoints_are_learnable` | implemented | `/31`と`/32`はnetwork/broadcast addressとして除外しない |
+| ARP-021B local SPA claim is ingress scoped | RFC 5227 link scope | `local_address_value_on_another_interface_is_learnable_on_ingress` | implemented | 別IfIdのlocal IPv4値と同じSPAはingress上のpeerとして学習可能 |
+| ARP-022 static authority over dynamic | local authority policy | `foreign_local_spa_cannot_poison_and_static_mapping_has_priority` | deviation | staticはARPで上書き/slot消費せず常にforward優先し、同keyのstale dynamic/pendingを削除 |
+| ARP-022A static snapshot reconciliation | control-plane publication contract | `reconcile_static_clears_stale_cache_and_wrapped_middle_action_fifo` | implemented | snapshot公開と同worker tickでdynamic/state/actionを削除し、wrapped ringのFIFO/容量/IfId独立性を保持 |
 | ARP-023 cache-full disposition/pending preservation | architecture contract | `ttl_boundary_refresh_expired_reuse_and_cache_full_are_exact` | implemented | live entry非evict、Reply consume、matching pending actionをclearしない |
 | ARP-024 unified monotonic watermark | architecture contract | `clock_regression_does_not_mutate_cache_and_later_equal_time_recovers` | implemented | regressionはcache/action不変、後続normal nowで回復 |
 | ARP-025 learned mapping cancels matching resolution | architecture contract | `reply_before_generated_execution_cancels_only_matching_fifo_action` | implemented | matching action/stateだけcancel、unrelated key/IfId FIFOとcapacityを維持 |

--- a/docs/requirements-v0.2.md
+++ b/docs/requirements-v0.2.md
@@ -15,6 +15,7 @@ Statusは`implemented`、`deferred`、`deviation`のいずれかです。test名
 | IO-007 generated partial/error completion | architecture contract | `generated_partial_tx_error_preserves_invariants_and_recycles_rejects` | implemented | 三つのaccounting不変条件を保持しrejectをreturn前にrecycle |
 | IO-008 generated builder failure isolation | defensive backend boundary | `builder_failure_cancels_lease_and_retains_action` | implemented | exact-length契約違反bufferをcancelしactionを保持 |
 | IO-009 real generated backend | backend roadmap | — | deferred | AF_XDP/DPDK generated allocator/TXは未実装 |
+| IO-010 ARP control consume lifecycle/accounting | architecture contract | `mixed_reply_then_ipv4_uses_dynamic_mapping_in_same_batch` | implemented | logical consumedとphysical recycleを区別し、received=TX+drop+consume |
 | ETH-001 Ethernet II framing | RFC 894 | `all_validation_and_decision_drops_are_granular_and_atomic` | implemented | 802.3 LLC/VLANはdeferred |
 | IP4-001 Version/IHL/Total Length validation | RFC 791 §3.1 | `all_validation_and_decision_drops_are_granular_and_atomic` | implemented | なし |
 | IP4-002 Total Length後のpadding無視 | RFC 791 §3.1 | `padding_is_ignored_but_preserved` | implemented | なし |
@@ -23,23 +24,24 @@ Statusは`implemented`、`deferred`、`deviation`のいずれかです。test名
 | IP4-004 fragmentをL3転送 | RFC 791 §3.1 | `fragment_flags_offset_payload_and_checksum_are_preserved_or_updated_correctly` | implemented | reassemblyはrouter slice外 |
 | IP4-005 header checksum validation | RFC 1071 | `all_validation_and_decision_drops_are_granular_and_atomic` | implemented | なし |
 | FWD-001 `/0`と`/32`を含むLPM | forwarding requirement | `lpm_supports_default_and_host_routes` | implemented | ECMPなし |
-| FWD-002 connected/gateway neighbor selection | forwarding requirement | `connected_route_uses_packet_destination_as_neighbor_target` | implemented | ARP学習自体はdeferred |
+| FWD-002 connected/gateway neighbor selection | forwarding requirement | `connected_route_uses_packet_destination_as_neighbor_target` | implemented | static lookupを優先しdynamicへfallback |
 | FWD-003 TTL decrement | RFC 791 §3.1 | `gateway_route_rewrites_and_reports_backend_acceptance` | implemented | TTL expiry ICMP生成はdeferred |
 | FWD-004 incremental checksum update | RFC 1624 §4 | `rfc_1624_negative_zero_boundary_is_positive_zero` | implemented | `0xdd2f,0x5555→0x3285 = 0x0000` |
 | FWD-005 drop atomicity | architecture contract | `all_validation_and_decision_drops_are_granular_and_atomic` | implemented | なし |
 | FWD-006 snapshot integrity | architecture contract | `snapshot_constructor_rejects_all_broken_references_and_duplicates` | implemented | 公開前にvalidation |
 | FWD-007 unresolved trigger atomicity/request action | RFC 1122 §2.3.2.1 | `unresolved_neighbor_generates_broadcast_arp_request_and_recycles_trigger_atomically` | implemented | 元IPv4はbyte不変NeighborUnresolved、RX finish後にgenerated session |
 | FWD-008 unresolved packet hold/replay | RFC 1122 §2.3.2.2, RFC 1812 §3.3.2 | — | deferred | hold/replay未実装。最初のpacketは解決後も自動再送されない |
-| ARP-001 Ethernet/IPv4 request profile validation | RFC 826, RFC 5494/IANA ARP Parameters | `arp_profile_validation_drops_are_granular_and_atomic` | implemented | HTYPE=1/PTYPE=0x0800/HLEN=6/PLEN=4/opcode=1。replyとunknown opcodeを区別 |
+| ARP-001 Ethernet/IPv4 Request/Reply profile validation | RFC 826, RFC 5494/IANA ARP Parameters | `arp_profile_validation_drops_are_granular_and_atomic` | implemented | HTYPE=1/PTYPE=0x0800/HLEN=6/PLEN=4、unknown opcodeはdrop |
 | ARP-002 local target in-place reply on ingress | RFC 826 | `arp_request_for_local_ipv4_replies_in_place_on_ingress` | implemented | 同じRX allocation、egress=ingress、wire fieldsを検証 |
 | ARP-003 probe reply with zero target protocol | RFC 5227 §2.5（Probe形式は§1.1/§2.1.1） | `arp_probe_for_local_ipv4_replies_with_zero_target_protocol` | implemented | SPA=0 requestにも通常reply |
 | ARP-004 request THA ignored/source identities not coupled | RFC 826 | `arp_request_target_hardware_is_ignored` | implemented | Ethernet source≠ARP SHAも受理 |
 | ARP-005 tail/padding preservation | RFC 826 wire profile | `arp_padding_is_ignored_and_preserved_on_reply` | implemented | 42 byte以後を変更しない |
-| ARP-006 nonlocal/proxy-disabled/reply/unknown opcode stable recycle | RFC 826, RFC 1027, RFC 5494/IANA ARP Parameters | `arp_nonlocal_and_reply_are_recycled_without_mutation` | implemented | nonlocal targetへ応答せずproxy ARPは無効。replyとunknown opcodeは別stable reason |
+| ARP-006 valid Reply/nonlocal Request consume | RFC 826, RFC 1027 | `arp_nonlocal_and_reply_are_recycled_without_mutation` | implemented | proxy ARPなし、valid controlはbyte不変consume。unknown opcodeだけdrop |
 | ARP-007 local binding snapshot integrity | architecture contract | `arp_snapshot_rejects_duplicate_or_unknown_local_addresses` | implemented | interfaceごとにlocal IPv4一つ、address重複/unknown interface/unspecified SPAを拒否。MACはInterfaceのみ |
-| ARP-008 address conflict detection/defense | RFC 5227 §2.4 | `arp_foreign_sender_claiming_local_address_gets_normal_reply` | deviation | foreign SHAがlocal SPAを名乗ってもconflict state/defensive announcementなし。local targetへの通常replyのみ |
-| ARP-009 responder learning absent | RFC 826 | `arp_reply_does_not_learn_or_generate_for_unresolved_neighbor` | deferred | 現sliceは受信requestからsenderを学習せず、直後のIPv4 neighbor missを実証 |
-| ARP-009A neighbor cache aging/flush | RFC 826 | — | deferred | mutable neighbor cache自体が未実装 |
+| ARP-008 address conflict detection/defense | RFC 5227 §2.4 | `foreign_local_spa_cannot_poison_and_static_mapping_has_priority` | deviation | foreign SHAのlocal SPA claimはcacheへ入れず、local Requestには通常replyするがdefenseなし |
+| ARP-009 request/reply learn-forward vertical slice | RFC 826 | `miss_request_reply_consume_then_reinjected_ipv4_forwards` | implemented | miss→Request→Reply consume/learn→fresh reinject forward。元packet holdなし |
+| ARP-009A dynamic TTL/lazy stale removal | RFC 1122 §2.3.2.1 | `ttl_boundary_refresh_expired_reuse_and_cache_full_are_exact` | implemented | configurable TTL、TTL-1 hit、exact expiry、expired reuse、live非evict |
+| ARP-009B eager cache scan/administrative flush | control-plane roadmap | — | deferred | lookup/insert時のlazy expiryのみ |
 | ARP-010 normal request 60-byte wire profile | RFC 826, RFC 894 | `unresolved_neighbor_generates_broadcast_arp_request_and_recycles_trigger_atomically` | implemented | broadcast Ethernet、SPAはnonzero local、THA zero、18-byte zero padding、FCSなし |
 | ARP-010A ordinary request is not Probe/Announcement | RFC 826, local deterministic profile | `ordinary_resolution_request_is_not_probe_or_announcement` | implemented | SPA nonzero、SPA≠TPA、opcode Request |
 | ARP-011 commit-based suppression deadline | RFC 1122 §2.3.2.1 | `suppression_deadline_starts_at_generated_commit_time` | implemented | enqueue=0ms、commit=700ms、1699ms suppress、1700ms queue |
@@ -58,6 +60,17 @@ Statusは`implemented`、`deferred`、`deviation`のいずれかです。test名
 | ARP-014A timer-only retry/max attempts/Failed | RFC 1122 §2.3.2.1 | — | deferred | retryはtraffic-drivenまたは保持actionのexecutor再実行のみ |
 | ARP-015 multi-worker resolution ownership/sharding | concurrency design | — | deferred | 現sliceはsingle worker ownerのみ。shard/SPSC handoff未実装 |
 | ARP-016 Probe/Announcement/GARP/ACD generation | RFC 5227 | — | deferred | generated pathは通常ARP Requestだけ。Probe/Announcement/GARP/ACDは未実装 |
+| ARP-017 target-local unsolicited admission/nonlocal ignore | RFC 826 | `unsolicited_local_reply_learns_while_nonlocal_absent_is_ignored` | implemented | solicited-only制限なし。target-local Replyはinsert、nonlocal absentはconsume-ignore |
+| ARP-018 merge precedes opcode/target and GARP refresh | RFC 826 | `existing_mapping_merge_precedes_target_and_opcode_and_garp_refreshes` | implemented | existing keyはReply/Request/Announcement、local/nonlocal TPAに依らずSHAへmerge |
+| ARP-019 local Request/Probe/SHA authority | RFC 826, RFC 5227 | `local_request_learns_sha_even_when_ethernet_source_differs_and_probe_does_not` | implemented | Requestはlearn後reply、Probeはno-learn、Ethernet source≠SHAでもSHAを採用 |
+| ARP-020 invalid sender hardware security drop | RFC 1812 §3.3.2, local zero policy | `invalid_sender_hardware_drops_atomically_without_cache_or_action_mutation` | implemented | zero/broadcast/multicast SHAはbyte/cache/action atomic drop |
+| ARP-021 non-host sender protocol no-learn | RFC 1812 §3.3.2, local policy | `non_host_sender_protocol_addresses_are_consumed_without_learning` | implemented | multicast/limited/directed broadcast SPAはconsumeするが学習しない |
+| ARP-022 static authority over dynamic | local authority policy | `foreign_local_spa_cannot_poison_and_static_mapping_has_priority` | deviation | staticはARPで上書き/slot消費せず常にforward優先 |
+| ARP-023 cache-full disposition/pending preservation | architecture contract | `ttl_boundary_refresh_expired_reuse_and_cache_full_are_exact` | implemented | live entry非evict、Reply consume、matching pending actionをclearしない |
+| ARP-024 unified monotonic watermark | architecture contract | `clock_regression_does_not_mutate_cache_and_later_equal_time_recovers` | implemented | regressionはcache/action不変、後続normal nowで回復 |
+| ARP-025 learned mapping cancels matching resolution | architecture contract | `reply_before_generated_execution_cancels_only_matching_fifo_action` | implemented | matching action/stateだけcancel、unrelated key/IfId FIFOとcapacityを維持 |
+| ARP-026 same-batch sequential visibility | architecture contract | `mixed_reply_then_ipv4_uses_dynamic_mapping_in_same_batch` | implemented | `[Reply, IPv4]`の2packet目が直前のdynamic mergeを利用 |
+| ARP-027 zero capacity/recreate safety | architecture contract | `zero_capacity_and_runtime_recreation_are_safe` | implemented | zero容量panicなし、constructorでcacheをemptyへ初期化 |
 | OBS-001 stable reason code | explainability requirement | `drop_reason_discriminants_and_codes_are_stable_and_unique` | implemented | repr(u16) |
 | OBS-002 requestedとaggregate TX outcome trace | explainability requirement | `partial_backend_completion_preserves_report_and_aggregate_trace` | implemented | packet単位accepted traceはdeferred |
 | OBS-003 protocol-aware ARP trace ordering | explainability requirement | `arp_trace_is_deterministic_and_tx_follows_commit` | implemented | validated/reply requested/TX requested/completionを順序検証 |


### PR DESCRIPTION
## Summary
- add a fixed-capacity, caller-backed dynamic ARP cache to each resolution runtime
- consume and learn valid RFC 826 traffic, with static-neighbor precedence and explicit reconciliation
- forward a freshly injected IPv4 packet after miss, generated request, and ARP reply learning
- add typed consume lifecycle/reporting across core and sim

## Safety and standards
- use RFC 826 broad merge semantics while documenting hardening deviations
- reject invalid sender hardware and non-host protocol addresses
- keep local-address protection ingress-scoped and static mappings authoritative
- expire entries at an exact configurable TTL without shared locks or per-packet allocation
- retain the first unresolved packet as recycled; packet hold/replay is intentionally out of scope

## Verification
- 65 workspace tests passed
- 4 compile-fail doctests passed
- fmt, check, clippy with warnings denied, rustdoc with warnings denied passed
- requirements ledger and diff checks passed
- three independent reviews: Critical 0, High 0, Medium 0, Low 0