### PR TITLE
feat(core): answer local ICMPv4 echo requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ active treeは、そのコードを継承しないv0.2のゼロベース実装�
 
 - `ruster-core`: backend所有packetを借用し、Ethernet II / IPv4検証、LPM、
   TTL/checksum/MAC rewrite、local IPv4向けARP reply、static neighbor miss時の
-  ARP Request生成action、fixed-capacity dynamic ARP cacheを扱う。
+  ARP Request生成action、fixed-capacity dynamic ARP cache、local ICMPv4 Echo
+  responderを扱う。
 - `ruster-io-sim`: rootやNICなしでRX/generated TXのFIFO、budget、TX/drop、
   traceを決定的に検証する。
 
@@ -28,6 +29,9 @@ fast pathはpacket batchをworkerが専有します。共有`Mutex`、packet単�
 packet clone、`dyn PacketIo`を導入しません。simの`Vec`はcold I/O境界に閉じています。
 ARP replyも同じRX bufferをin-placeで書き換え、受信interfaceへcommitします。現在の
 ARP profileはinterfaceごとにlocal IPv4を一つだけ持つ静的snapshotです。
+同じbinding宛てのICMPv4 Echo Requestも、checksumとsource admissionを完了してから同じ
+RX bufferをEcho Replyへ書き換えます。local宛ての未実装protocol/controlはroutingへ
+fall throughせず、typed consumeで終端します。
 
 static neighbor missでは元IPv4 packetをbyte不変でrecycleした後、worker-localな固定
 storageで1秒に一度までARP Requestを生成できます。RX batchとgenerated TX sessionは

--- a/crates/core/src/checksum.rs
+++ b/crates/core/src/checksum.rs
@@ -6,10 +6,10 @@
 pub fn internet_checksum(bytes: &[u8]) -> u16 {
     let mut chunks = bytes.chunks_exact(2);
     let mut sum = chunks.by_ref().fold(0_u32, |sum, word| {
-        sum + u32::from(u16::from_be_bytes([word[0], word[1]]))
+        add_folded(sum, u16::from_be_bytes([word[0], word[1]]))
     });
     if let Some(&last) = chunks.remainder().first() {
-        sum += u32::from(last) << 8;
+        sum = add_folded(sum, u16::from(last) << 8);
     }
     fold(sum)
 }
@@ -34,6 +34,11 @@ fn fold(sum: u32) -> u16 {
     !fold_sum(sum)
 }
 
+fn add_folded(sum: u32, word: u16) -> u32 {
+    let sum = sum + u32::from(word);
+    (sum & 0xffff) + (sum >> 16)
+}
+
 fn fold_sum(mut sum: u32) -> u16 {
     while sum > 0xffff {
         sum = (sum & 0xffff) + (sum >> 16);
@@ -53,5 +58,11 @@ mod tests {
     #[test]
     fn checksum_accepts_an_odd_slice_without_panicking() {
         assert_eq!(ipv4_header_checksum(&[0x01, 0x02, 0x03]), 0xfbfd);
+    }
+
+    #[test]
+    fn internet_checksum_folds_carry_for_large_odd_messages() {
+        let bytes = vec![0xff; 200_001];
+        assert_eq!(internet_checksum(&bytes), 0x00ff);
     }
 }

--- a/crates/core/src/checksum.rs
+++ b/crates/core/src/checksum.rs
@@ -1,10 +1,10 @@
-/// Computes the Internet checksum over an IPv4 header.
+/// Computes the Internet checksum over an arbitrary byte slice.
 ///
-/// The checksum field must be zero when creating a header. A complete valid
-/// header, including its checksum, produces zero.
+/// This is the checksum algorithm shared by IPv4 and ICMP. An odd final byte
+/// is treated as the high byte of a zero-padded 16-bit word.
 #[must_use]
-pub fn ipv4_header_checksum(header: &[u8]) -> u16 {
-    let mut chunks = header.chunks_exact(2);
+pub fn internet_checksum(bytes: &[u8]) -> u16 {
+    let mut chunks = bytes.chunks_exact(2);
     let mut sum = chunks.by_ref().fold(0_u32, |sum, word| {
         sum + u32::from(u16::from_be_bytes([word[0], word[1]]))
     });
@@ -12,6 +12,15 @@ pub fn ipv4_header_checksum(header: &[u8]) -> u16 {
         sum += u32::from(last) << 8;
     }
     fold(sum)
+}
+
+/// Computes the Internet checksum over an IPv4 header.
+///
+/// The checksum field must be zero when creating a header. A complete valid
+/// header, including its checksum, produces zero.
+#[must_use]
+pub fn ipv4_header_checksum(header: &[u8]) -> u16 {
+    internet_checksum(header)
 }
 
 /// Updates an Internet checksum after replacing one 16-bit word (RFC 1624 §4).

--- a/crates/core/src/forwarding.rs
+++ b/crates/core/src/forwarding.rs
@@ -35,6 +35,14 @@ pub enum DropReason {
     ArpSenderHardwareZero = 23,
     ArpSenderHardwareBroadcast = 24,
     ArpSenderHardwareMulticast = 25,
+    Icmpv4HeaderTruncated = 26,
+    Icmpv4EchoHeaderTruncated = 27,
+    Icmpv4ChecksumInvalid = 28,
+    Icmpv4EchoCodeInvalid = 29,
+    Icmpv4FragmentUnsupported = 30,
+    Icmpv4SourceNotUnicast = 31,
+    Icmpv4EthernetSourceInvalid = 32,
+    Icmpv4EthernetDestinationNotLocal = 33,
 }
 
 use DropReason::*;
@@ -68,6 +76,14 @@ impl DropReason {
             ArpSenderHardwareZero => "ARP_SENDER_HARDWARE_ZERO",
             ArpSenderHardwareBroadcast => "ARP_SENDER_HARDWARE_BROADCAST",
             ArpSenderHardwareMulticast => "ARP_SENDER_HARDWARE_MULTICAST",
+            Icmpv4HeaderTruncated => "ICMPV4_HEADER_TRUNCATED",
+            Icmpv4EchoHeaderTruncated => "ICMPV4_ECHO_HEADER_TRUNCATED",
+            Icmpv4ChecksumInvalid => "ICMPV4_CHECKSUM_INVALID",
+            Icmpv4EchoCodeInvalid => "ICMPV4_ECHO_CODE_INVALID",
+            Icmpv4FragmentUnsupported => "ICMPV4_FRAGMENT_UNSUPPORTED",
+            Icmpv4SourceNotUnicast => "ICMPV4_SOURCE_NOT_UNICAST",
+            Icmpv4EthernetSourceInvalid => "ICMPV4_ETHERNET_SOURCE_INVALID",
+            Icmpv4EthernetDestinationNotLocal => "ICMPV4_ETHERNET_DESTINATION_NOT_LOCAL",
         }
     }
 }
@@ -164,6 +180,11 @@ pub enum TraceEvent {
         ingress: IfId,
         destination: crate::Ipv4Address,
     },
+    Icmpv4EchoRequestValidated {
+        ingress: IfId,
+        source: crate::Ipv4Address,
+        destination: crate::Ipv4Address,
+    },
     ArpRequestValidated {
         ingress: IfId,
         sender_protocol: crate::Ipv4Address,
@@ -195,6 +216,11 @@ pub enum TraceEvent {
         egress: IfId,
         target_protocol: crate::Ipv4Address,
     },
+    Icmpv4EchoReplyRequested {
+        egress: IfId,
+        source: crate::Ipv4Address,
+        destination: crate::Ipv4Address,
+    },
     Dropped {
         ingress: IfId,
         reason: DropReason,
@@ -203,6 +229,10 @@ pub enum TraceEvent {
         ingress: IfId,
         reason: ConsumeReason,
         disposition: ControlDisposition,
+    },
+    Ipv4LocalConsumed {
+        ingress: IfId,
+        reason: ConsumeReason,
     },
     BatchCompleted {
         tx_accepted: usize,
@@ -257,10 +287,25 @@ struct ArpReplyDecision {
 }
 
 #[derive(Clone, Copy)]
+struct Icmpv4EchoReplyDecision {
+    egress: IfId,
+    local_mac: [u8; 6],
+    requester_mac: [u8; 6],
+    local_ip: [u8; 4],
+    requester_ip: [u8; 4],
+    ipv4_checksum: u16,
+    icmp_checksum: u16,
+    icmp_offset: usize,
+    icmp_end: usize,
+}
+
+#[derive(Clone, Copy)]
 enum PacketDecision {
     Ipv4(Ipv4RewriteDecision),
     ArpReply(ArpReplyDecision),
-    Consume(ControlDisposition),
+    Icmpv4EchoReply(Icmpv4EchoReplyDecision),
+    ConsumeArp(ControlDisposition),
+    ConsumeIpv4Local,
 }
 
 impl PacketDecision {
@@ -268,7 +313,10 @@ impl PacketDecision {
         match self {
             Self::Ipv4(decision) => decision.egress,
             Self::ArpReply(decision) => decision.egress,
-            Self::Consume(_) => unreachable!("consumed controls have no egress"),
+            Self::Icmpv4EchoReply(decision) => decision.egress,
+            Self::ConsumeArp(_) | Self::ConsumeIpv4Local => {
+                unreachable!("consumed controls have no egress")
+            }
         }
     }
 }
@@ -321,7 +369,10 @@ where
         let result = {
             let frame = packet.bytes_mut();
             decide(&*frame, snapshot, ingress, &mut resolution, trace).and_then(|decision| {
-                if matches!(decision, PacketDecision::Consume(_)) {
+                if matches!(
+                    decision,
+                    PacketDecision::ConsumeArp(_) | PacketDecision::ConsumeIpv4Local
+                ) {
                     Ok(decision)
                 } else {
                     apply_decision(frame, decision).map(|()| decision)
@@ -329,13 +380,21 @@ where
             })
         };
         match result {
-            Ok(PacketDecision::Consume(disposition)) => {
+            Ok(PacketDecision::ConsumeArp(disposition)) => {
                 packet.consume(ConsumeReason::ArpControl);
                 consumed += 1;
                 trace.record(TraceEvent::Consumed {
                     ingress,
                     reason: ConsumeReason::ArpControl,
                     disposition,
+                });
+            }
+            Ok(PacketDecision::ConsumeIpv4Local) => {
+                packet.consume(ConsumeReason::Ipv4LocalUnsupported);
+                consumed += 1;
+                trace.record(TraceEvent::Ipv4LocalConsumed {
+                    ingress,
+                    reason: ConsumeReason::Ipv4LocalUnsupported,
                 });
             }
             Ok(decision) => {
@@ -346,6 +405,13 @@ where
                     trace.record(TraceEvent::ArpReplyRequested {
                         egress,
                         target_protocol: crate::Ipv4Address::from_octets(arp.requester_protocol),
+                    });
+                }
+                if let PacketDecision::Icmpv4EchoReply(icmp) = decision {
+                    trace.record(TraceEvent::Icmpv4EchoReplyRequested {
+                        egress,
+                        source: crate::Ipv4Address::from_octets(icmp.local_ip),
+                        destination: crate::Ipv4Address::from_octets(icmp.requester_ip),
                     });
                 }
                 trace.record(TraceEvent::TxRequested { egress });
@@ -381,9 +447,7 @@ fn decide<T: TraceSink>(
 ) -> Result<PacketDecision, DropReason> {
     let ether_type = packet::read_u16(frame, 12).ok_or(EthernetHeaderTruncated)?;
     match ether_type {
-        IPV4_ETHERTYPE => {
-            decide_ipv4(frame, snapshot, ingress, resolution, trace).map(PacketDecision::Ipv4)
-        }
+        IPV4_ETHERTYPE => decide_ipv4(frame, snapshot, ingress, resolution, trace),
         ARP_ETHERTYPE => decide_arp(frame, snapshot, ingress, resolution, trace),
         _ => Err(UnsupportedEtherType),
     }
@@ -395,12 +459,19 @@ fn decide_ipv4<T: TraceSink>(
     ingress: IfId,
     resolution: &mut Option<(&mut ResolutionRuntime<'_>, MonotonicMillis)>,
     trace: &mut T,
-) -> Result<Ipv4RewriteDecision, DropReason> {
+) -> Result<PacketDecision, DropReason> {
     let ipv4 = validate_ipv4_frame(frame)?;
     trace.record(TraceEvent::Ipv4Validated {
         ingress,
         destination: ipv4.destination,
     });
+    let local = snapshot
+        .local_ipv4
+        .iter()
+        .any(|binding| binding.interface == ingress && binding.address == ipv4.destination);
+    if local {
+        return decide_local_ipv4(frame, snapshot, ingress, ipv4, trace);
+    }
     if ipv4.header_len > 20 {
         return Err(Ipv4OptionsUnsupported);
     }
@@ -477,7 +548,7 @@ fn decide_ipv4<T: TraceSink>(
         egress: route.egress(),
         neighbor_target: target,
     });
-    Ok(Ipv4RewriteDecision {
+    Ok(PacketDecision::Ipv4(Ipv4RewriteDecision {
         egress: route.egress(),
         source_mac: interface.mac.0,
         destination_mac: destination_mac.0,
@@ -487,7 +558,111 @@ fn decide_ipv4<T: TraceSink>(
         old_ttl_protocol: u16::from_be_bytes([ipv4.ttl, ipv4.protocol]),
         new_ttl_protocol: u16::from_be_bytes([ipv4.ttl - 1, ipv4.protocol]),
         old_checksum: ipv4.checksum,
-    })
+    }))
+}
+
+fn decide_local_ipv4<T: TraceSink>(
+    frame: &[u8],
+    snapshot: &ForwardingSnapshot<'_>,
+    ingress: IfId,
+    ipv4: packet::ValidatedIpv4,
+    trace: &mut T,
+) -> Result<PacketDecision, DropReason> {
+    if ipv4.header_len > 20 {
+        return Err(Ipv4OptionsUnsupported);
+    }
+    if ipv4.protocol != 1 {
+        return Ok(PacketDecision::ConsumeIpv4Local);
+    }
+
+    let flags_fragment =
+        packet::read_u16(frame, ipv4.header_offset + 6).ok_or(Ipv4HeaderLengthExceedsPacket)?;
+    if flags_fragment & 0x3fff != 0 {
+        return Err(Icmpv4FragmentUnsupported);
+    }
+
+    let icmp_offset = ipv4
+        .header_offset
+        .checked_add(ipv4.header_len)
+        .ok_or(Ipv4TotalLengthExceedsPacket)?;
+    let icmp_end = ipv4
+        .header_offset
+        .checked_add(ipv4.total_len)
+        .ok_or(Ipv4TotalLengthExceedsPacket)?;
+    let icmp = frame
+        .get(icmp_offset..icmp_end)
+        .ok_or(Ipv4TotalLengthExceedsPacket)?;
+    if icmp.len() < 4 {
+        return Err(Icmpv4HeaderTruncated);
+    }
+    if icmp[0] != 8 {
+        if crate::internet_checksum(icmp) != 0 {
+            return Err(Icmpv4ChecksumInvalid);
+        }
+        return Ok(PacketDecision::ConsumeIpv4Local);
+    }
+    if icmp[1] != 0 {
+        return Err(Icmpv4EchoCodeInvalid);
+    }
+    if icmp.len() < 8 {
+        return Err(Icmpv4EchoHeaderTruncated);
+    }
+    if crate::internet_checksum(icmp) != 0 {
+        return Err(Icmpv4ChecksumInvalid);
+    }
+
+    let interface = snapshot
+        .interfaces
+        .iter()
+        .find(|item| item.id == ingress)
+        .ok_or(InterfaceMiss)?;
+    if !sender_is_host(snapshot, ingress, ipv4.source)
+        || snapshot
+            .local_ipv4
+            .iter()
+            .any(|binding| binding.interface == ingress && binding.address == ipv4.source)
+    {
+        return Err(Icmpv4SourceNotUnicast);
+    }
+    let requester_mac: [u8; 6] = frame
+        .get(6..12)
+        .ok_or(EthernetHeaderTruncated)?
+        .try_into()
+        .map_err(|_| EthernetHeaderTruncated)?;
+    if requester_mac == [0; 6] || requester_mac[0] & 1 != 0 {
+        return Err(Icmpv4EthernetSourceInvalid);
+    }
+    if frame.get(0..6) != Some(interface.mac.0.as_slice()) {
+        return Err(Icmpv4EthernetDestinationNotLocal);
+    }
+    let old_icmp_checksum =
+        packet::read_u16(frame, icmp_offset + 2).ok_or(Icmpv4HeaderTruncated)?;
+    let ipv4_id =
+        packet::read_u16(frame, ipv4.header_offset + 4).ok_or(Ipv4HeaderLengthExceedsPacket)?;
+    let ipv4_checksum = rfc1624_update(
+        ipv4.checksum,
+        u16::from_be_bytes([ipv4.ttl, ipv4.protocol]),
+        u16::from_be_bytes([64, ipv4.protocol]),
+    );
+    let ipv4_checksum = rfc1624_update(ipv4_checksum, ipv4_id, 0);
+    let ipv4_checksum = rfc1624_update(ipv4_checksum, flags_fragment, 0x4000);
+    let icmp_checksum = rfc1624_update(old_icmp_checksum, 0x0800, 0x0000);
+    trace.record(TraceEvent::Icmpv4EchoRequestValidated {
+        ingress,
+        source: ipv4.source,
+        destination: ipv4.destination,
+    });
+    Ok(PacketDecision::Icmpv4EchoReply(Icmpv4EchoReplyDecision {
+        egress: ingress,
+        local_mac: interface.mac.0,
+        requester_mac,
+        local_ip: ipv4.destination.octets(),
+        requester_ip: ipv4.source.octets(),
+        ipv4_checksum,
+        icmp_checksum,
+        icmp_offset,
+        icmp_end,
+    }))
 }
 
 fn decide_arp<T: TraceSink>(
@@ -584,7 +759,7 @@ fn decide_arp<T: TraceSink>(
         });
     }
     if arp.opcode == ArpOpcode::Reply || !target_local {
-        return Ok(PacketDecision::Consume(disposition));
+        return Ok(PacketDecision::ConsumeArp(disposition));
     }
     let interface = snapshot
         .interfaces
@@ -623,7 +798,10 @@ fn apply_decision(frame: &mut [u8], decision: PacketDecision) -> Result<(), Drop
     match decision {
         PacketDecision::Ipv4(ipv4) => apply_ipv4_rewrite(frame, ipv4),
         PacketDecision::ArpReply(arp) => apply_arp_reply(frame, arp),
-        PacketDecision::Consume(_) => unreachable!("consume decisions are never rewritten"),
+        PacketDecision::Icmpv4EchoReply(icmp) => apply_icmpv4_echo_reply(frame, icmp),
+        PacketDecision::ConsumeArp(_) | PacketDecision::ConsumeIpv4Local => {
+            unreachable!("consume decisions are never rewritten")
+        }
     }
 }
 
@@ -663,6 +841,34 @@ fn apply_arp_reply(frame: &mut [u8], decision: ArpReplyDecision) -> Result<(), D
     Ok(())
 }
 
+fn apply_icmpv4_echo_reply(
+    frame: &mut [u8],
+    decision: Icmpv4EchoReplyDecision,
+) -> Result<(), DropReason> {
+    if frame.get(0..12).is_none()
+        || frame.get(14..34).is_none()
+        || frame.get(decision.icmp_offset..decision.icmp_end).is_none()
+        || frame
+            .get(decision.icmp_offset..decision.icmp_offset + 4)
+            .is_none()
+    {
+        return Err(Ipv4TotalLengthExceedsPacket);
+    }
+
+    frame[0..6].copy_from_slice(&decision.requester_mac);
+    frame[6..12].copy_from_slice(&decision.local_mac);
+    frame[18..20].copy_from_slice(&0_u16.to_be_bytes());
+    frame[20..22].copy_from_slice(&0x4000_u16.to_be_bytes());
+    frame[22] = 64;
+    frame[24..26].copy_from_slice(&decision.ipv4_checksum.to_be_bytes());
+    frame[26..30].copy_from_slice(&decision.local_ip);
+    frame[30..34].copy_from_slice(&decision.requester_ip);
+    frame[decision.icmp_offset] = 0;
+    frame[decision.icmp_offset + 2..decision.icmp_offset + 4]
+        .copy_from_slice(&decision.icmp_checksum.to_be_bytes());
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::DropReason;
@@ -695,6 +901,14 @@ mod tests {
             (23, "ARP_SENDER_HARDWARE_ZERO"),
             (24, "ARP_SENDER_HARDWARE_BROADCAST"),
             (25, "ARP_SENDER_HARDWARE_MULTICAST"),
+            (26, "ICMPV4_HEADER_TRUNCATED"),
+            (27, "ICMPV4_ECHO_HEADER_TRUNCATED"),
+            (28, "ICMPV4_CHECKSUM_INVALID"),
+            (29, "ICMPV4_ECHO_CODE_INVALID"),
+            (30, "ICMPV4_FRAGMENT_UNSUPPORTED"),
+            (31, "ICMPV4_SOURCE_NOT_UNICAST"),
+            (32, "ICMPV4_ETHERNET_SOURCE_INVALID"),
+            (33, "ICMPV4_ETHERNET_DESTINATION_NOT_LOCAL"),
         ];
         let actual = [
             DropReason::EthernetHeaderTruncated,
@@ -722,6 +936,14 @@ mod tests {
             DropReason::ArpSenderHardwareZero,
             DropReason::ArpSenderHardwareBroadcast,
             DropReason::ArpSenderHardwareMulticast,
+            DropReason::Icmpv4HeaderTruncated,
+            DropReason::Icmpv4EchoHeaderTruncated,
+            DropReason::Icmpv4ChecksumInvalid,
+            DropReason::Icmpv4EchoCodeInvalid,
+            DropReason::Icmpv4FragmentUnsupported,
+            DropReason::Icmpv4SourceNotUnicast,
+            DropReason::Icmpv4EthernetSourceInvalid,
+            DropReason::Icmpv4EthernetDestinationNotLocal,
         ];
         for (reason, &(discriminant, code)) in actual.iter().zip(&expected) {
             assert_eq!(*reason as u16, discriminant);

--- a/crates/core/src/forwarding.rs
+++ b/crates/core/src/forwarding.rs
@@ -43,7 +43,6 @@ pub enum DropReason {
     Icmpv4SourceNotUnicast = 31,
     Icmpv4EthernetSourceInvalid = 32,
     Icmpv4EthernetDestinationNotLocal = 33,
-    Icmpv4ReservedFlagSet = 34,
 }
 
 use DropReason::*;
@@ -85,7 +84,6 @@ impl DropReason {
             Icmpv4SourceNotUnicast => "ICMPV4_SOURCE_NOT_UNICAST",
             Icmpv4EthernetSourceInvalid => "ICMPV4_ETHERNET_SOURCE_INVALID",
             Icmpv4EthernetDestinationNotLocal => "ICMPV4_ETHERNET_DESTINATION_NOT_LOCAL",
-            Icmpv4ReservedFlagSet => "ICMPV4_RESERVED_FLAG_SET",
         }
     }
 }
@@ -630,9 +628,6 @@ fn decide_local_ipv4<T: TraceSink>(
 
     let flags_fragment =
         packet::read_u16(frame, ipv4.header_offset + 6).ok_or(Ipv4HeaderLengthExceedsPacket)?;
-    if flags_fragment & 0x8000 != 0 {
-        return Err(Icmpv4ReservedFlagSet);
-    }
     if flags_fragment & 0x3fff != 0 {
         return Err(Icmpv4FragmentUnsupported);
     }
@@ -966,7 +961,6 @@ mod tests {
             (31, "ICMPV4_SOURCE_NOT_UNICAST"),
             (32, "ICMPV4_ETHERNET_SOURCE_INVALID"),
             (33, "ICMPV4_ETHERNET_DESTINATION_NOT_LOCAL"),
-            (34, "ICMPV4_RESERVED_FLAG_SET"),
         ];
         let actual = [
             DropReason::EthernetHeaderTruncated,
@@ -1002,7 +996,6 @@ mod tests {
             DropReason::Icmpv4SourceNotUnicast,
             DropReason::Icmpv4EthernetSourceInvalid,
             DropReason::Icmpv4EthernetDestinationNotLocal,
-            DropReason::Icmpv4ReservedFlagSet,
         ];
         for (reason, &(discriminant, code)) in actual.iter().zip(&expected) {
             assert_eq!(*reason as u16, discriminant);

--- a/crates/core/src/forwarding.rs
+++ b/crates/core/src/forwarding.rs
@@ -43,6 +43,7 @@ pub enum DropReason {
     Icmpv4SourceNotUnicast = 31,
     Icmpv4EthernetSourceInvalid = 32,
     Icmpv4EthernetDestinationNotLocal = 33,
+    Icmpv4ReservedFlagSet = 34,
 }
 
 use DropReason::*;
@@ -84,6 +85,7 @@ impl DropReason {
             Icmpv4SourceNotUnicast => "ICMPV4_SOURCE_NOT_UNICAST",
             Icmpv4EthernetSourceInvalid => "ICMPV4_ETHERNET_SOURCE_INVALID",
             Icmpv4EthernetDestinationNotLocal => "ICMPV4_ETHERNET_DESTINATION_NOT_LOCAL",
+            Icmpv4ReservedFlagSet => "ICMPV4_RESERVED_FLAG_SET",
         }
     }
 }
@@ -100,12 +102,44 @@ pub enum SnapshotError {
     LocalIpv4BindingUnspecified,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Ipv4OriginPolicy {
+    default_ttl: u8,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum Ipv4OriginPolicyError {
+    DefaultTtlZero,
+}
+
+impl Ipv4OriginPolicy {
+    pub const fn new(default_ttl: u8) -> Result<Self, Ipv4OriginPolicyError> {
+        if default_ttl == 0 {
+            return Err(Ipv4OriginPolicyError::DefaultTtlZero);
+        }
+        Ok(Self { default_ttl })
+    }
+
+    #[must_use]
+    pub const fn default_ttl(self) -> u8 {
+        self.default_ttl
+    }
+}
+
+impl Default for Ipv4OriginPolicy {
+    fn default() -> Self {
+        Self { default_ttl: 64 }
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct ForwardingSnapshot<'a> {
     routes: &'a [Route],
     interfaces: &'a [Interface],
     neighbors: &'a [Neighbor],
     local_ipv4: &'a [LocalIpv4Binding],
+    ipv4_origin: Ipv4OriginPolicy,
 }
 
 impl<'a> ForwardingSnapshot<'a> {
@@ -114,6 +148,22 @@ impl<'a> ForwardingSnapshot<'a> {
         interfaces: &'a [Interface],
         neighbors: &'a [Neighbor],
         local_ipv4: &'a [LocalIpv4Binding],
+    ) -> Result<Self, SnapshotError> {
+        Self::with_ipv4_origin_policy(
+            routes,
+            interfaces,
+            neighbors,
+            local_ipv4,
+            Ipv4OriginPolicy::default(),
+        )
+    }
+
+    pub fn with_ipv4_origin_policy(
+        routes: &'a [Route],
+        interfaces: &'a [Interface],
+        neighbors: &'a [Neighbor],
+        local_ipv4: &'a [LocalIpv4Binding],
+        ipv4_origin: Ipv4OriginPolicy,
     ) -> Result<Self, SnapshotError> {
         for (index, route) in routes.iter().enumerate() {
             if routes[..index].iter().any(|candidate| {
@@ -170,11 +220,13 @@ impl<'a> ForwardingSnapshot<'a> {
             interfaces,
             neighbors,
             local_ipv4,
+            ipv4_origin,
         })
     }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum TraceEvent {
     Ipv4Validated {
         ingress: IfId,
@@ -295,6 +347,7 @@ struct Icmpv4EchoReplyDecision {
     requester_ip: [u8; 4],
     ipv4_checksum: u16,
     icmp_checksum: u16,
+    reply_ttl: u8,
     icmp_offset: usize,
     icmp_end: usize,
 }
@@ -577,6 +630,9 @@ fn decide_local_ipv4<T: TraceSink>(
 
     let flags_fragment =
         packet::read_u16(frame, ipv4.header_offset + 6).ok_or(Ipv4HeaderLengthExceedsPacket)?;
+    if flags_fragment & 0x8000 != 0 {
+        return Err(Icmpv4ReservedFlagSet);
+    }
     if flags_fragment & 0x3fff != 0 {
         return Err(Icmpv4FragmentUnsupported);
     }
@@ -642,7 +698,7 @@ fn decide_local_ipv4<T: TraceSink>(
     let ipv4_checksum = rfc1624_update(
         ipv4.checksum,
         u16::from_be_bytes([ipv4.ttl, ipv4.protocol]),
-        u16::from_be_bytes([64, ipv4.protocol]),
+        u16::from_be_bytes([snapshot.ipv4_origin.default_ttl(), ipv4.protocol]),
     );
     let ipv4_checksum = rfc1624_update(ipv4_checksum, ipv4_id, 0);
     let ipv4_checksum = rfc1624_update(ipv4_checksum, flags_fragment, 0x4000);
@@ -660,6 +716,7 @@ fn decide_local_ipv4<T: TraceSink>(
         requester_ip: ipv4.source.octets(),
         ipv4_checksum,
         icmp_checksum,
+        reply_ttl: snapshot.ipv4_origin.default_ttl(),
         icmp_offset,
         icmp_end,
     }))
@@ -859,7 +916,7 @@ fn apply_icmpv4_echo_reply(
     frame[6..12].copy_from_slice(&decision.local_mac);
     frame[18..20].copy_from_slice(&0_u16.to_be_bytes());
     frame[20..22].copy_from_slice(&0x4000_u16.to_be_bytes());
-    frame[22] = 64;
+    frame[22] = decision.reply_ttl;
     frame[24..26].copy_from_slice(&decision.ipv4_checksum.to_be_bytes());
     frame[26..30].copy_from_slice(&decision.local_ip);
     frame[30..34].copy_from_slice(&decision.requester_ip);
@@ -909,6 +966,7 @@ mod tests {
             (31, "ICMPV4_SOURCE_NOT_UNICAST"),
             (32, "ICMPV4_ETHERNET_SOURCE_INVALID"),
             (33, "ICMPV4_ETHERNET_DESTINATION_NOT_LOCAL"),
+            (34, "ICMPV4_RESERVED_FLAG_SET"),
         ];
         let actual = [
             DropReason::EthernetHeaderTruncated,
@@ -944,6 +1002,7 @@ mod tests {
             DropReason::Icmpv4SourceNotUnicast,
             DropReason::Icmpv4EthernetSourceInvalid,
             DropReason::Icmpv4EthernetDestinationNotLocal,
+            DropReason::Icmpv4ReservedFlagSet,
         ];
         for (reason, &(discriminant, code)) in actual.iter().zip(&expected) {
             assert_eq!(*reason as u16, discriminant);

--- a/crates/core/src/io.rs
+++ b/crates/core/src/io.rs
@@ -46,6 +46,9 @@ pub enum SlotCompletion {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ConsumeReason {
     ArpControl,
+    /// Valid local IPv4 traffic that this deliberately small control plane
+    /// does not implement. It must not fall through to router forwarding.
+    Ipv4LocalUnsupported,
 }
 
 /// A core-owned, worker-local RAII lease.

--- a/crates/core/src/io.rs
+++ b/crates/core/src/io.rs
@@ -44,6 +44,7 @@ pub enum SlotCompletion {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum ConsumeReason {
     ArpControl,
     /// Valid local IPv4 traffic that this deliberately small control plane

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -12,7 +12,7 @@ mod route;
 pub use checksum::{internet_checksum, ipv4_header_checksum, rfc1624_update};
 pub use forwarding::{
     forward_batch, forward_batch_with_resolution, BatchReport, DropReason, ForwardingSnapshot,
-    NoTrace, SnapshotError, TraceEvent, TraceSink,
+    Ipv4OriginPolicy, Ipv4OriginPolicyError, NoTrace, SnapshotError, TraceEvent, TraceSink,
 };
 pub use generated::{
     GeneratedAllocationError, GeneratedBatchCompletion, GeneratedPacketBatch, GeneratedPacketIo,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -9,7 +9,7 @@ mod packet;
 mod resolution;
 mod route;
 
-pub use checksum::{ipv4_header_checksum, rfc1624_update};
+pub use checksum::{internet_checksum, ipv4_header_checksum, rfc1624_update};
 pub use forwarding::{
     forward_batch, forward_batch_with_resolution, BatchReport, DropReason, ForwardingSnapshot,
     NoTrace, SnapshotError, TraceEvent, TraceSink,

--- a/crates/io-sim/tests/icmpv4.rs
+++ b/crates/io-sim/tests/icmpv4.rs
@@ -1,0 +1,526 @@
+use ruster_core::{
+    forward_batch, internet_checksum, ipv4_header_checksum, BatchCompletion, ConsumeReason,
+    DropReason, ForwardingSnapshot, IfId, Interface, Ipv4Address, LocalIpv4Binding, MacAddress,
+    Neighbor, NoTrace, PacketBatch, PacketLease, PacketSlot, Route, SlotCompletion, TraceEvent,
+};
+use ruster_io_sim::{RecycleCause, SimIo, VecTrace};
+
+const LAN: IfId = IfId(1);
+const WAN: IfId = IfId(2);
+const LOCAL_MAC: MacAddress = MacAddress([0x02, 0, 0, 0, 0, 1]);
+const WAN_MAC: MacAddress = MacAddress([0x02, 0, 0, 0, 0, 2]);
+const PEER_MAC: [u8; 6] = [0x02, 0, 0, 0, 0, 0x20];
+const NEXT_HOP_MAC: MacAddress = MacAddress([0x02, 0, 0, 0, 0, 0x30]);
+const LOCAL_IP: Ipv4Address = Ipv4Address::from_octets([192, 0, 2, 1]);
+const PEER_IP: Ipv4Address = Ipv4Address::from_octets([192, 0, 2, 20]);
+
+fn interfaces() -> [Interface; 2] {
+    [
+        Interface {
+            id: LAN,
+            mac: LOCAL_MAC,
+        },
+        Interface {
+            id: WAN,
+            mac: WAN_MAC,
+        },
+    ]
+}
+
+fn local_binding(interface: IfId) -> LocalIpv4Binding {
+    LocalIpv4Binding {
+        interface,
+        address: LOCAL_IP,
+    }
+}
+
+fn local_snapshot<'a>(
+    interfaces: &'a [Interface],
+    bindings: &'a [LocalIpv4Binding],
+) -> ForwardingSnapshot<'a> {
+    ForwardingSnapshot::new(&[], interfaces, &[], bindings).unwrap()
+}
+
+fn routed_snapshot<'a>(
+    routes: &'a [Route],
+    interfaces: &'a [Interface],
+    neighbors: &'a [Neighbor],
+    bindings: &'a [LocalIpv4Binding],
+) -> ForwardingSnapshot<'a> {
+    ForwardingSnapshot::new(routes, interfaces, neighbors, bindings).unwrap()
+}
+
+fn icmp_message(kind: u8, code: u8, payload: &[u8]) -> Vec<u8> {
+    let mut message = vec![0_u8; 8 + payload.len()];
+    message[0] = kind;
+    message[1] = code;
+    message[4..6].copy_from_slice(&0x4567_u16.to_be_bytes());
+    message[6..8].copy_from_slice(&0x89ab_u16.to_be_bytes());
+    message[8..].copy_from_slice(payload);
+    let checksum = internet_checksum(&message);
+    message[2..4].copy_from_slice(&checksum.to_be_bytes());
+    message
+}
+
+fn ipv4_frame(
+    destination: Ipv4Address,
+    protocol: u8,
+    ttl: u8,
+    flags_fragment: u16,
+    body: &[u8],
+    padding: &[u8],
+) -> Vec<u8> {
+    let total_len = 20 + body.len();
+    let mut frame = vec![0_u8; 14 + total_len + padding.len()];
+    frame[0..6].copy_from_slice(&LOCAL_MAC.0);
+    frame[6..12].copy_from_slice(&PEER_MAC);
+    frame[12..14].copy_from_slice(&0x0800_u16.to_be_bytes());
+    frame[14] = 0x45;
+    frame[15] = 0xb8;
+    frame[16..18].copy_from_slice(&u16::try_from(total_len).unwrap().to_be_bytes());
+    frame[18..20].copy_from_slice(&0x1234_u16.to_be_bytes());
+    frame[20..22].copy_from_slice(&flags_fragment.to_be_bytes());
+    frame[22] = ttl;
+    frame[23] = protocol;
+    frame[26..30].copy_from_slice(&PEER_IP.octets());
+    frame[30..34].copy_from_slice(&destination.octets());
+    frame[34..34 + body.len()].copy_from_slice(body);
+    frame[34 + body.len()..].copy_from_slice(padding);
+    let checksum = ipv4_header_checksum(&frame[14..34]);
+    frame[24..26].copy_from_slice(&checksum.to_be_bytes());
+    frame
+}
+
+fn echo_request(payload: &[u8], padding: &[u8]) -> Vec<u8> {
+    ipv4_frame(LOCAL_IP, 1, 1, 0, &icmp_message(8, 0, payload), padding)
+}
+
+fn with_ipv4_source(mut frame: Vec<u8>, source: Ipv4Address) -> Vec<u8> {
+    frame[26..30].copy_from_slice(&source.octets());
+    frame[24..26].fill(0);
+    let checksum = ipv4_header_checksum(&frame[14..34]);
+    frame[24..26].copy_from_slice(&checksum.to_be_bytes());
+    frame
+}
+
+fn assert_drop_atomic(frame: Vec<u8>, snapshot: &ForwardingSnapshot<'_>, expected: DropReason) {
+    let original = frame.clone();
+    let mut io = SimIo::new();
+    io.inject(LAN, frame);
+    let report = io.run_once(1, snapshot, &mut NoTrace).unwrap();
+    assert_eq!(report.received, 1);
+    assert_eq!(report.tx_requested, 0);
+    assert_eq!(report.dropped, 1);
+    assert_eq!(report.consumed, 0);
+    let recycled = io.pop_recycled().unwrap();
+    assert_eq!(recycled.cause, RecycleCause::Forwarding(expected));
+    assert_eq!(recycled.bytes, original, "drop must be byte-atomic");
+}
+
+#[test]
+fn local_echo_reply_is_in_place_exact_and_traced() {
+    let interfaces = interfaces();
+    let bindings = [local_binding(LAN)];
+    let snapshot = local_snapshot(&interfaces, &bindings);
+    let padding = [0xde, 0xad, 0xbe, 0xef, 0x55];
+    let request = echo_request(&[1, 2, 3, 4], &padding);
+    let allocation = request.as_ptr();
+    let mut io = SimIo::new();
+    io.inject(LAN, request);
+    let mut trace = VecTrace::default();
+
+    let report = io.run_once(1, &snapshot, &mut trace).unwrap();
+
+    assert_eq!(report.received, 1);
+    assert_eq!(report.tx_requested, 1);
+    assert_eq!(report.dropped, 0);
+    assert_eq!(report.consumed, 0);
+    assert_eq!(
+        report.completion,
+        BatchCompletion {
+            tx_requested: 1,
+            tx_accepted: 1,
+            tx_rejected: 0,
+            recycled: 0,
+            error: None,
+        }
+    );
+    let reply = io.pop_tx().unwrap();
+    assert_eq!(
+        reply.bytes.as_ptr(),
+        allocation,
+        "RX allocation must be reused"
+    );
+    assert_eq!(reply.ingress, LAN);
+    assert_eq!(reply.egress, LAN);
+    assert_eq!(&reply.bytes[0..6], &PEER_MAC);
+    assert_eq!(&reply.bytes[6..12], &LOCAL_MAC.0);
+    assert_eq!(reply.bytes[15], 0xb8, "DSCP/ECN is preserved");
+    assert_eq!(&reply.bytes[18..20], &[0, 0], "atomic reply ID is zero");
+    assert_eq!(&reply.bytes[20..22], &0x4000_u16.to_be_bytes());
+    assert_eq!(reply.bytes[22], 64);
+    assert_eq!(reply.bytes[23], 1);
+    assert_eq!(&reply.bytes[26..30], &LOCAL_IP.octets());
+    assert_eq!(&reply.bytes[30..34], &PEER_IP.octets());
+    assert_eq!(ipv4_header_checksum(&reply.bytes[14..34]), 0);
+    assert_eq!(reply.bytes[34], 0);
+    assert_eq!(reply.bytes[35], 0);
+    assert_eq!(&reply.bytes[38..40], &0x4567_u16.to_be_bytes());
+    assert_eq!(&reply.bytes[40..42], &0x89ab_u16.to_be_bytes());
+    let total_len = usize::from(u16::from_be_bytes([reply.bytes[16], reply.bytes[17]]));
+    assert_eq!(internet_checksum(&reply.bytes[34..14 + total_len]), 0);
+    assert_eq!(&reply.bytes[42..46], &[1, 2, 3, 4]);
+    assert_eq!(&reply.bytes[14 + total_len..], &padding);
+    assert!(matches!(
+        trace.events(),
+        [
+            TraceEvent::Ipv4Validated {
+                ingress: LAN,
+                destination: LOCAL_IP
+            },
+            TraceEvent::Icmpv4EchoRequestValidated {
+                ingress: LAN,
+                source: PEER_IP,
+                destination: LOCAL_IP
+            },
+            TraceEvent::Icmpv4EchoReplyRequested {
+                egress: LAN,
+                source: LOCAL_IP,
+                destination: PEER_IP
+            },
+            TraceEvent::TxRequested { egress: LAN },
+            TraceEvent::BatchCompleted {
+                tx_accepted: 1,
+                tx_rejected: 0
+            }
+        ]
+    ));
+}
+
+#[test]
+fn odd_length_echo_payload_checksum_and_ttl_zero_are_supported() {
+    let interfaces = interfaces();
+    let bindings = [local_binding(LAN)];
+    let snapshot = local_snapshot(&interfaces, &bindings);
+    let mut request = echo_request(&[0xa5], &[]);
+    request[22] = 0;
+    request[24..26].fill(0);
+    let checksum = ipv4_header_checksum(&request[14..34]);
+    request[24..26].copy_from_slice(&checksum.to_be_bytes());
+    let mut io = SimIo::new();
+    io.inject(LAN, request);
+
+    let report = io.run_once(1, &snapshot, &mut NoTrace).unwrap();
+
+    assert_eq!(report.tx_requested, 1);
+    let reply = io.pop_tx().unwrap();
+    assert_eq!(reply.bytes[22], 64);
+    assert_eq!(reply.bytes[42], 0xa5);
+    assert_eq!(internet_checksum(&reply.bytes[34..43]), 0);
+}
+
+#[test]
+fn exact_icmp_truncation_boundaries_have_stable_atomic_reasons() {
+    let interfaces = interfaces();
+    let bindings = [local_binding(LAN)];
+    let snapshot = local_snapshot(&interfaces, &bindings);
+
+    for body_len in 0..4 {
+        assert_drop_atomic(
+            ipv4_frame(LOCAL_IP, 1, 64, 0, &vec![0; body_len], &[]),
+            &snapshot,
+            DropReason::Icmpv4HeaderTruncated,
+        );
+    }
+    for body_len in 4..8 {
+        let mut body = vec![0; body_len];
+        body[0] = 8;
+        assert_drop_atomic(
+            ipv4_frame(LOCAL_IP, 1, 64, 0, &body, &[]),
+            &snapshot,
+            DropReason::Icmpv4EchoHeaderTruncated,
+        );
+    }
+    let mut io = SimIo::new();
+    io.inject(LAN, echo_request(&[], &[]));
+    assert_eq!(
+        io.run_once(1, &snapshot, &mut NoTrace)
+            .unwrap()
+            .tx_requested,
+        1
+    );
+}
+
+#[test]
+fn invalid_ipv4_or_icmp_checksum_and_nonzero_echo_code_are_atomic() {
+    let interfaces = interfaces();
+    let bindings = [local_binding(LAN)];
+    let snapshot = local_snapshot(&interfaces, &bindings);
+
+    let mut bad_ip = echo_request(&[1, 2], &[]);
+    bad_ip[24] ^= 1;
+    assert_drop_atomic(bad_ip, &snapshot, DropReason::Ipv4HeaderChecksumInvalid);
+
+    let mut bad_icmp = echo_request(&[1, 2], &[]);
+    bad_icmp[36] ^= 1;
+    assert_drop_atomic(bad_icmp, &snapshot, DropReason::Icmpv4ChecksumInvalid);
+
+    let bad_code = ipv4_frame(LOCAL_IP, 1, 64, 0, &icmp_message(8, 1, &[]), &[]);
+    assert_drop_atomic(bad_code, &snapshot, DropReason::Icmpv4EchoCodeInvalid);
+}
+
+#[test]
+fn local_echo_fragments_are_typed_atomic_drops() {
+    let interfaces = interfaces();
+    let bindings = [local_binding(LAN)];
+    let snapshot = local_snapshot(&interfaces, &bindings);
+    for flags_fragment in [0x2000, 0x0001, 0x6000] {
+        assert_drop_atomic(
+            ipv4_frame(
+                LOCAL_IP,
+                1,
+                64,
+                flags_fragment,
+                &icmp_message(8, 0, &[]),
+                &[],
+            ),
+            &snapshot,
+            DropReason::Icmpv4FragmentUnsupported,
+        );
+    }
+}
+
+#[test]
+fn invalid_echo_ipv4_sources_cannot_trigger_replies() {
+    let interfaces = interfaces();
+    let routes = [Route::new(Ipv4Address::from_octets([192, 0, 2, 0]), 24, LAN, None).unwrap()];
+    let bindings = [local_binding(LAN)];
+    let snapshot = routed_snapshot(&routes, &interfaces, &[], &bindings);
+    let invalid_sources = [
+        Ipv4Address::from_octets([0, 0, 0, 1]),
+        Ipv4Address::from_octets([127, 0, 0, 1]),
+        Ipv4Address::from_octets([224, 0, 0, 1]),
+        Ipv4Address::from_octets([240, 0, 0, 1]),
+        Ipv4Address::from_octets([255, 255, 255, 255]),
+        Ipv4Address::from_octets([192, 0, 2, 0]),
+        Ipv4Address::from_octets([192, 0, 2, 255]),
+        LOCAL_IP,
+    ];
+
+    for source in invalid_sources {
+        assert_drop_atomic(
+            with_ipv4_source(echo_request(&[], &[]), source),
+            &snapshot,
+            DropReason::Icmpv4SourceNotUnicast,
+        );
+    }
+}
+
+#[test]
+fn echo_requires_unicast_source_mac_and_exact_local_destination_mac() {
+    let interfaces = interfaces();
+    let bindings = [local_binding(LAN)];
+    let snapshot = local_snapshot(&interfaces, &bindings);
+
+    for source in [[0; 6], [0xff; 6], [0x01, 0, 0, 0, 0, 1]] {
+        let mut frame = echo_request(&[], &[]);
+        frame[6..12].copy_from_slice(&source);
+        assert_drop_atomic(frame, &snapshot, DropReason::Icmpv4EthernetSourceInvalid);
+    }
+
+    for destination in [[0xff; 6], [0x01, 0, 0, 0, 0, 1], [0x02, 0, 0, 0, 0, 9]] {
+        let mut frame = echo_request(&[], &[]);
+        frame[0..6].copy_from_slice(&destination);
+        assert_drop_atomic(
+            frame,
+            &snapshot,
+            DropReason::Icmpv4EthernetDestinationNotLocal,
+        );
+    }
+}
+
+#[test]
+fn local_address_matching_is_strictly_ingress_scoped() {
+    let interfaces = interfaces();
+    let routes = [Route::new(LOCAL_IP, 32, LAN, None).unwrap()];
+    let neighbors = [Neighbor {
+        interface: LAN,
+        target: LOCAL_IP,
+        mac: NEXT_HOP_MAC,
+    }];
+    let bindings = [local_binding(WAN)];
+    let snapshot = routed_snapshot(&routes, &interfaces, &neighbors, &bindings);
+    let mut io = SimIo::new();
+    io.inject(
+        LAN,
+        ipv4_frame(LOCAL_IP, 1, 64, 0, &icmp_message(8, 0, &[1]), &[]),
+    );
+
+    let report = io.run_once(1, &snapshot, &mut NoTrace).unwrap();
+
+    assert_eq!(report.tx_requested, 1);
+    let forwarded = io.pop_tx().unwrap();
+    assert_eq!(forwarded.egress, LAN);
+    assert_eq!(&forwarded.bytes[0..6], &NEXT_HOP_MAC.0);
+    assert_eq!(&forwarded.bytes[6..12], &LOCAL_MAC.0);
+    assert_eq!(forwarded.bytes[22], 63);
+    assert_eq!(forwarded.bytes[34], 8, "nonlocal ICMP is not intercepted");
+}
+
+#[test]
+fn valid_unsupported_local_traffic_is_consumed_without_routing() {
+    let interfaces = interfaces();
+    let bindings = [local_binding(LAN)];
+    let snapshot = local_snapshot(&interfaces, &bindings);
+    let udp = ipv4_frame(LOCAL_IP, 17, 64, 0, &[0; 8], &[]);
+    let unreachable = ipv4_frame(LOCAL_IP, 1, 64, 0, &icmp_message(3, 0, &[]), &[]);
+    let originals = [udp.clone(), unreachable.clone()];
+    let mut io = SimIo::new();
+    io.inject(LAN, udp);
+    io.inject(LAN, unreachable);
+    let mut trace = VecTrace::default();
+
+    let report = io.run_once(2, &snapshot, &mut trace).unwrap();
+
+    assert_eq!(report.received, 2);
+    assert_eq!(report.tx_requested, 0);
+    assert_eq!(report.dropped, 0);
+    assert_eq!(report.consumed, 2);
+    assert_eq!(
+        report.completion,
+        BatchCompletion {
+            tx_requested: 0,
+            tx_accepted: 0,
+            tx_rejected: 0,
+            recycled: 2,
+            error: None,
+        }
+    );
+    for original in originals {
+        let recycled = io.pop_recycled().unwrap();
+        assert_eq!(
+            recycled.cause,
+            RecycleCause::Consumed(ConsumeReason::Ipv4LocalUnsupported)
+        );
+        assert_eq!(recycled.bytes, original);
+    }
+    assert!(matches!(
+        trace.events(),
+        [
+            TraceEvent::Ipv4Validated {
+                ingress: LAN,
+                destination: LOCAL_IP
+            },
+            TraceEvent::Ipv4LocalConsumed {
+                ingress: LAN,
+                reason: ConsumeReason::Ipv4LocalUnsupported
+            },
+            TraceEvent::Ipv4Validated {
+                ingress: LAN,
+                destination: LOCAL_IP
+            },
+            TraceEvent::Ipv4LocalConsumed {
+                ingress: LAN,
+                reason: ConsumeReason::Ipv4LocalUnsupported
+            },
+            TraceEvent::BatchCompleted {
+                tx_accepted: 0,
+                tx_rejected: 0
+            }
+        ]
+    ));
+}
+
+#[test]
+fn malformed_unsupported_local_icmp_checksum_is_dropped() {
+    let interfaces = interfaces();
+    let bindings = [local_binding(LAN)];
+    let snapshot = local_snapshot(&interfaces, &bindings);
+    let mut frame = ipv4_frame(LOCAL_IP, 1, 64, 0, &icmp_message(3, 0, &[]), &[]);
+    frame[36] ^= 1;
+    assert_drop_atomic(frame, &snapshot, DropReason::Icmpv4ChecksumInvalid);
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RejectError {
+    RingFull,
+}
+
+struct RejectBatch {
+    packet: Option<Vec<u8>>,
+}
+
+struct RejectSlot {
+    bytes: Vec<u8>,
+}
+
+impl PacketSlot for RejectSlot {
+    fn ingress(&self) -> IfId {
+        LAN
+    }
+
+    fn bytes_mut(&mut self) -> &mut [u8] {
+        &mut self.bytes
+    }
+
+    fn complete(self, completion: SlotCompletion) {
+        assert_eq!(completion, SlotCompletion::Transmit(LAN));
+        assert_eq!(self.bytes[34], 0);
+        assert_eq!(internet_checksum(&self.bytes[34..]), 0);
+    }
+}
+
+impl PacketBatch for RejectBatch {
+    type Error = RejectError;
+    type Slot<'a> = RejectSlot;
+
+    fn next_packet(&mut self) -> Option<PacketLease<Self::Slot<'_>>> {
+        self.packet
+            .take()
+            .map(|bytes| PacketLease::new(RejectSlot { bytes }))
+    }
+
+    fn finish(self) -> BatchCompletion<Self::Error> {
+        BatchCompletion {
+            tx_requested: 1,
+            tx_accepted: 0,
+            tx_rejected: 1,
+            recycled: 0,
+            error: Some(RejectError::RingFull),
+        }
+    }
+}
+
+#[test]
+fn echo_partial_backend_rejection_preserves_lifecycle_and_trace() {
+    let interfaces = interfaces();
+    let bindings = [local_binding(LAN)];
+    let snapshot = local_snapshot(&interfaces, &bindings);
+    let batch = RejectBatch {
+        packet: Some(echo_request(&[1, 2], &[])),
+    };
+    let mut trace = VecTrace::default();
+
+    let report = forward_batch(batch, &snapshot, &mut trace);
+
+    assert_eq!(report.received, 1);
+    assert_eq!(report.tx_requested, 1);
+    assert_eq!(report.dropped, 0);
+    assert_eq!(report.consumed, 0);
+    assert_eq!(report.completion.tx_accepted, 0);
+    assert_eq!(report.completion.tx_rejected, 1);
+    assert_eq!(report.completion.error, Some(RejectError::RingFull));
+    assert!(matches!(
+        trace.events(),
+        [
+            TraceEvent::Ipv4Validated { .. },
+            TraceEvent::Icmpv4EchoRequestValidated { .. },
+            TraceEvent::Icmpv4EchoReplyRequested { egress: LAN, .. },
+            TraceEvent::TxRequested { egress: LAN },
+            TraceEvent::BatchCompleted {
+                tx_accepted: 0,
+                tx_rejected: 1
+            }
+        ]
+    ));
+}

--- a/crates/io-sim/tests/icmpv4.rs
+++ b/crates/io-sim/tests/icmpv4.rs
@@ -1,7 +1,10 @@
 use ruster_core::{
-    forward_batch, internet_checksum, ipv4_header_checksum, BatchCompletion, ConsumeReason,
-    DropReason, ForwardingSnapshot, IfId, Interface, Ipv4Address, LocalIpv4Binding, MacAddress,
-    Neighbor, NoTrace, PacketBatch, PacketLease, PacketSlot, Route, SlotCompletion, TraceEvent,
+    execute_one_arp_request, forward_batch, forward_batch_with_resolution, internet_checksum,
+    ipv4_header_checksum, BatchCompletion, ConsumeReason, DropReason, DynamicNeighborSlot,
+    ForwardingSnapshot, IfId, Interface, Ipv4Address, Ipv4OriginPolicy, Ipv4OriginPolicyError,
+    LocalIpv4Binding, MacAddress, MonotonicMillis, Neighbor, NoGeneratedTrace, NoTrace,
+    PacketBatch, PacketIo, PacketLease, PacketSlot, ResolutionActionSlot, ResolutionPolicy,
+    ResolutionRuntime, ResolutionStateSlot, Route, SlotCompletion, TraceEvent,
 };
 use ruster_io_sim::{RecycleCause, SimIo, VecTrace};
 
@@ -93,6 +96,33 @@ fn ipv4_frame(
 
 fn echo_request(payload: &[u8], padding: &[u8]) -> Vec<u8> {
     ipv4_frame(LOCAL_IP, 1, 1, 0, &icmp_message(8, 0, payload), padding)
+}
+
+fn echo_request_with_options() -> Vec<u8> {
+    let mut frame = echo_request(&[1, 2], &[]);
+    frame.splice(34..34, [1, 1, 0, 0]);
+    frame[14] = 0x46;
+    let total_len = u16::from_be_bytes([frame[16], frame[17]]) + 4;
+    frame[16..18].copy_from_slice(&total_len.to_be_bytes());
+    frame[24..26].fill(0);
+    let checksum = ipv4_header_checksum(&frame[14..38]);
+    frame[24..26].copy_from_slice(&checksum.to_be_bytes());
+    frame
+}
+
+fn arp_reply(sender: Ipv4Address, sender_mac: MacAddress) -> Vec<u8> {
+    let mut frame = vec![0_u8; 60];
+    frame[0..6].copy_from_slice(&LOCAL_MAC.0);
+    frame[6..12].copy_from_slice(&sender_mac.0);
+    frame[12..14].copy_from_slice(&0x0806_u16.to_be_bytes());
+    frame[14..16].copy_from_slice(&1_u16.to_be_bytes());
+    frame[16..18].copy_from_slice(&0x0800_u16.to_be_bytes());
+    frame[18..22].copy_from_slice(&[6, 4, 0, 2]);
+    frame[22..28].copy_from_slice(&sender_mac.0);
+    frame[28..32].copy_from_slice(&sender.octets());
+    frame[32..38].copy_from_slice(&LOCAL_MAC.0);
+    frame[38..42].copy_from_slice(&LOCAL_IP.octets());
+    frame
 }
 
 fn with_ipv4_source(mut frame: Vec<u8>, source: Ipv4Address) -> Vec<u8> {
@@ -220,6 +250,49 @@ fn odd_length_echo_payload_checksum_and_ttl_zero_are_supported() {
 }
 
 #[test]
+fn configured_origin_ttl_is_validated_and_used_for_echo_reply() {
+    assert_eq!(
+        Ipv4OriginPolicy::new(0),
+        Err(Ipv4OriginPolicyError::DefaultTtlZero)
+    );
+    assert_eq!(Ipv4OriginPolicy::default().default_ttl(), 64);
+    let interfaces = interfaces();
+    let bindings = [local_binding(LAN)];
+    let snapshot = ForwardingSnapshot::with_ipv4_origin_policy(
+        &[],
+        &interfaces,
+        &[],
+        &bindings,
+        Ipv4OriginPolicy::new(37).unwrap(),
+    )
+    .unwrap();
+    let mut io = SimIo::new();
+    io.inject(LAN, echo_request(&[], &[]));
+
+    assert_eq!(
+        io.run_once(1, &snapshot, &mut NoTrace)
+            .unwrap()
+            .tx_requested,
+        1
+    );
+    let reply = io.pop_tx().unwrap();
+    assert_eq!(reply.bytes[22], 37);
+    assert_eq!(ipv4_header_checksum(&reply.bytes[14..34]), 0);
+}
+
+#[test]
+fn local_echo_with_ipv4_options_is_an_atomic_documented_deviation() {
+    let interfaces = interfaces();
+    let bindings = [local_binding(LAN)];
+    let snapshot = local_snapshot(&interfaces, &bindings);
+    assert_drop_atomic(
+        echo_request_with_options(),
+        &snapshot,
+        DropReason::Ipv4OptionsUnsupported,
+    );
+}
+
+#[test]
 fn exact_icmp_truncation_boundaries_have_stable_atomic_reasons() {
     let interfaces = interfaces();
     let bindings = [local_binding(LAN)];
@@ -288,6 +361,18 @@ fn local_echo_fragments_are_typed_atomic_drops() {
             DropReason::Icmpv4FragmentUnsupported,
         );
     }
+}
+
+#[test]
+fn local_echo_reserved_flag_is_typed_atomic_drop() {
+    let interfaces = interfaces();
+    let bindings = [local_binding(LAN)];
+    let snapshot = local_snapshot(&interfaces, &bindings);
+    assert_drop_atomic(
+        ipv4_frame(LOCAL_IP, 1, 64, 0x8000, &icmp_message(8, 0, &[]), &[]),
+        &snapshot,
+        DropReason::Icmpv4ReservedFlagSet,
+    );
 }
 
 #[test]
@@ -429,6 +514,122 @@ fn valid_unsupported_local_traffic_is_consumed_without_routing() {
             }
         ]
     ));
+}
+
+#[test]
+fn local_echo_and_consume_leave_resolution_runtime_untouched() {
+    let interfaces = interfaces();
+    let routes = [Route::new(Ipv4Address::from_octets([192, 0, 2, 0]), 24, LAN, None).unwrap()];
+    let bindings = [local_binding(LAN)];
+    let snapshot = routed_snapshot(&routes, &interfaces, &[], &bindings);
+    let first = Ipv4Address::from_octets([192, 0, 2, 21]);
+    let second = Ipv4Address::from_octets([192, 0, 2, 22]);
+    let third = Ipv4Address::from_octets([192, 0, 2, 23]);
+    let learned = Ipv4Address::from_octets([192, 0, 2, 24]);
+    let mut states = [ResolutionStateSlot::EMPTY; 3];
+    let mut actions = [ResolutionActionSlot::EMPTY; 3];
+    let mut cache = [DynamicNeighborSlot::EMPTY; 1];
+    let mut runtime = ResolutionRuntime::with_dynamic_neighbors(
+        ResolutionPolicy::new(1_000, 2_000).unwrap(),
+        &mut states,
+        &mut actions,
+        &mut cache,
+    );
+    let mut io = SimIo::new();
+
+    io.inject(LAN, arp_reply(learned, NEXT_HOP_MAC));
+    let batch = io.receive(1).unwrap();
+    forward_batch_with_resolution(
+        batch,
+        &snapshot,
+        &mut runtime,
+        MonotonicMillis(100),
+        &mut NoTrace,
+    );
+    io.pop_recycled();
+    for target in [first, second] {
+        io.inject(LAN, ipv4_frame(target, 17, 64, 0, &[0; 8], &[]));
+    }
+    let batch = io.receive(2).unwrap();
+    forward_batch_with_resolution(
+        batch,
+        &snapshot,
+        &mut runtime,
+        MonotonicMillis(100),
+        &mut NoTrace,
+    );
+    io.pop_recycled();
+    io.pop_recycled();
+    let counters_before = runtime.counters();
+    assert_eq!(runtime.dynamic_neighbor_count(), 1);
+    assert_eq!(runtime.pending_actions(), 2);
+
+    io.inject(LAN, echo_request(&[], &[]));
+    io.inject(LAN, ipv4_frame(LOCAL_IP, 17, 64, 0, &[0; 8], &[]));
+    let batch = io.receive(2).unwrap();
+    let local = forward_batch_with_resolution(
+        batch,
+        &snapshot,
+        &mut runtime,
+        MonotonicMillis(200),
+        &mut NoTrace,
+    );
+
+    assert_eq!(
+        (
+            local.tx_requested,
+            local.consumed,
+            local.dropped,
+            runtime.dynamic_neighbor_count(),
+            runtime.pending_actions(),
+            runtime.counters()
+        ),
+        (1, 1, 0, 1, 2, counters_before)
+    );
+    io.pop_tx();
+    io.pop_recycled();
+
+    io.inject(LAN, ipv4_frame(learned, 17, 64, 0, &[0; 8], &[]));
+    let batch = io.receive(1).unwrap();
+    let learned_forward = forward_batch_with_resolution(
+        batch,
+        &snapshot,
+        &mut runtime,
+        MonotonicMillis(150),
+        &mut NoTrace,
+    );
+    assert_eq!(learned_forward.tx_requested, 1);
+    assert_eq!(&io.pop_tx().unwrap().bytes[0..6], &NEXT_HOP_MAC.0);
+    assert_eq!(runtime.dynamic_neighbor_count(), 1);
+    assert_eq!(runtime.pending_actions(), 2);
+    assert_eq!(runtime.counters(), counters_before);
+
+    io.inject(LAN, ipv4_frame(third, 17, 64, 0, &[0; 8], &[]));
+    let batch = io.receive(1).unwrap();
+    let after = forward_batch_with_resolution(
+        batch,
+        &snapshot,
+        &mut runtime,
+        MonotonicMillis(150),
+        &mut NoTrace,
+    );
+    assert_eq!(after.dropped, 1);
+    assert_eq!(runtime.pending_actions(), 3);
+    assert_eq!(runtime.counters().clock_regressions, 0);
+
+    for expected in [first, second, third] {
+        let generated = execute_one_arp_request(
+            &mut io,
+            &mut runtime,
+            MonotonicMillis(150),
+            &mut NoGeneratedTrace,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(generated.action.target_ip, expected);
+    }
+    assert_eq!(runtime.pending_actions(), 0);
+    assert_eq!(runtime.dynamic_neighbor_count(), 1);
 }
 
 #[test]

--- a/crates/io-sim/tests/icmpv4.rs
+++ b/crates/io-sim/tests/icmpv4.rs
@@ -364,15 +364,26 @@ fn local_echo_fragments_are_typed_atomic_drops() {
 }
 
 #[test]
-fn local_echo_reserved_flag_is_typed_atomic_drop() {
+fn local_echo_reserved_flag_is_accepted_and_cleared_in_reply() {
     let interfaces = interfaces();
     let bindings = [local_binding(LAN)];
     let snapshot = local_snapshot(&interfaces, &bindings);
-    assert_drop_atomic(
+    let mut io = SimIo::new();
+    io.inject(
+        LAN,
         ipv4_frame(LOCAL_IP, 1, 64, 0x8000, &icmp_message(8, 0, &[]), &[]),
-        &snapshot,
-        DropReason::Icmpv4ReservedFlagSet,
     );
+
+    let report = io.run_once(1, &snapshot, &mut NoTrace).unwrap();
+
+    assert_eq!(report.tx_requested, 1);
+    assert_eq!(report.dropped, 0);
+    let reply = io.pop_tx().unwrap();
+    assert_eq!(&reply.bytes[18..20], &[0, 0]);
+    assert_eq!(&reply.bytes[20..22], &0x4000_u16.to_be_bytes());
+    assert_eq!(ipv4_header_checksum(&reply.bytes[14..34]), 0);
+    assert_eq!(reply.bytes[34], 0);
+    assert_eq!(internet_checksum(&reply.bytes[34..42]), 0);
 }
 
 #[test]

--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -186,8 +186,9 @@ behaviorであり、RFC準拠のupper-layer deliveryを主張しません。RFC 
 deliveryはdeferredです。
 
 IPv4 reassemblyはRFC 1122 §3.2.1.4に対する現時点の明示deviationです。local ICMP fragmentは
-reassemblyや応答を行わず`Icmpv4FragmentUnsupported`でdropします。IPv4 reserved flagはRFC 791
-のzero requirementに従い、fragmentとは区別した`Icmpv4ReservedFlagSet`でbyte不変dropします。
+reassemblyや応答を行わず`Icmpv4FragmentUnsupported`でdropします。RFC 1812 §4.2.2.3に従い、
+reserved IPv4 flagがnonzeroであることだけを理由に受信packetをdropしません。valid local Echo
+として処理し、originated atomic Replyではreserved bitをclearしてDFだけを設定します。
 IPv4 options付きlocal Echoもbyte不変dropします。RFC 1122 §3.2.2.6とRFC 1812 §4.3.3.6が
 source-route reversalをMUST、Record Route/Timestamp更新をSHOULDとしているため、これは
 明示deviationです。Timestamp等の他ICMP query、options処理、ICMP error生成（TTL

--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -34,8 +34,9 @@ simの`BatchCompletion.recycled`にはdropとconsumeの両方を数えます。�
 ```text
 Ethernet validate
   ├─ IPv4 version/IHL/Total Length/header checksum validate
-  │    → options policy → TTL check → LPM → typed neighbor/interface lookup
-  │    → TTL/checksum/MAC rewrite → commit
+  │    ├─ ingress local binding → ICMPv4 validate/admission → Echo Reply or local consume
+  │    └─ options policy → TTL check → LPM → typed neighbor/interface lookup
+  │         → TTL/checksum/MAC rewrite → commit
   └─ Ethernet/IPv4 ARP profile validate → ingress local target lookup
        → RFC 826 merge → Request localならin-place Reply、それ以外はlocal consume
 ```
@@ -134,6 +135,47 @@ v0.2 bootstrapはEthernet II上のIPv4 datagramを転送します。
 - fragment offsetやMFに関係なく、このsliceはL4を参照しないためdatagramとして転送する。
 - TTLは1減算し、header checksumはRFC 1624のincremental updateで更新する。
 
+## ICMPv4 local control scope
+
+RFC 792とRFC 1122 §3.2.2.6に従い、ingress `IfId`にbindingされたdestinationだけを
+router自身へのlocal deliveryとして扱います。同じaddressが別interfaceにbindingされて
+いてもlocal扱いせず、通常のL3 forwardingへ進めます。local判定はIPv4
+version/IHL/Total Length/header checksum検証後、forwardingのTTL expiry/LPM/ARPより前です。
+したがってTTL 0/1のlocal Echo Requestにも応答し、reply TTLは受信値から独立した64です。
+
+実装profileはIHL=5、protocol=1、unfragmented、Echo Request Type 8/Code 0です。ICMP message
+範囲はIPv4 Total Lengthで閉じ、Internet checksumはodd lengthを含む全messageで検証します。
+全validation/admissionを終えるまでbytesを変更しません。replyは同じRX leaseをingressへ
+commitし、次だけを書き換えます。
+
+- Ethernet destinationをrequest source、sourceをingress Interface MACにする。
+- IPv4 source/destinationを交換し、TTLを64にする。
+- RFC 6864のatomic datagram profileとしてID=0、DF=1、MF=0、fragment offset=0にする。
+- ICMP Typeを0へ変え、IPv4/ICMP checksumをRFC 1624で正しく更新する。
+
+DSCP/ECN、Total Length、protocol、ICMP identifier/sequence/data、IPv4 Total Length後の
+link paddingは保存します。IPv4 address pairの交換はone's-complement sumを変えないため、
+IPv4 checksum更新対象はTTL/protocol word、ID、flags/offsetです。
+
+RFC 1812 §§4.2.2.11, 4.2.3.1, 5.3.7に基づくnarrow anti-amplification profileとして、
+replyを生成する前に次を要求します。
+
+- IPv4 sourceがingress上のunicast hostである。`0/8`、`127/8`、multicast、`240/4`、
+  limited/directed broadcast、connected network address、ingress-local claimはdropする。
+- Ethernet sourceがnonzero unicastである。
+- Ethernet destinationがingress Interface MACと完全一致する。broadcast、multicast、
+  foreign unicast宛てのIP-local frameには応答しない。
+
+validなlocal non-ICMPと、checksum-validなunfragmented non-Echo ICMPは
+`Ipv4LocalUnsupported`でbyte不変consumeし、routing/ARPへ流しません。malformed/truncated
+Echo、invalid checksum、nonzero Echo code、source/L2 admission failureはstable
+`DropReason`でbyte不変dropします。
+
+IPv4 reassemblyはRFC 1122 §3.2.1.4に対する現時点の明示deviationです。local ICMP fragmentは
+reassemblyや応答を行わず`Icmpv4FragmentUnsupported`でdropします。Timestamp等の他ICMP query、
+IPv4 options、ICMP error生成（TTL Exceeded/Destination Unreachableを含む）、rate limit、
+PMTU処理はdeferredです。
+
 ## ARP control scope
 
 Ethernet II / IPv4 profile（HTYPE 1、PTYPE 0x0800、HLEN 6、PLEN 4）のRequest/Replyを
@@ -170,8 +212,9 @@ local SPAを名乗り、そのlocal addressをTPAにしたrequestも通常reques
 追加policyでdropしないことを優先した明示deviationです。
 
 eager cache scan/flush、timer retry、unresolved packet hold queue、gratuitous ARP生成、
-ARP Probe/Announcement生成、proxy ARP、VLAN、Address Conflict Detection、ICMP生成、
-NAT、firewall、config parser、pcap、AF_XDP、DPDK、binary、thread、benchmarkはこの
+ARP Probe/Announcement生成、proxy ARP、VLAN、Address Conflict Detection、Echo Reply以外の
+ICMP生成、NAT、firewall、config parser、pcap、AF_XDP、DPDK、binary、thread、
+benchmarkはこの
 sliceのscope外です。
 
 ## backend progression

--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -48,6 +48,9 @@ packet terminal traceの`TxRequested`はcommit後に記録しますが、wire送
 ordered outcome/tokenを導入するまではpacket単位accepted traceを主張しません。
 `TraceSink`はpanic禁止の契約で、productionの`NoTrace`はallocationしません。
 `VecTrace`はsim crateだけに存在します。
+`DropReason`は既存の`repr(u16)` discriminantを変更せず末尾へ追加します。
+`TraceEvent`と`ConsumeReason`は今後のprotocol追加をsource-compatibleにするため
+`#[non_exhaustive]`です。downstreamはwildcard armを持つ必要があります。
 
 route、interface、neighbor、local IPv4 bindingはvalidated immutable snapshotのborrowed
 sliceです。routeはcanonical prefixだけを受け付け、lookupは`/0`と`/32`を含む
@@ -137,11 +140,18 @@ v0.2 bootstrapはEthernet II上のIPv4 datagramを転送します。
 
 ## ICMPv4 local control scope
 
-RFC 792とRFC 1122 §3.2.2.6に従い、ingress `IfId`にbindingされたdestinationだけを
-router自身へのlocal deliveryとして扱います。同じaddressが別interfaceにbindingされて
-いてもlocal扱いせず、通常のL3 forwardingへ進めます。local判定はIPv4
+RFC 792とRFC 1122 §3.2.2.6のEcho responder要件を実装します。ただしlocal deliveryは
+RFC 1122 §3.3.4.2のStrong ES modelと同様に、ingress `IfId`にbindingされたdestinationだけを
+router自身宛てとして扱います。同じaddressが別interfaceにbindingされていてもlocal扱いせず、
+通常のL3 forwardingへ進めます。これはrouterのいずれかのinterface address宛てをlocal
+deliveryとするRFC 1812 §5.2.3からのbootstrap deviationです。local判定はIPv4
 version/IHL/Total Length/header checksum検証後、forwardingのTTL expiry/LPM/ARPより前です。
-したがってTTL 0/1のlocal Echo Requestにも応答し、reply TTLは受信値から独立した64です。
+したがってTTL 0/1のlocal Echo Requestにも応答します。
+
+originated IPv4のTTLはRFC 1122 §3.2.1.7とRFC 1812 §4.2.2.9に従うvalidated
+`Ipv4OriginPolicy`から取得します。`ForwardingSnapshot::new`はdefault 64を使い、
+`with_ipv4_origin_policy`で1..=255を選べます。zeroはsnapshotへ到達する前にrejectします。
+Echo Reply TTLは受信値から独立したこのpolicy値です。
 
 実装profileはIHL=5、protocol=1、unfragmented、Echo Request Type 8/Code 0です。ICMP message
 範囲はIPv4 Total Lengthで閉じ、Internet checksumはodd lengthを含む全messageで検証します。
@@ -149,7 +159,7 @@ version/IHL/Total Length/header checksum検証後、forwardingのTTL expiry/LPM/
 commitし、次だけを書き換えます。
 
 - Ethernet destinationをrequest source、sourceをingress Interface MACにする。
-- IPv4 source/destinationを交換し、TTLを64にする。
+- IPv4 source/destinationを交換し、TTLをvalidated origin policy値にする。
 - RFC 6864のatomic datagram profileとしてID=0、DF=1、MF=0、fragment offset=0にする。
 - ICMP Typeを0へ変え、IPv4/ICMP checksumをRFC 1624で正しく更新する。
 
@@ -157,24 +167,31 @@ DSCP/ECN、Total Length、protocol、ICMP identifier/sequence/data、IPv4 Total 
 link paddingは保存します。IPv4 address pairの交換はone's-complement sumを変えないため、
 IPv4 checksum更新対象はTTL/protocol word、ID、flags/offsetです。
 
-RFC 1812 §§4.2.2.11, 4.2.3.1, 5.3.7に基づくnarrow anti-amplification profileとして、
-replyを生成する前に次を要求します。
+RFC 1812 §§4.2.2.11, 5.3.4, 5.3.7とlocal anti-amplification policyに基づくnarrow
+admission profileとして、replyを生成する前に次を要求します。
 
 - IPv4 sourceがingress上のunicast hostである。`0/8`、`127/8`、multicast、`240/4`、
   limited/directed broadcast、connected network address、ingress-local claimはdropする。
-- Ethernet sourceがnonzero unicastである。
-- Ethernet destinationがingress Interface MACと完全一致する。broadcast、multicast、
-  foreign unicast宛てのIP-local frameには応答しない。
+- RFC 1812 §5.3.4のlink broadcast/multicast抑止に加え、local policyとしてEthernet
+  sourceがnonzero unicastである。
+- local policyとしてEthernet destinationがingress Interface MACと完全一致する。
+  broadcast、multicast、foreign unicast宛てのIP-local frameには応答しない。
 
 validなlocal non-ICMPと、checksum-validなunfragmented non-Echo ICMPは
 `Ipv4LocalUnsupported`でbyte不変consumeし、routing/ARPへ流しません。malformed/truncated
 Echo、invalid checksum、nonzero Echo code、source/L2 admission failureはstable
-`DropReason`でbyte不変dropします。
+`DropReason`でbyte不変dropします。このconsumeはpacket ownershipを確実に終端するarchitecture
+behaviorであり、RFC準拠のupper-layer deliveryを主張しません。RFC 1122 §3.2.2とRFC 1812
+§4.3.3が想定するEcho ReplyおよびICMP error/controlのICMP user interfaceはまだ存在せず、
+deliveryはdeferredです。
 
 IPv4 reassemblyはRFC 1122 §3.2.1.4に対する現時点の明示deviationです。local ICMP fragmentは
-reassemblyや応答を行わず`Icmpv4FragmentUnsupported`でdropします。Timestamp等の他ICMP query、
-IPv4 options、ICMP error生成（TTL Exceeded/Destination Unreachableを含む）、rate limit、
-PMTU処理はdeferredです。
+reassemblyや応答を行わず`Icmpv4FragmentUnsupported`でdropします。IPv4 reserved flagはRFC 791
+のzero requirementに従い、fragmentとは区別した`Icmpv4ReservedFlagSet`でbyte不変dropします。
+IPv4 options付きlocal Echoもbyte不変dropします。RFC 1122 §3.2.2.6とRFC 1812 §4.3.3.6が
+source-route reversalをMUST、Record Route/Timestamp更新をSHOULDとしているため、これは
+明示deviationです。Timestamp等の他ICMP query、options処理、ICMP error生成（TTL
+Exceeded/Destination Unreachableを含む）、rate limit、PMTU処理はdeferredです。
 
 ## ARP control scope
 

--- a/docs/requirements-v0.2.md
+++ b/docs/requirements-v0.2.md
@@ -39,7 +39,7 @@ Statusは`implemented`、`deferred`、`deviation`のいずれかです。test名
 | ICMP4-004 malformed Echo atomic drop | RFC 792, architecture contract | `invalid_ipv4_or_icmp_checksum_and_nonzero_echo_code_are_atomic` | implemented | invalid IPv4/ICMP checksumとnonzero codeはstable reasonでbyte不変drop |
 | ICMP4-005 exact ICMP/Echo minimum lengths | RFC 792 | `exact_icmp_truncation_boundaries_have_stable_atomic_reasons` | implemented | common header 4 bytes、Echo header 8 bytesの直前/境界を検証 |
 | ICMP4-006 local fragment reassembly | RFC 1122 §3.2.1.4 | `local_echo_fragments_are_typed_atomic_drops` | deviation | reassembly未実装のためMF/offset付きlocal ICMPをbyte不変dropし応答しない |
-| ICMP4-006A reserved IPv4 flag rejection | RFC 791 §3.1 | `local_echo_reserved_flag_is_typed_atomic_drop` | implemented | reserved flagをfragment reasonと区別してbyte不変drop |
+| ICMP4-006A reserved IPv4 flag handling | RFC 1812 §4.2.2.3 | `local_echo_reserved_flag_is_accepted_and_cleared_in_reply` | implemented | reserved bitだけでは受信dropせず、originated atomic ReplyではclearしてDFだけを設定 |
 | ICMP4-007 invalid IPv4 source reply suppression | RFC 1812 §§4.2.2.11, 5.3.7 | `invalid_echo_ipv4_sources_cannot_trigger_replies` | implemented | non-host、connected network/broadcast、ingress-local sourceへ応答しない |
 | ICMP4-008 exact L2 reply admission | RFC 1812 §5.3.4, local anti-amplification policy | `echo_requires_unicast_source_mac_and_exact_local_destination_mac` | implemented | link broadcast/multicastを抑止し、local policyでnonzero unicast sourceとexact local destination MACを要求 |
 | ICMP4-009 atomic reply IPv4 profile | RFC 6864, local deterministic policy | `local_echo_reply_is_in_place_exact_and_traced` | implemented | default TTL=64、ID=0、DF=1、MF/offset=0。DSCP/ECNとTotal Lengthは保存 |

--- a/docs/requirements-v0.2.md
+++ b/docs/requirements-v0.2.md
@@ -16,6 +16,7 @@ Statusは`implemented`、`deferred`、`deviation`のいずれかです。test名
 | IO-008 generated builder failure isolation | defensive backend boundary | `builder_failure_cancels_lease_and_retains_action` | implemented | exact-length契約違反bufferをcancelしactionを保持 |
 | IO-009 real generated backend | backend roadmap | — | deferred | AF_XDP/DPDK generated allocator/TXは未実装 |
 | IO-010 ARP control consume lifecycle/accounting | architecture contract | `mixed_reply_then_ipv4_uses_dynamic_mapping_in_same_batch` | implemented | `BatchReport`/`RecycleCause`でlogical consumeを区別。physical recycle countはdrop+consumeを含み、received=TX+drop+consume |
+| IO-011 local IPv4 consume lifecycle/accounting | architecture contract | `valid_unsupported_local_traffic_is_consumed_without_routing` | implemented | valid unsupported local deliveryをrouting/ARPへ流さずtyped consume |
 | ETH-001 Ethernet II framing | RFC 894 | `all_validation_and_decision_drops_are_granular_and_atomic` | implemented | 802.3 LLC/VLANはdeferred |
 | IP4-001 Version/IHL/Total Length validation | RFC 791 §3.1 | `all_validation_and_decision_drops_are_granular_and_atomic` | implemented | なし |
 | IP4-002 Total Length後のpadding無視 | RFC 791 §3.1 | `padding_is_ignored_but_preserved` | implemented | なし |
@@ -31,6 +32,18 @@ Statusは`implemented`、`deferred`、`deviation`のいずれかです。test名
 | FWD-006 snapshot integrity | architecture contract | `snapshot_constructor_rejects_all_broken_references_and_duplicates` | implemented | 公開前にvalidation |
 | FWD-007 unresolved trigger atomicity/request action | RFC 1122 §2.3.2.1 | `unresolved_neighbor_generates_broadcast_arp_request_and_recycles_trigger_atomically` | implemented | 元IPv4はbyte不変NeighborUnresolved、RX finish後にgenerated session |
 | FWD-008 unresolved packet hold/replay | RFC 1122 §2.3.2.2, RFC 1812 §3.3.2 | — | deferred | hold/replay未実装。最初のpacketは解決後も自動再送されない |
+| ICMP4-001 ingress-scoped local delivery | RFC 1122 §3.2.1.3 | `local_address_matching_is_strictly_ingress_scoped` | implemented | ingress IfIdとdestination addressの両方が一致したbindingだけlocal |
+| ICMP4-002 Echo Request/Reply in-place profile | RFC 792, RFC 1122 §3.2.2.6 | `local_echo_reply_is_in_place_exact_and_traced` | implemented | Type 8/Code 0を同じRX allocationでType 0へ変換しingress commit |
+| ICMP4-003 full/odd-length checksum and Total Length boundary | RFC 792, RFC 1071 | `odd_length_echo_payload_checksum_and_ttl_zero_are_supported` | implemented | ICMP全messageを検証しodd final octetとlink paddingを区別 |
+| ICMP4-004 malformed Echo atomic drop | RFC 792, architecture contract | `invalid_ipv4_or_icmp_checksum_and_nonzero_echo_code_are_atomic` | implemented | invalid IPv4/ICMP checksumとnonzero codeはstable reasonでbyte不変drop |
+| ICMP4-005 exact ICMP/Echo minimum lengths | RFC 792 | `exact_icmp_truncation_boundaries_have_stable_atomic_reasons` | implemented | common header 4 bytes、Echo header 8 bytesの直前/境界を検証 |
+| ICMP4-006 local fragment reassembly | RFC 1122 §3.2.1.4 | `local_echo_fragments_are_typed_atomic_drops` | deviation | reassembly未実装のためMF/offset付きlocal ICMPをbyte不変dropし応答しない |
+| ICMP4-007 invalid IPv4 source reply suppression | RFC 1812 §§4.2.2.11, 5.3.7 | `invalid_echo_ipv4_sources_cannot_trigger_replies` | implemented | non-host、connected network/broadcast、ingress-local sourceへ応答しない |
+| ICMP4-008 exact L2 reply admission | RFC 1812 §4.2.3.1, local anti-amplification policy | `echo_requires_unicast_source_mac_and_exact_local_destination_mac` | implemented | nonzero unicast source MACかつdestinationがingress MACと完全一致する場合だけ応答 |
+| ICMP4-009 atomic reply IPv4 profile | RFC 6864, local deterministic policy | `local_echo_reply_is_in_place_exact_and_traced` | implemented | TTL=64、ID=0、DF=1、MF/offset=0。DSCP/ECNとTotal Lengthは保存 |
+| ICMP4-010 unsupported local delivery consume | RFC 1122 §3.2.2 | `valid_unsupported_local_traffic_is_consumed_without_routing` | implemented | local non-ICMPとchecksum-valid non-Echo ICMPをbyte不変consume |
+| ICMP4-011 partial TX completion | architecture contract | `echo_partial_backend_rejection_preserves_lifecycle_and_trace` | implemented | requested/accepted/rejected/errorとterminal traceを保持 |
+| ICMP4-012 ICMP error generation and other queries | RFC 792, RFC 1122 §3.2.2 | — | deferred | TTL Exceeded、Destination Unreachable、Timestamp等は未実装 |
 | ARP-001 Ethernet/IPv4 Request/Reply profile validation | RFC 826, RFC 5494/IANA ARP Parameters | `arp_profile_validation_drops_are_granular_and_atomic` | implemented | HTYPE=1/PTYPE=0x0800/HLEN=6/PLEN=4、unknown opcodeはdrop |
 | ARP-002 local target in-place reply on ingress | RFC 826 | `arp_request_for_local_ipv4_replies_in_place_on_ingress` | implemented | 同じRX allocation、egress=ingress、wire fieldsを検証 |
 | ARP-003 probe reply with zero target protocol | RFC 5227 §2.5（Probe形式は§1.1/§2.1.1） | `arp_probe_for_local_ipv4_replies_with_zero_target_protocol` | implemented | SPA=0 requestにも通常reply |

--- a/docs/requirements-v0.2.md
+++ b/docs/requirements-v0.2.md
@@ -32,18 +32,23 @@ Statusは`implemented`、`deferred`、`deviation`のいずれかです。test名
 | FWD-006 snapshot integrity | architecture contract | `snapshot_constructor_rejects_all_broken_references_and_duplicates` | implemented | 公開前にvalidation |
 | FWD-007 unresolved trigger atomicity/request action | RFC 1122 §2.3.2.1 | `unresolved_neighbor_generates_broadcast_arp_request_and_recycles_trigger_atomically` | implemented | 元IPv4はbyte不変NeighborUnresolved、RX finish後にgenerated session |
 | FWD-008 unresolved packet hold/replay | RFC 1122 §2.3.2.2, RFC 1812 §3.3.2 | — | deferred | hold/replay未実装。最初のpacketは解決後も自動再送されない |
-| ICMP4-001 ingress-scoped local delivery | RFC 1122 §3.2.1.3 | `local_address_matching_is_strictly_ingress_scoped` | implemented | ingress IfIdとdestination addressの両方が一致したbindingだけlocal |
+| ICMP4-001 ingress-scoped local delivery | RFC 1122 §3.3.4.2, RFC 1812 §5.2.3 | `local_address_matching_is_strictly_ingress_scoped` | deviation | Strong ES同様のingress scopeを採用し、RFC 1812のrouter-wide local deliveryと異なる |
 | ICMP4-002 Echo Request/Reply in-place profile | RFC 792, RFC 1122 §3.2.2.6 | `local_echo_reply_is_in_place_exact_and_traced` | implemented | Type 8/Code 0を同じRX allocationでType 0へ変換しingress commit |
+| ICMP4-002A Echo with IPv4 options | RFC 1122 §3.2.2.6, RFC 1812 §4.3.3.6 | `local_echo_with_ipv4_options_is_an_atomic_documented_deviation` | deviation | source-route reversal MUSTとRR/Timestamp更新 SHOULDを未実装のためbyte不変drop |
 | ICMP4-003 full/odd-length checksum and Total Length boundary | RFC 792, RFC 1071 | `odd_length_echo_payload_checksum_and_ttl_zero_are_supported` | implemented | ICMP全messageを検証しodd final octetとlink paddingを区別 |
 | ICMP4-004 malformed Echo atomic drop | RFC 792, architecture contract | `invalid_ipv4_or_icmp_checksum_and_nonzero_echo_code_are_atomic` | implemented | invalid IPv4/ICMP checksumとnonzero codeはstable reasonでbyte不変drop |
 | ICMP4-005 exact ICMP/Echo minimum lengths | RFC 792 | `exact_icmp_truncation_boundaries_have_stable_atomic_reasons` | implemented | common header 4 bytes、Echo header 8 bytesの直前/境界を検証 |
 | ICMP4-006 local fragment reassembly | RFC 1122 §3.2.1.4 | `local_echo_fragments_are_typed_atomic_drops` | deviation | reassembly未実装のためMF/offset付きlocal ICMPをbyte不変dropし応答しない |
+| ICMP4-006A reserved IPv4 flag rejection | RFC 791 §3.1 | `local_echo_reserved_flag_is_typed_atomic_drop` | implemented | reserved flagをfragment reasonと区別してbyte不変drop |
 | ICMP4-007 invalid IPv4 source reply suppression | RFC 1812 §§4.2.2.11, 5.3.7 | `invalid_echo_ipv4_sources_cannot_trigger_replies` | implemented | non-host、connected network/broadcast、ingress-local sourceへ応答しない |
-| ICMP4-008 exact L2 reply admission | RFC 1812 §4.2.3.1, local anti-amplification policy | `echo_requires_unicast_source_mac_and_exact_local_destination_mac` | implemented | nonzero unicast source MACかつdestinationがingress MACと完全一致する場合だけ応答 |
-| ICMP4-009 atomic reply IPv4 profile | RFC 6864, local deterministic policy | `local_echo_reply_is_in_place_exact_and_traced` | implemented | TTL=64、ID=0、DF=1、MF/offset=0。DSCP/ECNとTotal Lengthは保存 |
-| ICMP4-010 unsupported local delivery consume | RFC 1122 §3.2.2 | `valid_unsupported_local_traffic_is_consumed_without_routing` | implemented | local non-ICMPとchecksum-valid non-Echo ICMPをbyte不変consume |
+| ICMP4-008 exact L2 reply admission | RFC 1812 §5.3.4, local anti-amplification policy | `echo_requires_unicast_source_mac_and_exact_local_destination_mac` | implemented | link broadcast/multicastを抑止し、local policyでnonzero unicast sourceとexact local destination MACを要求 |
+| ICMP4-009 atomic reply IPv4 profile | RFC 6864, local deterministic policy | `local_echo_reply_is_in_place_exact_and_traced` | implemented | default TTL=64、ID=0、DF=1、MF/offset=0。DSCP/ECNとTotal Lengthは保存 |
+| ICMP4-009A configurable originated TTL | RFC 1122 §3.2.1.7, RFC 1812 §4.2.2.9 | `configured_origin_ttl_is_validated_and_used_for_echo_reply` | implemented | `Ipv4OriginPolicy`はdefault 64、1..=255を許可しzeroをreject |
+| ICMP4-010 unsupported local consume lifecycle | architecture contract | `valid_unsupported_local_traffic_is_consumed_without_routing` | implemented | local non-ICMPとchecksum-valid non-Echo ICMPをbyte不変consumeしownershipを終端 |
+| ICMP4-010A ICMP user interface delivery | RFC 1122 §3.2.2, RFC 1812 §4.3.3 | — | deferred | Echo ReplyとICMP error/controlを渡すupper-layer interfaceは未実装 |
 | ICMP4-011 partial TX completion | architecture contract | `echo_partial_backend_rejection_preserves_lifecycle_and_trace` | implemented | requested/accepted/rejected/errorとterminal traceを保持 |
 | ICMP4-012 ICMP error generation and other queries | RFC 792, RFC 1122 §3.2.2 | — | deferred | TTL Exceeded、Destination Unreachable、Timestamp等は未実装 |
+| ICMP4-013 resolution isolation | architecture contract | `local_echo_and_consume_leave_resolution_runtime_untouched` | implemented | Echo/consumeはdynamic cache、pending state/action、FIFO/capacity、monotonic watermarkを変更しない |
 | ARP-001 Ethernet/IPv4 Request/Reply profile validation | RFC 826, RFC 5494/IANA ARP Parameters | `arp_profile_validation_drops_are_granular_and_atomic` | implemented | HTYPE=1/PTYPE=0x0800/HLEN=6/PLEN=4、unknown opcodeはdrop |
 | ARP-002 local target in-place reply on ingress | RFC 826 | `arp_request_for_local_ipv4_replies_in_place_on_ingress` | implemented | 同じRX allocation、egress=ingress、wire fieldsを検証 |
 | ARP-003 probe reply with zero target protocol | RFC 5227 §2.5（Probe形式は§1.1/§2.1.1） | `arp_probe_for_local_ipv4_replies_with_zero_target_protocol` | implemented | SPA=0 requestにも通常reply |


### PR DESCRIPTION
## Summary
- answer ingress-local ICMPv4 Echo Requests in place on the RX lease
- validate full odd-length ICMP checksums and exact IPv4 Total Length boundaries
- add validated configurable originated IPv4 TTL policy with default 64
- keep valid unsupported local delivery out of routing and ARP via typed consume

## Wire and safety profile
- swap Ethernet and IPv4 endpoints, preserve Echo data and link padding
- originate an RFC 6864 atomic reply with ID zero and DF set
- reject fragments, malformed Echo, invalid sources, and unsafe L2 admission atomically
- accept incoming reserved IPv4 flag as required and clear it in the originated reply
- preserve dynamic ARP cache, pending FIFO, counters, and monotonic watermark

## Standards ledger
- implement RFC 792 Echo format and RFC 1812 originated TTL behavior
- explicitly record ingress Strong ES scope, IPv4 options, and reassembly deviations
- defer ICMP user-interface delivery and generated error messages

## Verification
- 81 workspace tests passed
- 4 compile-fail doctests passed
- fmt, check, clippy with warnings denied, rustdoc with warnings denied passed
- requirements ledger and diff checks passed
- independent RFC/security and lifecycle reviews: Critical 0, High 0, Medium 0, Low 0