### PR TITLE
feat(core): add worker-local UDP NAT44

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ nonzero checksumとIPv4 checksumをRFC 1624でincremental更新します。
 
 idle TTLはdefault 300秒、minimum 120秒で、outbound TX requestだけがrefreshします。
 live stateをcapacity pressureでevictせず、snapshot/config mismatchはfail closedです。
+NAT runtimeへ到達した非退行時刻はdrop結果でもwatermarkへ反映し、expired/miss後の古い
+時刻によるmapping復活を許しません。outsideからinsideへのpublic DNATを通らない直通LPMも
+neighbor解決前にfail closedです。
 publication変更はvalidated configと`Nat44UdpRuntime::reconcile`による明示的な全state flushを
 要求します。fragment、hairpin、ICMP error translation/PMTU、TCP/ICMP query NAT、static
 forward、multi-public、port randomization/parity、full firewallはdeferredで、RFC 4787/

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ active treeは、そのコードを継承しないv0.2のゼロベース実装�
 - `ruster-core`: backend所有packetを借用し、Ethernet II / IPv4検証、LPM、
   TTL/checksum/MAC rewrite、local IPv4向けARP reply、static neighbor miss時の
   ARP Request生成action、fixed-capacity dynamic ARP cache、local ICMPv4 Echo
-  responder、ICMPv4 Time Exceeded / Destination Unreachable生成を扱う。
+  responder、ICMPv4 Time Exceeded / Destination Unreachable生成、opt-inの
+  single-domain UDP NAT44/NAPTを扱う。
 - `ruster-io-sim`: rootやNICなしでRX/generated TXのFIFO、budget、TX/drop、
   traceを決定的に検証する。
 
@@ -53,6 +54,21 @@ fixed-capacity worker-local FIFOとper-egress default 100ms timer limiterを共�
 staticまたはfresh dynamic neighborが無い場合はARPだけを開始し、今回のICMP actionは保持
 しません。generated outer IPv4は576 bytes以下、quoteは受信時IPv4 bytesを最大548 bytes
 所有し、link paddingを含みません。
+
+UDP NAT44は`forward_batch_with_nat44_udp`、またはgenerated ICMP errorも含む
+`forward_batch_with_nat44_udp_and_icmpv4_errors`を選んだworkerだけで有効です。一つの
+inside/outside/public IPv4とnonzero port poolを設定し、mappingとremote-address filter
+peerをcaller-backed固定配列で所有します。outboundはEndpoint-Independent Mapping、
+inboundは過去に送信したremote IPv4だけを許すAddress-Dependent Filteringです。
+IPv4 optionsなし、DF=1/MF=0/offset=0のatomic UDPだけを変換し、UDP checksum zeroを保存、
+nonzero checksumとIPv4 checksumをRFC 1624でincremental更新します。
+
+idle TTLはdefault 300秒、minimum 120秒で、outbound TX requestだけがrefreshします。
+live stateをcapacity pressureでevictせず、snapshot/config mismatchはfail closedです。
+publication変更はvalidated configと`Nat44UdpRuntime::reconcile`による明示的な全state flushを
+要求します。fragment、hairpin、ICMP error translation/PMTU、TCP/ICMP query NAT、static
+forward、multi-public、port randomization/parity、full firewallはdeferredで、RFC 4787/
+7857全体への準拠は主張しません。
 
 ## 開発
 

--- a/crates/core/src/forwarding.rs
+++ b/crates/core/src/forwarding.rs
@@ -1,10 +1,12 @@
+use crate::nat44::{Nat44UdpInboundPlan, Nat44UdpOutboundPlan, Nat44UdpPlanError};
 use crate::resolution::DynamicLookup;
 use crate::{
     packet, rfc1624_update, route, validate_arp, validate_ipv4_frame, ArpOpcode, ArpRequestAction,
     BatchCompletion, ConsumeReason, ControlDisposition, Icmpv4ErrorAction, Icmpv4ErrorDisposition,
     Icmpv4ErrorKind, Icmpv4ErrorRuntime, Icmpv4TimeExceededDisposition, IfId, Interface,
-    LocalIpv4Binding, MonotonicMillis, Neighbor, PacketBatch, ResolutionResult, ResolutionRuntime,
-    Route, ARP_ETHERTYPE, IPV4_ETHERTYPE,
+    LocalIpv4Binding, MonotonicMillis, Nat44UdpConfig, Nat44UdpDisposition, Nat44UdpRuntime,
+    Neighbor, PacketBatch, ResolutionResult, ResolutionRuntime, Route, ARP_ETHERTYPE,
+    IPV4_ETHERTYPE,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -44,6 +46,25 @@ pub enum DropReason {
     Icmpv4SourceNotUnicast = 31,
     Icmpv4EthernetSourceInvalid = 32,
     Icmpv4EthernetDestinationNotLocal = 33,
+    Nat44UdpRuntimeUnavailable = 34,
+    Nat44UdpConfigMismatch = 35,
+    Nat44UdpUnsupportedTransport = 36,
+    Nat44UdpHairpinUnsupported = 37,
+    Nat44UdpNonAtomicIpv4Unsupported = 38,
+    Nat44UdpHeaderTruncated = 39,
+    Nat44UdpLengthTooSmall = 40,
+    Nat44UdpLengthExceedsIpv4Payload = 41,
+    Nat44UdpSourcePortZero = 42,
+    Nat44UdpSourceForbidden = 43,
+    Nat44UdpReverseAuthorityMismatch = 44,
+    Nat44UdpMappingMiss = 45,
+    Nat44UdpFilterDenied = 46,
+    Nat44UdpMappingTableFull = 47,
+    Nat44UdpPeerTableFull = 48,
+    Nat44UdpPortExhausted = 49,
+    Nat44UdpClockRegression = 50,
+    Nat44UdpWrongIngress = 51,
+    Nat44UdpWrongEgress = 52,
 }
 
 use DropReason::*;
@@ -85,6 +106,25 @@ impl DropReason {
             Icmpv4SourceNotUnicast => "ICMPV4_SOURCE_NOT_UNICAST",
             Icmpv4EthernetSourceInvalid => "ICMPV4_ETHERNET_SOURCE_INVALID",
             Icmpv4EthernetDestinationNotLocal => "ICMPV4_ETHERNET_DESTINATION_NOT_LOCAL",
+            Nat44UdpRuntimeUnavailable => "NAT44_UDP_RUNTIME_UNAVAILABLE",
+            Nat44UdpConfigMismatch => "NAT44_UDP_CONFIG_MISMATCH",
+            Nat44UdpUnsupportedTransport => "NAT44_UDP_UNSUPPORTED_TRANSPORT",
+            Nat44UdpHairpinUnsupported => "NAT44_UDP_HAIRPIN_UNSUPPORTED",
+            Nat44UdpNonAtomicIpv4Unsupported => "NAT44_UDP_NON_ATOMIC_IPV4_UNSUPPORTED",
+            Nat44UdpHeaderTruncated => "NAT44_UDP_HEADER_TRUNCATED",
+            Nat44UdpLengthTooSmall => "NAT44_UDP_LENGTH_TOO_SMALL",
+            Nat44UdpLengthExceedsIpv4Payload => "NAT44_UDP_LENGTH_EXCEEDS_IPV4_PAYLOAD",
+            Nat44UdpSourcePortZero => "NAT44_UDP_SOURCE_PORT_ZERO",
+            Nat44UdpSourceForbidden => "NAT44_UDP_SOURCE_FORBIDDEN",
+            Nat44UdpReverseAuthorityMismatch => "NAT44_UDP_REVERSE_AUTHORITY_MISMATCH",
+            Nat44UdpMappingMiss => "NAT44_UDP_MAPPING_MISS",
+            Nat44UdpFilterDenied => "NAT44_UDP_FILTER_DENIED",
+            Nat44UdpMappingTableFull => "NAT44_UDP_MAPPING_TABLE_FULL",
+            Nat44UdpPeerTableFull => "NAT44_UDP_PEER_TABLE_FULL",
+            Nat44UdpPortExhausted => "NAT44_UDP_PORT_EXHAUSTED",
+            Nat44UdpClockRegression => "NAT44_UDP_CLOCK_REGRESSION",
+            Nat44UdpWrongIngress => "NAT44_UDP_WRONG_INGRESS",
+            Nat44UdpWrongEgress => "NAT44_UDP_WRONG_EGRESS",
         }
     }
 }
@@ -338,6 +378,10 @@ pub enum TraceEvent {
         source: crate::Ipv4Address,
         destination: crate::Ipv4Address,
     },
+    Nat44Udp {
+        ingress: IfId,
+        disposition: Nat44UdpDisposition,
+    },
     Dropped {
         ingress: IfId,
         reason: DropReason,
@@ -418,8 +462,32 @@ struct Icmpv4EchoReplyDecision {
 }
 
 #[derive(Clone, Copy)]
+enum Nat44UdpTransition {
+    Outbound(Nat44UdpOutboundPlan),
+    Inbound(Nat44UdpInboundPlan),
+}
+
+#[derive(Clone, Copy)]
+struct Nat44UdpRewriteDecision {
+    forwarding: Ipv4RewriteDecision,
+    address_offset: usize,
+    address_end: usize,
+    new_address: [u8; 4],
+    port_offset: usize,
+    port_end: usize,
+    new_port: u16,
+    udp_checksum_offset: usize,
+    udp_checksum_end: usize,
+    ipv4_checksum: u16,
+    udp_checksum: u16,
+    transition: Nat44UdpTransition,
+    disposition: Nat44UdpDisposition,
+}
+
+#[derive(Clone, Copy)]
 enum PacketDecision {
     Ipv4(Ipv4RewriteDecision),
+    Nat44Udp(Nat44UdpRewriteDecision),
     ArpReply(ArpReplyDecision),
     Icmpv4EchoReply(Icmpv4EchoReplyDecision),
     ConsumeArp(ControlDisposition),
@@ -430,6 +498,7 @@ impl PacketDecision {
     fn egress(self) -> IfId {
         match self {
             Self::Ipv4(decision) => decision.egress,
+            Self::Nat44Udp(decision) => decision.forwarding.egress,
             Self::ArpReply(decision) => decision.egress,
             Self::Icmpv4EchoReply(decision) => decision.egress,
             Self::ConsumeArp(_) | Self::ConsumeIpv4Local => {
@@ -448,7 +517,7 @@ where
     B: PacketBatch,
     T: TraceSink,
 {
-    forward_batch_inner(batch, snapshot, None, None, trace)
+    forward_batch_inner(batch, snapshot, None, None, None, None, trace)
 }
 
 /// Forwards RX packets and queues resolution actions without allocating TX
@@ -464,7 +533,15 @@ where
     B: PacketBatch,
     T: TraceSink,
 {
-    forward_batch_inner(batch, snapshot, Some((runtime, now)), None, trace)
+    forward_batch_inner(
+        batch,
+        snapshot,
+        Some((runtime, now)),
+        None,
+        None,
+        None,
+        trace,
+    )
 }
 
 /// Forwards RX packets while queueing ARP resolution and eligible ICMPv4 error
@@ -488,6 +565,71 @@ where
         snapshot,
         Some((resolution, now)),
         Some((icmpv4_errors, now)),
+        None,
+        None,
+        trace,
+    )
+}
+
+/// Runs the forwarding, ARP resolution, and one configured UDP NAPT domain as
+/// one ordered worker-local service.
+///
+/// Passing `None` for `nat44_udp` deliberately fails closed for packets that
+/// cross the configured inside/outside boundary. This lets a control plane
+/// publish configuration before runtime storage without leaking private
+/// addresses. Generated ARP execution remains a separate post-RX phase.
+pub fn forward_batch_with_nat44_udp<B, T>(
+    batch: B,
+    snapshot: &ForwardingSnapshot<'_>,
+    resolution: &mut ResolutionRuntime<'_>,
+    config: &Nat44UdpConfig,
+    nat44_udp: Option<&mut Nat44UdpRuntime<'_>>,
+    now: MonotonicMillis,
+    trace: &mut T,
+) -> BatchReport<B::Error>
+where
+    B: PacketBatch,
+    T: TraceSink,
+{
+    forward_batch_inner(
+        batch,
+        snapshot,
+        Some((resolution, now)),
+        None,
+        Some(config),
+        nat44_udp,
+        trace,
+    )
+}
+
+/// Runs the complete ARP-resolution, generated-ICMPv4-error, and UDP NAPT
+/// service composition in one ordered RX phase.
+///
+/// TTL expiry, route miss, and direct ARP failure capture happen before NAT
+/// mutation and therefore quote the original datagram. Generated packet
+/// execution still starts only after this RX function returns.
+#[allow(clippy::too_many_arguments)]
+pub fn forward_batch_with_nat44_udp_and_icmpv4_errors<B, T>(
+    batch: B,
+    snapshot: &ForwardingSnapshot<'_>,
+    resolution: &mut ResolutionRuntime<'_>,
+    icmpv4_errors: &mut Icmpv4ErrorRuntime<'_>,
+    config: &Nat44UdpConfig,
+    nat44_udp: Option<&mut Nat44UdpRuntime<'_>>,
+    now: MonotonicMillis,
+    trace: &mut T,
+) -> BatchReport<B::Error>
+where
+    B: PacketBatch,
+    T: TraceSink,
+{
+    forward_batch_inner(
+        batch,
+        snapshot,
+        Some((resolution, now)),
+        Some((icmpv4_errors, now)),
+        Some(config),
+        nat44_udp,
         trace,
     )
 }
@@ -497,6 +639,8 @@ fn forward_batch_inner<B, T>(
     snapshot: &ForwardingSnapshot<'_>,
     mut resolution: Option<(&mut ResolutionRuntime<'_>, MonotonicMillis)>,
     mut icmpv4_errors: Option<(&mut Icmpv4ErrorRuntime<'_>, MonotonicMillis)>,
+    nat44_udp_config: Option<&Nat44UdpConfig>,
+    mut nat44_udp: Option<&mut Nat44UdpRuntime<'_>>,
     trace: &mut T,
 ) -> BatchReport<B::Error>
 where
@@ -510,6 +654,7 @@ where
     while let Some(mut packet) = batch.next_packet() {
         received += 1;
         let ingress = packet.ingress();
+        let nat_now_ms = resolution.as_ref().map_or(0, |(_, now)| now.0);
         let result = {
             let frame = packet.bytes_mut();
             decide(
@@ -518,6 +663,8 @@ where
                 ingress,
                 &mut resolution,
                 &mut icmpv4_errors,
+                nat44_udp_config,
+                &mut nat44_udp,
                 trace,
             )
             .and_then(|decision| {
@@ -551,6 +698,23 @@ where
             }
             Ok(decision) => {
                 let egress = decision.egress();
+                if let PacketDecision::Nat44Udp(nat) = decision {
+                    let runtime = nat44_udp
+                        .as_deref_mut()
+                        .expect("NAT decision requires a bound runtime");
+                    match nat.transition {
+                        Nat44UdpTransition::Outbound(plan) => {
+                            runtime.commit_outbound(plan, nat_now_ms);
+                        }
+                        Nat44UdpTransition::Inbound(plan) => {
+                            runtime.commit_inbound(plan, nat_now_ms);
+                        }
+                    }
+                    trace.record(TraceEvent::Nat44Udp {
+                        ingress,
+                        disposition: nat.disposition,
+                    });
+                }
                 packet.commit(egress);
                 tx_requested += 1;
                 if let PacketDecision::ArpReply(arp) = decision {
@@ -590,28 +754,43 @@ where
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn decide<T: TraceSink>(
     frame: &[u8],
     snapshot: &ForwardingSnapshot<'_>,
     ingress: IfId,
     resolution: &mut Option<(&mut ResolutionRuntime<'_>, MonotonicMillis)>,
     icmpv4_errors: &mut Option<(&mut Icmpv4ErrorRuntime<'_>, MonotonicMillis)>,
+    nat44_udp_config: Option<&Nat44UdpConfig>,
+    nat44_udp: &mut Option<&mut Nat44UdpRuntime<'_>>,
     trace: &mut T,
 ) -> Result<PacketDecision, DropReason> {
     let ether_type = packet::read_u16(frame, 12).ok_or(EthernetHeaderTruncated)?;
     match ether_type {
-        IPV4_ETHERTYPE => decide_ipv4(frame, snapshot, ingress, resolution, icmpv4_errors, trace),
+        IPV4_ETHERTYPE => decide_ipv4(
+            frame,
+            snapshot,
+            ingress,
+            resolution,
+            icmpv4_errors,
+            nat44_udp_config,
+            nat44_udp,
+            trace,
+        ),
         ARP_ETHERTYPE => decide_arp(frame, snapshot, ingress, resolution, trace),
         _ => Err(UnsupportedEtherType),
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn decide_ipv4<T: TraceSink>(
     frame: &[u8],
     snapshot: &ForwardingSnapshot<'_>,
     ingress: IfId,
     resolution: &mut Option<(&mut ResolutionRuntime<'_>, MonotonicMillis)>,
     icmpv4_errors: &mut Option<(&mut Icmpv4ErrorRuntime<'_>, MonotonicMillis)>,
+    nat44_udp_config: Option<&Nat44UdpConfig>,
+    nat44_udp: &mut Option<&mut Nat44UdpRuntime<'_>>,
     trace: &mut T,
 ) -> Result<PacketDecision, DropReason> {
     let ipv4 = validate_ipv4_frame(frame)?;
@@ -619,6 +798,22 @@ fn decide_ipv4<T: TraceSink>(
         ingress,
         destination: ipv4.destination,
     });
+    if let Some(config) = nat44_udp_config {
+        if ingress == config.inside() && ipv4.destination == config.public_address() {
+            return nat44_udp_drop(nat44_udp, ingress, Nat44UdpHairpinUnsupported, trace);
+        }
+        if ipv4.destination == config.public_address() && ipv4.protocol == 17 {
+            if ipv4.header_len > 20 {
+                return nat44_udp_drop(nat44_udp, ingress, Ipv4OptionsUnsupported, trace);
+            }
+            if ingress != config.outside() {
+                return nat44_udp_drop(nat44_udp, ingress, Nat44UdpWrongIngress, trace);
+            }
+            return decide_nat44_udp_inbound(
+                frame, snapshot, ingress, ipv4, resolution, config, nat44_udp, trace,
+            );
+        }
+    }
     let local = snapshot
         .local_ipv4
         .iter()
@@ -762,7 +957,7 @@ fn decide_ipv4<T: TraceSink>(
         egress: route.egress(),
         neighbor_target: target,
     });
-    Ok(PacketDecision::Ipv4(Ipv4RewriteDecision {
+    let forwarding = Ipv4RewriteDecision {
         egress: route.egress(),
         source_mac: interface.mac.0,
         destination_mac: destination_mac.0,
@@ -772,7 +967,420 @@ fn decide_ipv4<T: TraceSink>(
         old_ttl_protocol: u16::from_be_bytes([ipv4.ttl, ipv4.protocol]),
         new_ttl_protocol: u16::from_be_bytes([ipv4.ttl - 1, ipv4.protocol]),
         old_checksum: ipv4.checksum,
+    };
+    if let Some(config) = nat44_udp_config {
+        if ingress == config.inside() && route.egress() == config.outside() {
+            return decide_nat44_udp_outbound(
+                frame,
+                snapshot,
+                ingress,
+                ipv4,
+                forwarding,
+                config,
+                nat44_udp,
+                resolution
+                    .as_ref()
+                    .map_or(MonotonicMillis(0), |(_, now)| *now),
+                trace,
+            );
+        }
+    }
+    Ok(PacketDecision::Ipv4(forwarding))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn decide_nat44_udp_outbound<T: TraceSink>(
+    frame: &[u8],
+    snapshot: &ForwardingSnapshot<'_>,
+    ingress: IfId,
+    ipv4: packet::ValidatedIpv4,
+    forwarding: Ipv4RewriteDecision,
+    config: &Nat44UdpConfig,
+    nat44_udp: &mut Option<&mut Nat44UdpRuntime<'_>>,
+    now: MonotonicMillis,
+    trace: &mut T,
+) -> Result<PacketDecision, DropReason> {
+    if ipv4.protocol != 17 {
+        return nat44_udp_drop(nat44_udp, ingress, Nat44UdpUnsupportedTransport, trace);
+    }
+    if let Err(reason) = validate_nat44_atomic(frame, ipv4) {
+        return nat44_udp_drop(nat44_udp, ingress, reason, trace);
+    }
+    let udp = match validate_nat44_udp(frame, ipv4) {
+        Ok(udp) => udp,
+        Err(reason) => return nat44_udp_drop(nat44_udp, ingress, reason, trace),
+    };
+    if udp.source_port == 0 {
+        return nat44_udp_drop(nat44_udp, ingress, Nat44UdpSourcePortZero, trace);
+    }
+    if !icmp_error_source_is_host(snapshot, ipv4.source)
+        || snapshot
+            .local_ipv4
+            .iter()
+            .any(|binding| binding.address == ipv4.source)
+        || ipv4.source == config.public_address()
+    {
+        return nat44_udp_drop(nat44_udp, ingress, Nat44UdpSourceForbidden, trace);
+    }
+    if route::lookup(snapshot.routes, ipv4.source)
+        .is_none_or(|reverse| reverse.egress() != config.inside())
+    {
+        return nat44_udp_drop(nat44_udp, ingress, Nat44UdpReverseAuthorityMismatch, trace);
+    }
+    let runtime = require_nat44_udp_runtime(snapshot, config, nat44_udp, ingress, trace)?;
+    let plan = match runtime.plan_outbound(ipv4.source, udp.source_port, ipv4.destination, now.0) {
+        Ok(plan) => plan,
+        Err(error) => {
+            runtime.record_plan_error(error);
+            let (reason, disposition) = nat44_udp_plan_error(error);
+            trace.record(TraceEvent::Nat44Udp {
+                ingress,
+                disposition,
+            });
+            return Err(reason);
+        }
+    };
+    build_nat44_udp_rewrite(
+        ipv4,
+        udp,
+        forwarding,
+        ipv4.source,
+        config.public_address(),
+        udp.source_port,
+        plan.public_port(),
+        Nat44UdpTransition::Outbound(plan),
+        plan.disposition(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn decide_nat44_udp_inbound<T: TraceSink>(
+    frame: &[u8],
+    snapshot: &ForwardingSnapshot<'_>,
+    ingress: IfId,
+    ipv4: packet::ValidatedIpv4,
+    resolution: &mut Option<(&mut ResolutionRuntime<'_>, MonotonicMillis)>,
+    config: &Nat44UdpConfig,
+    nat44_udp: &mut Option<&mut Nat44UdpRuntime<'_>>,
+    trace: &mut T,
+) -> Result<PacketDecision, DropReason> {
+    if let Err(reason) = validate_nat44_atomic(frame, ipv4) {
+        return nat44_udp_drop(nat44_udp, ingress, reason, trace);
+    }
+    let udp = match validate_nat44_udp(frame, ipv4) {
+        Ok(udp) => udp,
+        Err(reason) => return nat44_udp_drop(nat44_udp, ingress, reason, trace),
+    };
+    if ipv4.ttl <= 1 {
+        return nat44_udp_drop(nat44_udp, ingress, Ipv4TtlExpired, trace);
+    }
+    if !icmp_error_source_is_host(snapshot, ipv4.source)
+        || snapshot
+            .local_ipv4
+            .iter()
+            .any(|binding| binding.address == ipv4.source)
+    {
+        return nat44_udp_drop(nat44_udp, ingress, Nat44UdpSourceForbidden, trace);
+    }
+    let now = resolution
+        .as_ref()
+        .map_or(MonotonicMillis(0), |(_, now)| *now);
+    let runtime = require_nat44_udp_runtime(snapshot, config, nat44_udp, ingress, trace)?;
+    let plan = match runtime.plan_inbound(udp.destination_port, ipv4.source, now.0) {
+        Ok(plan) => plan,
+        Err(error) => {
+            runtime.record_plan_error(error);
+            let (reason, disposition) = nat44_udp_plan_error(error);
+            trace.record(TraceEvent::Nat44Udp {
+                ingress,
+                disposition,
+            });
+            return Err(reason);
+        }
+    };
+    let internal_address = plan.internal_address();
+    let Some(reverse_route) = route::lookup(snapshot.routes, internal_address) else {
+        return nat44_udp_drop(nat44_udp, ingress, Nat44UdpReverseAuthorityMismatch, trace);
+    };
+    if reverse_route.egress() != config.inside() {
+        return nat44_udp_drop(nat44_udp, ingress, Nat44UdpWrongEgress, trace);
+    }
+    let target = reverse_route.next_hop().unwrap_or(internal_address);
+    let interface = snapshot
+        .interfaces
+        .iter()
+        .find(|interface| interface.id == reverse_route.egress())
+        .ok_or(InterfaceMiss)?;
+    let destination_mac = if let Some(neighbor) = snapshot
+        .neighbors
+        .iter()
+        .find(|neighbor| neighbor.interface == reverse_route.egress() && neighbor.target == target)
+    {
+        neighbor.mac
+    } else if let Some((resolution_runtime, resolution_now)) = resolution.as_mut() {
+        match resolution_runtime.lookup_dynamic(reverse_route.egress(), target, *resolution_now) {
+            DynamicLookup::Hit(mac) => mac,
+            DynamicLookup::ClockRegression => {
+                return nat44_udp_drop(nat44_udp, ingress, NeighborUnresolved, trace);
+            }
+            DynamicLookup::Miss => {
+                if let Some(binding) = snapshot
+                    .local_ipv4
+                    .iter()
+                    .find(|binding| binding.interface == reverse_route.egress())
+                {
+                    let result = resolution_runtime.schedule(
+                        ArpRequestAction {
+                            egress: reverse_route.egress(),
+                            source_mac: interface.mac,
+                            source_ip: binding.address,
+                            target_ip: target,
+                        },
+                        *resolution_now,
+                        false,
+                    );
+                    trace.record(TraceEvent::NeighborResolution {
+                        egress: reverse_route.egress(),
+                        target,
+                        result,
+                    });
+                }
+                return nat44_udp_drop(nat44_udp, ingress, NeighborUnresolved, trace);
+            }
+        }
+    } else {
+        return nat44_udp_drop(nat44_udp, ingress, NeighborUnresolved, trace);
+    };
+    let ttl_offset = ipv4.header_offset + 8;
+    let checksum_offset = ipv4.header_offset + 10;
+    let forwarding = Ipv4RewriteDecision {
+        egress: reverse_route.egress(),
+        source_mac: interface.mac.0,
+        destination_mac: destination_mac.0,
+        ttl_offset,
+        checksum_offset,
+        checksum_end: checksum_offset + 2,
+        old_ttl_protocol: u16::from_be_bytes([ipv4.ttl, ipv4.protocol]),
+        new_ttl_protocol: u16::from_be_bytes([ipv4.ttl - 1, ipv4.protocol]),
+        old_checksum: ipv4.checksum,
+    };
+    trace.record(TraceEvent::Routed {
+        egress: reverse_route.egress(),
+        neighbor_target: target,
+    });
+    build_nat44_udp_rewrite(
+        ipv4,
+        udp,
+        forwarding,
+        ipv4.destination,
+        internal_address,
+        udp.destination_port,
+        plan.internal_port(),
+        Nat44UdpTransition::Inbound(plan),
+        plan.disposition(),
+    )
+}
+
+#[derive(Clone, Copy)]
+struct ValidatedNat44Udp {
+    offset: usize,
+    source_port: u16,
+    destination_port: u16,
+    checksum: u16,
+}
+
+fn validate_nat44_atomic(frame: &[u8], ipv4: packet::ValidatedIpv4) -> Result<(), DropReason> {
+    let flags_fragment =
+        packet::read_u16(frame, ipv4.header_offset + 6).ok_or(Ipv4HeaderLengthExceedsPacket)?;
+    if flags_fragment != 0x4000 {
+        return Err(Nat44UdpNonAtomicIpv4Unsupported);
+    }
+    Ok(())
+}
+
+fn validate_nat44_udp(
+    frame: &[u8],
+    ipv4: packet::ValidatedIpv4,
+) -> Result<ValidatedNat44Udp, DropReason> {
+    let offset = ipv4
+        .header_offset
+        .checked_add(ipv4.header_len)
+        .ok_or(Nat44UdpHeaderTruncated)?;
+    let ipv4_end = ipv4
+        .header_offset
+        .checked_add(ipv4.total_len)
+        .ok_or(Nat44UdpHeaderTruncated)?;
+    let header_end = offset.checked_add(8).ok_or(Nat44UdpHeaderTruncated)?;
+    if header_end > ipv4_end || frame.get(offset..header_end).is_none() {
+        return Err(Nat44UdpHeaderTruncated);
+    }
+    let length = usize::from(packet::read_u16(frame, offset + 4).ok_or(Nat44UdpHeaderTruncated)?);
+    if length < 8 {
+        return Err(Nat44UdpLengthTooSmall);
+    }
+    let payload_len = ipv4.total_len - ipv4.header_len;
+    if length > payload_len {
+        return Err(Nat44UdpLengthExceedsIpv4Payload);
+    }
+    Ok(ValidatedNat44Udp {
+        offset,
+        source_port: packet::read_u16(frame, offset).ok_or(Nat44UdpHeaderTruncated)?,
+        destination_port: packet::read_u16(frame, offset + 2).ok_or(Nat44UdpHeaderTruncated)?,
+        checksum: packet::read_u16(frame, offset + 6).ok_or(Nat44UdpHeaderTruncated)?,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_nat44_udp_rewrite(
+    ipv4: packet::ValidatedIpv4,
+    udp: ValidatedNat44Udp,
+    forwarding: Ipv4RewriteDecision,
+    old_address: crate::Ipv4Address,
+    new_address: crate::Ipv4Address,
+    old_port: u16,
+    new_port: u16,
+    transition: Nat44UdpTransition,
+    disposition: Nat44UdpDisposition,
+) -> Result<PacketDecision, DropReason> {
+    let outbound = matches!(transition, Nat44UdpTransition::Outbound(_));
+    let address_offset = ipv4
+        .header_offset
+        .checked_add(if outbound { 12 } else { 16 })
+        .ok_or(Ipv4HeaderLengthExceedsPacket)?;
+    let address_end = address_offset
+        .checked_add(4)
+        .ok_or(Ipv4HeaderLengthExceedsPacket)?;
+    let port_offset = udp
+        .offset
+        .checked_add(if outbound { 0 } else { 2 })
+        .ok_or(Nat44UdpHeaderTruncated)?;
+    let port_end = port_offset.checked_add(2).ok_or(Nat44UdpHeaderTruncated)?;
+    let udp_checksum_offset = udp.offset.checked_add(6).ok_or(Nat44UdpHeaderTruncated)?;
+    let udp_checksum_end = udp_checksum_offset
+        .checked_add(2)
+        .ok_or(Nat44UdpHeaderTruncated)?;
+    let old_octets = old_address.octets();
+    let new_octets = new_address.octets();
+    let old_high = u16::from_be_bytes([old_octets[0], old_octets[1]]);
+    let old_low = u16::from_be_bytes([old_octets[2], old_octets[3]]);
+    let new_high = u16::from_be_bytes([new_octets[0], new_octets[1]]);
+    let new_low = u16::from_be_bytes([new_octets[2], new_octets[3]]);
+    let ipv4_checksum = rfc1624_update(
+        rfc1624_update(
+            rfc1624_update(
+                forwarding.old_checksum,
+                forwarding.old_ttl_protocol,
+                forwarding.new_ttl_protocol,
+            ),
+            old_high,
+            new_high,
+        ),
+        old_low,
+        new_low,
+    );
+    let udp_checksum = if udp.checksum == 0 {
+        0
+    } else {
+        let updated = rfc1624_update(
+            rfc1624_update(
+                rfc1624_update(udp.checksum, old_high, new_high),
+                old_low,
+                new_low,
+            ),
+            old_port,
+            new_port,
+        );
+        if updated == 0 {
+            0xffff
+        } else {
+            updated
+        }
+    };
+    Ok(PacketDecision::Nat44Udp(Nat44UdpRewriteDecision {
+        forwarding,
+        address_offset,
+        address_end,
+        new_address: new_octets,
+        port_offset,
+        port_end,
+        new_port,
+        udp_checksum_offset,
+        udp_checksum_end,
+        ipv4_checksum,
+        udp_checksum,
+        transition,
+        disposition,
     }))
+}
+
+fn nat44_udp_plan_error(error: Nat44UdpPlanError) -> (DropReason, Nat44UdpDisposition) {
+    match error {
+        Nat44UdpPlanError::MappingMiss => (Nat44UdpMappingMiss, Nat44UdpDisposition::MappingMiss),
+        Nat44UdpPlanError::FilterDenied => {
+            (Nat44UdpFilterDenied, Nat44UdpDisposition::FilterDenied)
+        }
+        Nat44UdpPlanError::MappingFull => {
+            (Nat44UdpMappingTableFull, Nat44UdpDisposition::MappingFull)
+        }
+        Nat44UdpPlanError::PeerFull => (Nat44UdpPeerTableFull, Nat44UdpDisposition::PeerFull),
+        Nat44UdpPlanError::PortExhausted => {
+            (Nat44UdpPortExhausted, Nat44UdpDisposition::PortExhausted)
+        }
+        Nat44UdpPlanError::ClockRegression => (
+            Nat44UdpClockRegression,
+            Nat44UdpDisposition::ClockRegression,
+        ),
+    }
+}
+
+fn nat44_udp_drop<T: TraceSink>(
+    _runtime: &mut Option<&mut Nat44UdpRuntime<'_>>,
+    ingress: IfId,
+    reason: DropReason,
+    trace: &mut T,
+) -> Result<PacketDecision, DropReason> {
+    trace.record(TraceEvent::Nat44Udp {
+        ingress,
+        disposition: Nat44UdpDisposition::Rejected { reason },
+    });
+    Err(reason)
+}
+
+fn require_nat44_udp_runtime<'runtime, 'storage, T: TraceSink>(
+    snapshot: &ForwardingSnapshot<'_>,
+    config: &Nat44UdpConfig,
+    runtime: &'runtime mut Option<&mut Nat44UdpRuntime<'storage>>,
+    ingress: IfId,
+    trace: &mut T,
+) -> Result<&'runtime mut Nat44UdpRuntime<'storage>, DropReason> {
+    if !config.authority_matches(snapshot) {
+        if let Some(runtime) = runtime.as_deref_mut() {
+            runtime.record_config_mismatch();
+        }
+        trace.record(TraceEvent::Nat44Udp {
+            ingress,
+            disposition: Nat44UdpDisposition::ConfigMismatch,
+        });
+        return Err(Nat44UdpConfigMismatch);
+    }
+    let Some(runtime) = runtime.as_deref_mut() else {
+        trace.record(TraceEvent::Nat44Udp {
+            ingress,
+            disposition: Nat44UdpDisposition::Rejected {
+                reason: Nat44UdpRuntimeUnavailable,
+            },
+        });
+        return Err(Nat44UdpRuntimeUnavailable);
+    };
+    if runtime.config() != *config {
+        runtime.record_config_mismatch();
+        trace.record(TraceEvent::Nat44Udp {
+            ingress,
+            disposition: Nat44UdpDisposition::ConfigMismatch,
+        });
+        return Err(Nat44UdpConfigMismatch);
+    }
+    Ok(runtime)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1272,12 +1880,45 @@ fn sender_is_host(
 fn apply_decision(frame: &mut [u8], decision: PacketDecision) -> Result<(), DropReason> {
     match decision {
         PacketDecision::Ipv4(ipv4) => apply_ipv4_rewrite(frame, ipv4),
+        PacketDecision::Nat44Udp(nat) => apply_nat44_udp_rewrite(frame, nat),
         PacketDecision::ArpReply(arp) => apply_arp_reply(frame, arp),
         PacketDecision::Icmpv4EchoReply(icmp) => apply_icmpv4_echo_reply(frame, icmp),
         PacketDecision::ConsumeArp(_) | PacketDecision::ConsumeIpv4Local => {
             unreachable!("consume decisions are never rewritten")
         }
     }
+}
+
+fn apply_nat44_udp_rewrite(
+    frame: &mut [u8],
+    decision: Nat44UdpRewriteDecision,
+) -> Result<(), DropReason> {
+    if frame.get(0..12).is_none()
+        || frame.get(decision.forwarding.ttl_offset).is_none()
+        || frame
+            .get(decision.forwarding.checksum_offset..decision.forwarding.checksum_end)
+            .is_none()
+        || frame
+            .get(decision.address_offset..decision.address_end)
+            .is_none()
+        || frame.get(decision.port_offset..decision.port_end).is_none()
+        || frame
+            .get(decision.udp_checksum_offset..decision.udp_checksum_end)
+            .is_none()
+    {
+        return Err(Nat44UdpHeaderTruncated);
+    }
+    frame[0..6].copy_from_slice(&decision.forwarding.destination_mac);
+    frame[6..12].copy_from_slice(&decision.forwarding.source_mac);
+    frame[decision.forwarding.ttl_offset] -= 1;
+    frame[decision.forwarding.checksum_offset..decision.forwarding.checksum_end]
+        .copy_from_slice(&decision.ipv4_checksum.to_be_bytes());
+    frame[decision.address_offset..decision.address_end].copy_from_slice(&decision.new_address);
+    frame[decision.port_offset..decision.port_end]
+        .copy_from_slice(&decision.new_port.to_be_bytes());
+    frame[decision.udp_checksum_offset..decision.udp_checksum_end]
+        .copy_from_slice(&decision.udp_checksum.to_be_bytes());
+    Ok(())
 }
 
 fn apply_ipv4_rewrite(frame: &mut [u8], decision: Ipv4RewriteDecision) -> Result<(), DropReason> {
@@ -1384,6 +2025,25 @@ mod tests {
             (31, "ICMPV4_SOURCE_NOT_UNICAST"),
             (32, "ICMPV4_ETHERNET_SOURCE_INVALID"),
             (33, "ICMPV4_ETHERNET_DESTINATION_NOT_LOCAL"),
+            (34, "NAT44_UDP_RUNTIME_UNAVAILABLE"),
+            (35, "NAT44_UDP_CONFIG_MISMATCH"),
+            (36, "NAT44_UDP_UNSUPPORTED_TRANSPORT"),
+            (37, "NAT44_UDP_HAIRPIN_UNSUPPORTED"),
+            (38, "NAT44_UDP_NON_ATOMIC_IPV4_UNSUPPORTED"),
+            (39, "NAT44_UDP_HEADER_TRUNCATED"),
+            (40, "NAT44_UDP_LENGTH_TOO_SMALL"),
+            (41, "NAT44_UDP_LENGTH_EXCEEDS_IPV4_PAYLOAD"),
+            (42, "NAT44_UDP_SOURCE_PORT_ZERO"),
+            (43, "NAT44_UDP_SOURCE_FORBIDDEN"),
+            (44, "NAT44_UDP_REVERSE_AUTHORITY_MISMATCH"),
+            (45, "NAT44_UDP_MAPPING_MISS"),
+            (46, "NAT44_UDP_FILTER_DENIED"),
+            (47, "NAT44_UDP_MAPPING_TABLE_FULL"),
+            (48, "NAT44_UDP_PEER_TABLE_FULL"),
+            (49, "NAT44_UDP_PORT_EXHAUSTED"),
+            (50, "NAT44_UDP_CLOCK_REGRESSION"),
+            (51, "NAT44_UDP_WRONG_INGRESS"),
+            (52, "NAT44_UDP_WRONG_EGRESS"),
         ];
         let actual = [
             DropReason::EthernetHeaderTruncated,
@@ -1419,7 +2079,27 @@ mod tests {
             DropReason::Icmpv4SourceNotUnicast,
             DropReason::Icmpv4EthernetSourceInvalid,
             DropReason::Icmpv4EthernetDestinationNotLocal,
+            DropReason::Nat44UdpRuntimeUnavailable,
+            DropReason::Nat44UdpConfigMismatch,
+            DropReason::Nat44UdpUnsupportedTransport,
+            DropReason::Nat44UdpHairpinUnsupported,
+            DropReason::Nat44UdpNonAtomicIpv4Unsupported,
+            DropReason::Nat44UdpHeaderTruncated,
+            DropReason::Nat44UdpLengthTooSmall,
+            DropReason::Nat44UdpLengthExceedsIpv4Payload,
+            DropReason::Nat44UdpSourcePortZero,
+            DropReason::Nat44UdpSourceForbidden,
+            DropReason::Nat44UdpReverseAuthorityMismatch,
+            DropReason::Nat44UdpMappingMiss,
+            DropReason::Nat44UdpFilterDenied,
+            DropReason::Nat44UdpMappingTableFull,
+            DropReason::Nat44UdpPeerTableFull,
+            DropReason::Nat44UdpPortExhausted,
+            DropReason::Nat44UdpClockRegression,
+            DropReason::Nat44UdpWrongIngress,
+            DropReason::Nat44UdpWrongEgress,
         ];
+        assert_eq!(actual.len(), expected.len());
         for (reason, &(discriminant, code)) in actual.iter().zip(&expected) {
             assert_eq!(*reason as u16, discriminant);
             assert_eq!(reason.code(), code);

--- a/crates/core/src/forwarding.rs
+++ b/crates/core/src/forwarding.rs
@@ -65,6 +65,7 @@ pub enum DropReason {
     Nat44UdpClockRegression = 50,
     Nat44UdpWrongIngress = 51,
     Nat44UdpWrongEgress = 52,
+    Nat44ExternalToInternalBypass = 53,
 }
 
 use DropReason::*;
@@ -125,6 +126,7 @@ impl DropReason {
             Nat44UdpClockRegression => "NAT44_UDP_CLOCK_REGRESSION",
             Nat44UdpWrongIngress => "NAT44_UDP_WRONG_INGRESS",
             Nat44UdpWrongEgress => "NAT44_UDP_WRONG_EGRESS",
+            Nat44ExternalToInternalBypass => "NAT44_EXTERNAL_TO_INTERNAL_BYPASS",
         }
     }
 }
@@ -800,14 +802,31 @@ fn decide_ipv4<T: TraceSink>(
     });
     if let Some(config) = nat44_udp_config {
         if ingress == config.inside() && ipv4.destination == config.public_address() {
-            return nat44_udp_drop(nat44_udp, ingress, Nat44UdpHairpinUnsupported, trace);
+            observe_nat_candidate_if_present(
+                snapshot,
+                config,
+                nat44_udp,
+                resolution
+                    .as_ref()
+                    .map_or(MonotonicMillis(0), |(_, now)| *now),
+                ingress,
+                trace,
+            )?;
+            return nat44_udp_drop(ingress, Nat44UdpHairpinUnsupported, trace);
         }
         if ipv4.destination == config.public_address() && ipv4.protocol == 17 {
-            if ipv4.header_len > 20 {
-                return nat44_udp_drop(nat44_udp, ingress, Ipv4OptionsUnsupported, trace);
-            }
             if ingress != config.outside() {
-                return nat44_udp_drop(nat44_udp, ingress, Nat44UdpWrongIngress, trace);
+                observe_nat_candidate_if_present(
+                    snapshot,
+                    config,
+                    nat44_udp,
+                    resolution
+                        .as_ref()
+                        .map_or(MonotonicMillis(0), |(_, now)| *now),
+                    ingress,
+                    trace,
+                )?;
+                return nat44_udp_drop(ingress, Nat44UdpWrongIngress, trace);
             }
             return decide_nat44_udp_inbound(
                 frame, snapshot, ingress, ipv4, resolution, config, nat44_udp, trace,
@@ -845,6 +864,11 @@ fn decide_ipv4<T: TraceSink>(
         }
         return Err(RouteMiss);
     };
+    if nat44_udp_config
+        .is_some_and(|config| ingress == config.outside() && route.egress() == config.inside())
+    {
+        return nat44_udp_drop(ingress, Nat44ExternalToInternalBypass, trace);
+    }
     if ipv4.ttl <= 1 {
         if let Some((runtime, now)) = icmpv4_errors.as_mut() {
             let disposition = decide_icmpv4_error(
@@ -1000,18 +1024,30 @@ fn decide_nat44_udp_outbound<T: TraceSink>(
     now: MonotonicMillis,
     trace: &mut T,
 ) -> Result<PacketDecision, DropReason> {
+    let runtime = require_nat44_udp_runtime(snapshot, config, nat44_udp, ingress, trace)?;
+    if let Err(error) = runtime.observe_now(now.0) {
+        let (reason, disposition) = nat44_udp_plan_error(error);
+        trace.record(TraceEvent::Nat44Udp {
+            ingress,
+            disposition,
+        });
+        return Err(reason);
+    }
+    if ipv4.header_len > 20 {
+        return nat44_udp_drop(ingress, Ipv4OptionsUnsupported, trace);
+    }
     if ipv4.protocol != 17 {
-        return nat44_udp_drop(nat44_udp, ingress, Nat44UdpUnsupportedTransport, trace);
+        return nat44_udp_drop(ingress, Nat44UdpUnsupportedTransport, trace);
     }
     if let Err(reason) = validate_nat44_atomic(frame, ipv4) {
-        return nat44_udp_drop(nat44_udp, ingress, reason, trace);
+        return nat44_udp_drop(ingress, reason, trace);
     }
     let udp = match validate_nat44_udp(frame, ipv4) {
         Ok(udp) => udp,
-        Err(reason) => return nat44_udp_drop(nat44_udp, ingress, reason, trace),
+        Err(reason) => return nat44_udp_drop(ingress, reason, trace),
     };
     if udp.source_port == 0 {
-        return nat44_udp_drop(nat44_udp, ingress, Nat44UdpSourcePortZero, trace);
+        return nat44_udp_drop(ingress, Nat44UdpSourcePortZero, trace);
     }
     if !icmp_error_source_is_host(snapshot, ipv4.source)
         || snapshot
@@ -1020,14 +1056,13 @@ fn decide_nat44_udp_outbound<T: TraceSink>(
             .any(|binding| binding.address == ipv4.source)
         || ipv4.source == config.public_address()
     {
-        return nat44_udp_drop(nat44_udp, ingress, Nat44UdpSourceForbidden, trace);
+        return nat44_udp_drop(ingress, Nat44UdpSourceForbidden, trace);
     }
     if route::lookup(snapshot.routes, ipv4.source)
         .is_none_or(|reverse| reverse.egress() != config.inside())
     {
-        return nat44_udp_drop(nat44_udp, ingress, Nat44UdpReverseAuthorityMismatch, trace);
+        return nat44_udp_drop(ingress, Nat44UdpReverseAuthorityMismatch, trace);
     }
-    let runtime = require_nat44_udp_runtime(snapshot, config, nat44_udp, ingress, trace)?;
     let plan = match runtime.plan_outbound(ipv4.source, udp.source_port, ipv4.destination, now.0) {
         Ok(plan) => plan,
         Err(error) => {
@@ -1064,15 +1099,30 @@ fn decide_nat44_udp_inbound<T: TraceSink>(
     nat44_udp: &mut Option<&mut Nat44UdpRuntime<'_>>,
     trace: &mut T,
 ) -> Result<PacketDecision, DropReason> {
+    let now = resolution
+        .as_ref()
+        .map_or(MonotonicMillis(0), |(_, now)| *now);
+    let runtime = require_nat44_udp_runtime(snapshot, config, nat44_udp, ingress, trace)?;
+    if let Err(error) = runtime.observe_now(now.0) {
+        let (reason, disposition) = nat44_udp_plan_error(error);
+        trace.record(TraceEvent::Nat44Udp {
+            ingress,
+            disposition,
+        });
+        return Err(reason);
+    }
+    if ipv4.header_len > 20 {
+        return nat44_udp_drop(ingress, Ipv4OptionsUnsupported, trace);
+    }
     if let Err(reason) = validate_nat44_atomic(frame, ipv4) {
-        return nat44_udp_drop(nat44_udp, ingress, reason, trace);
+        return nat44_udp_drop(ingress, reason, trace);
     }
     let udp = match validate_nat44_udp(frame, ipv4) {
         Ok(udp) => udp,
-        Err(reason) => return nat44_udp_drop(nat44_udp, ingress, reason, trace),
+        Err(reason) => return nat44_udp_drop(ingress, reason, trace),
     };
     if ipv4.ttl <= 1 {
-        return nat44_udp_drop(nat44_udp, ingress, Ipv4TtlExpired, trace);
+        return nat44_udp_drop(ingress, Ipv4TtlExpired, trace);
     }
     if !icmp_error_source_is_host(snapshot, ipv4.source)
         || snapshot
@@ -1080,12 +1130,8 @@ fn decide_nat44_udp_inbound<T: TraceSink>(
             .iter()
             .any(|binding| binding.address == ipv4.source)
     {
-        return nat44_udp_drop(nat44_udp, ingress, Nat44UdpSourceForbidden, trace);
+        return nat44_udp_drop(ingress, Nat44UdpSourceForbidden, trace);
     }
-    let now = resolution
-        .as_ref()
-        .map_or(MonotonicMillis(0), |(_, now)| *now);
-    let runtime = require_nat44_udp_runtime(snapshot, config, nat44_udp, ingress, trace)?;
     let plan = match runtime.plan_inbound(udp.destination_port, ipv4.source, now.0) {
         Ok(plan) => plan,
         Err(error) => {
@@ -1100,10 +1146,10 @@ fn decide_nat44_udp_inbound<T: TraceSink>(
     };
     let internal_address = plan.internal_address();
     let Some(reverse_route) = route::lookup(snapshot.routes, internal_address) else {
-        return nat44_udp_drop(nat44_udp, ingress, Nat44UdpReverseAuthorityMismatch, trace);
+        return nat44_udp_drop(ingress, Nat44UdpReverseAuthorityMismatch, trace);
     };
     if reverse_route.egress() != config.inside() {
-        return nat44_udp_drop(nat44_udp, ingress, Nat44UdpWrongEgress, trace);
+        return nat44_udp_drop(ingress, Nat44UdpWrongEgress, trace);
     }
     let target = reverse_route.next_hop().unwrap_or(internal_address);
     let interface = snapshot
@@ -1121,7 +1167,7 @@ fn decide_nat44_udp_inbound<T: TraceSink>(
         match resolution_runtime.lookup_dynamic(reverse_route.egress(), target, *resolution_now) {
             DynamicLookup::Hit(mac) => mac,
             DynamicLookup::ClockRegression => {
-                return nat44_udp_drop(nat44_udp, ingress, NeighborUnresolved, trace);
+                return nat44_udp_drop(ingress, NeighborUnresolved, trace);
             }
             DynamicLookup::Miss => {
                 if let Some(binding) = snapshot
@@ -1145,11 +1191,11 @@ fn decide_nat44_udp_inbound<T: TraceSink>(
                         result,
                     });
                 }
-                return nat44_udp_drop(nat44_udp, ingress, NeighborUnresolved, trace);
+                return nat44_udp_drop(ingress, NeighborUnresolved, trace);
             }
         }
     } else {
-        return nat44_udp_drop(nat44_udp, ingress, NeighborUnresolved, trace);
+        return nat44_udp_drop(ingress, NeighborUnresolved, trace);
     };
     let ttl_offset = ipv4.header_offset + 8;
     let checksum_offset = ipv4.header_offset + 10;
@@ -1334,7 +1380,6 @@ fn nat44_udp_plan_error(error: Nat44UdpPlanError) -> (DropReason, Nat44UdpDispos
 }
 
 fn nat44_udp_drop<T: TraceSink>(
-    _runtime: &mut Option<&mut Nat44UdpRuntime<'_>>,
     ingress: IfId,
     reason: DropReason,
     trace: &mut T,
@@ -1381,6 +1426,29 @@ fn require_nat44_udp_runtime<'runtime, 'storage, T: TraceSink>(
         return Err(Nat44UdpConfigMismatch);
     }
     Ok(runtime)
+}
+
+fn observe_nat_candidate_if_present<T: TraceSink>(
+    snapshot: &ForwardingSnapshot<'_>,
+    config: &Nat44UdpConfig,
+    runtime: &mut Option<&mut Nat44UdpRuntime<'_>>,
+    now: MonotonicMillis,
+    ingress: IfId,
+    trace: &mut T,
+) -> Result<(), DropReason> {
+    if runtime.is_none() {
+        return Ok(());
+    }
+    let runtime = require_nat44_udp_runtime(snapshot, config, runtime, ingress, trace)?;
+    if let Err(error) = runtime.observe_now(now.0) {
+        let (reason, disposition) = nat44_udp_plan_error(error);
+        trace.record(TraceEvent::Nat44Udp {
+            ingress,
+            disposition,
+        });
+        return Err(reason);
+    }
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2044,6 +2112,7 @@ mod tests {
             (50, "NAT44_UDP_CLOCK_REGRESSION"),
             (51, "NAT44_UDP_WRONG_INGRESS"),
             (52, "NAT44_UDP_WRONG_EGRESS"),
+            (53, "NAT44_EXTERNAL_TO_INTERNAL_BYPASS"),
         ];
         let actual = [
             DropReason::EthernetHeaderTruncated,
@@ -2098,6 +2167,7 @@ mod tests {
             DropReason::Nat44UdpClockRegression,
             DropReason::Nat44UdpWrongIngress,
             DropReason::Nat44UdpWrongEgress,
+            DropReason::Nat44ExternalToInternalBypass,
         ];
         assert_eq!(actual.len(), expected.len());
         for (reason, &(discriminant, code)) in actual.iter().zip(&expected) {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -6,14 +6,16 @@ mod forwarding;
 mod generated;
 mod icmpv4_error;
 mod io;
+mod nat44;
 mod packet;
 mod resolution;
 mod route;
 
 pub use checksum::{internet_checksum, ipv4_header_checksum, rfc1624_update};
 pub use forwarding::{
-    forward_batch, forward_batch_with_resolution, forward_batch_with_resolution_and_icmpv4_errors,
-    BatchReport, DropReason, ForwardingSnapshot, Ipv4OriginPolicy, Ipv4OriginPolicyError, NoTrace,
+    forward_batch, forward_batch_with_nat44_udp, forward_batch_with_nat44_udp_and_icmpv4_errors,
+    forward_batch_with_resolution, forward_batch_with_resolution_and_icmpv4_errors, BatchReport,
+    DropReason, ForwardingSnapshot, Ipv4OriginPolicy, Ipv4OriginPolicyError, NoTrace,
     SnapshotError, TraceEvent, TraceSink,
 };
 pub use generated::{
@@ -32,6 +34,12 @@ pub use icmpv4_error::{
 };
 pub use io::{
     BatchCompletion, ConsumeReason, PacketBatch, PacketIo, PacketLease, PacketSlot, SlotCompletion,
+};
+pub use nat44::{
+    Nat44UdpConfig, Nat44UdpConfigError, Nat44UdpCounters, Nat44UdpDisposition,
+    Nat44UdpMappingSlot, Nat44UdpPeerSlot, Nat44UdpPolicy, Nat44UdpPolicyError,
+    Nat44UdpReconcileReport, Nat44UdpRuntime, NAT44_UDP_DEFAULT_IDLE_TTL_MS,
+    NAT44_UDP_MAX_IDLE_TTL_MS, NAT44_UDP_MIN_IDLE_TTL_MS,
 };
 pub use packet::{
     validate_arp, validate_arp_request, validate_ipv4_frame, ArpOpcode, MacAddress, ValidatedArp,

--- a/crates/core/src/nat44.rs
+++ b/crates/core/src/nat44.rs
@@ -1,0 +1,1009 @@
+use std::{marker::PhantomData, rc::Rc};
+
+use crate::{route, ForwardingSnapshot, IfId, Ipv4Address};
+
+pub const NAT44_UDP_MIN_IDLE_TTL_MS: u64 = 120_000;
+pub const NAT44_UDP_DEFAULT_IDLE_TTL_MS: u64 = 300_000;
+pub const NAT44_UDP_MAX_IDLE_TTL_MS: u64 = 86_400_000;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Nat44UdpPolicy {
+    idle_ttl_ms: u64,
+    allocator_seed: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum Nat44UdpPolicyError {
+    IdleTtlTooShort,
+    IdleTtlTooLong,
+}
+
+impl Nat44UdpPolicy {
+    pub const fn new(idle_ttl_ms: u64, allocator_seed: u64) -> Result<Self, Nat44UdpPolicyError> {
+        if idle_ttl_ms < NAT44_UDP_MIN_IDLE_TTL_MS {
+            return Err(Nat44UdpPolicyError::IdleTtlTooShort);
+        }
+        if idle_ttl_ms > NAT44_UDP_MAX_IDLE_TTL_MS {
+            return Err(Nat44UdpPolicyError::IdleTtlTooLong);
+        }
+        Ok(Self {
+            idle_ttl_ms,
+            allocator_seed,
+        })
+    }
+
+    #[must_use]
+    pub const fn idle_ttl_ms(self) -> u64 {
+        self.idle_ttl_ms
+    }
+
+    #[must_use]
+    pub const fn allocator_seed(self) -> u64 {
+        self.allocator_seed
+    }
+}
+
+impl Default for Nat44UdpPolicy {
+    fn default() -> Self {
+        Self {
+            idle_ttl_ms: NAT44_UDP_DEFAULT_IDLE_TTL_MS,
+            allocator_seed: 0,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Nat44UdpConfig {
+    inside: IfId,
+    outside: IfId,
+    public_address: Ipv4Address,
+    first_port: u16,
+    last_port: u16,
+    policy: Nat44UdpPolicy,
+    authority: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum Nat44UdpConfigError {
+    InterfacesEqual,
+    InsideInterfaceMissing,
+    OutsideInterfaceMissing,
+    PublicAddressNotHostUnicast,
+    PublicBindingMissing,
+    PublicBindingWrongInterface,
+    PortPoolIncludesZero,
+    PortPoolReversed,
+}
+
+impl Nat44UdpConfig {
+    pub fn new(
+        snapshot: &ForwardingSnapshot<'_>,
+        inside: IfId,
+        outside: IfId,
+        public_address: Ipv4Address,
+        first_port: u16,
+        last_port: u16,
+        policy: Nat44UdpPolicy,
+    ) -> Result<Self, Nat44UdpConfigError> {
+        if inside == outside {
+            return Err(Nat44UdpConfigError::InterfacesEqual);
+        }
+        if !snapshot
+            .interfaces
+            .iter()
+            .any(|interface| interface.id == inside)
+        {
+            return Err(Nat44UdpConfigError::InsideInterfaceMissing);
+        }
+        if !snapshot
+            .interfaces
+            .iter()
+            .any(|interface| interface.id == outside)
+        {
+            return Err(Nat44UdpConfigError::OutsideInterfaceMissing);
+        }
+        if !address_is_host_unicast(snapshot, public_address) {
+            return Err(Nat44UdpConfigError::PublicAddressNotHostUnicast);
+        }
+        let Some(binding) = snapshot
+            .local_ipv4
+            .iter()
+            .find(|binding| binding.address == public_address)
+        else {
+            return Err(Nat44UdpConfigError::PublicBindingMissing);
+        };
+        if binding.interface != outside {
+            return Err(Nat44UdpConfigError::PublicBindingWrongInterface);
+        }
+        if first_port == 0 {
+            return Err(Nat44UdpConfigError::PortPoolIncludesZero);
+        }
+        if first_port > last_port {
+            return Err(Nat44UdpConfigError::PortPoolReversed);
+        }
+        Ok(Self {
+            inside,
+            outside,
+            public_address,
+            first_port,
+            last_port,
+            policy,
+            authority: snapshot_authority(snapshot),
+        })
+    }
+
+    #[must_use]
+    pub const fn inside(self) -> IfId {
+        self.inside
+    }
+
+    #[must_use]
+    pub const fn outside(self) -> IfId {
+        self.outside
+    }
+
+    #[must_use]
+    pub const fn public_address(self) -> Ipv4Address {
+        self.public_address
+    }
+
+    #[must_use]
+    pub const fn first_port(self) -> u16 {
+        self.first_port
+    }
+
+    #[must_use]
+    pub const fn last_port(self) -> u16 {
+        self.last_port
+    }
+
+    #[must_use]
+    pub const fn policy(self) -> Nat44UdpPolicy {
+        self.policy
+    }
+
+    pub(crate) fn authority_matches(self, snapshot: &ForwardingSnapshot<'_>) -> bool {
+        self.authority == snapshot_authority(snapshot)
+            && snapshot.local_ipv4.iter().any(|binding| {
+                binding.interface == self.outside && binding.address == self.public_address
+            })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Nat44UdpMappingSlot {
+    occupied: bool,
+    generation: u64,
+    inside: IfId,
+    internal_address: Ipv4Address,
+    internal_port: u16,
+    public_port: u16,
+    last_outbound_ms: u64,
+}
+
+impl Default for Nat44UdpMappingSlot {
+    fn default() -> Self {
+        Self {
+            occupied: false,
+            generation: 0,
+            inside: IfId(0),
+            internal_address: Ipv4Address::from_octets([0; 4]),
+            internal_port: 0,
+            public_port: 0,
+            last_outbound_ms: 0,
+        }
+    }
+}
+
+impl Nat44UdpMappingSlot {
+    #[must_use]
+    pub const fn is_occupied(self) -> bool {
+        self.occupied
+    }
+
+    #[must_use]
+    pub const fn internal_address(self) -> Ipv4Address {
+        self.internal_address
+    }
+
+    #[must_use]
+    pub const fn internal_port(self) -> u16 {
+        self.internal_port
+    }
+
+    #[must_use]
+    pub const fn public_port(self) -> u16 {
+        self.public_port
+    }
+
+    #[must_use]
+    pub const fn last_outbound_ms(self) -> u64 {
+        self.last_outbound_ms
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Nat44UdpPeerSlot {
+    occupied: bool,
+    mapping_index: usize,
+    mapping_generation: u64,
+    remote_address: Ipv4Address,
+}
+
+impl Default for Nat44UdpPeerSlot {
+    fn default() -> Self {
+        Self {
+            occupied: false,
+            mapping_index: 0,
+            mapping_generation: 0,
+            remote_address: Ipv4Address::from_octets([0; 4]),
+        }
+    }
+}
+
+impl Nat44UdpPeerSlot {
+    #[must_use]
+    pub const fn is_occupied(self) -> bool {
+        self.occupied
+    }
+
+    #[must_use]
+    pub const fn remote_address(self) -> Ipv4Address {
+        self.remote_address
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct Nat44UdpCounters {
+    pub mappings_created: u64,
+    pub mappings_reused: u64,
+    pub mappings_expired: u64,
+    pub peers_created: u64,
+    pub outbound_translated: u64,
+    pub inbound_translated: u64,
+    pub mapping_misses: u64,
+    pub filter_denied: u64,
+    pub mapping_full: u64,
+    pub peer_full: u64,
+    pub port_exhausted: u64,
+    pub clock_regressions: u64,
+    pub config_mismatches: u64,
+    pub reconciliations: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum Nat44UdpDisposition {
+    OutboundTranslated {
+        public_port: u16,
+        mapping_created: bool,
+        peer_created: bool,
+    },
+    InboundTranslated {
+        internal_address: Ipv4Address,
+        internal_port: u16,
+    },
+    MappingMiss,
+    FilterDenied,
+    MappingFull,
+    PeerFull,
+    PortExhausted,
+    ClockRegression,
+    ConfigMismatch,
+    Rejected {
+        reason: crate::DropReason,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Nat44UdpReconcileReport {
+    pub mappings_flushed: usize,
+    pub peers_flushed: usize,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct Nat44UdpOutboundPlan {
+    mapping_index: usize,
+    mapping: Nat44UdpMappingSlot,
+    peer_index: Option<usize>,
+    peer: Option<Nat44UdpPeerSlot>,
+    mapping_created: bool,
+    mapping_expired: bool,
+    peer_created: bool,
+}
+
+impl Nat44UdpOutboundPlan {
+    pub(crate) const fn public_port(self) -> u16 {
+        self.mapping.public_port
+    }
+
+    pub(crate) const fn disposition(self) -> Nat44UdpDisposition {
+        Nat44UdpDisposition::OutboundTranslated {
+            public_port: self.mapping.public_port,
+            mapping_created: self.mapping_created,
+            peer_created: self.peer_created,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct Nat44UdpInboundPlan {
+    mapping_index: usize,
+    mapping_generation: u64,
+    internal_address: Ipv4Address,
+    internal_port: u16,
+}
+
+impl Nat44UdpInboundPlan {
+    pub(crate) const fn internal_address(self) -> Ipv4Address {
+        self.internal_address
+    }
+
+    pub(crate) const fn internal_port(self) -> u16 {
+        self.internal_port
+    }
+
+    pub(crate) const fn disposition(self) -> Nat44UdpDisposition {
+        Nat44UdpDisposition::InboundTranslated {
+            internal_address: self.internal_address,
+            internal_port: self.internal_port,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Nat44UdpPlanError {
+    MappingMiss,
+    FilterDenied,
+    MappingFull,
+    PeerFull,
+    PortExhausted,
+    ClockRegression,
+}
+
+/// Fixed-capacity, worker-local UDP NAPT state.
+///
+/// The caller owns both storage arrays. Recreating the runtime deliberately
+/// clears them. The `Rc` marker makes the runtime `!Send + !Sync`, so a mapping
+/// shard cannot accidentally migrate between packet workers.
+///
+/// ```compile_fail
+/// use ruster_core::Nat44UdpRuntime;
+/// fn assert_send<T: Send>() {}
+/// assert_send::<Nat44UdpRuntime<'static>>();
+/// ```
+///
+/// ```compile_fail
+/// use ruster_core::Nat44UdpRuntime;
+/// fn assert_sync<T: Sync>() {}
+/// assert_sync::<Nat44UdpRuntime<'static>>();
+/// ```
+pub struct Nat44UdpRuntime<'a> {
+    config: Nat44UdpConfig,
+    mappings: &'a mut [Nat44UdpMappingSlot],
+    peers: &'a mut [Nat44UdpPeerSlot],
+    watermark_ms: Option<u64>,
+    next_generation: u64,
+    counters: Nat44UdpCounters,
+    _worker_local: PhantomData<Rc<()>>,
+}
+
+impl<'a> Nat44UdpRuntime<'a> {
+    pub fn new(
+        config: Nat44UdpConfig,
+        mappings: &'a mut [Nat44UdpMappingSlot],
+        peers: &'a mut [Nat44UdpPeerSlot],
+    ) -> Self {
+        mappings.fill(Nat44UdpMappingSlot::default());
+        peers.fill(Nat44UdpPeerSlot::default());
+        Self {
+            config,
+            mappings,
+            peers,
+            watermark_ms: None,
+            next_generation: 1,
+            counters: Nat44UdpCounters::default(),
+            _worker_local: PhantomData,
+        }
+    }
+
+    #[must_use]
+    pub const fn config(&self) -> Nat44UdpConfig {
+        self.config
+    }
+
+    #[must_use]
+    pub const fn counters(&self) -> Nat44UdpCounters {
+        self.counters
+    }
+
+    #[must_use]
+    pub fn mappings(&self) -> &[Nat44UdpMappingSlot] {
+        self.mappings
+    }
+
+    #[must_use]
+    pub fn peers(&self) -> &[Nat44UdpPeerSlot] {
+        self.peers
+    }
+
+    pub fn reconcile(&mut self, config: Nat44UdpConfig) -> Nat44UdpReconcileReport {
+        let mappings_flushed = self
+            .mappings
+            .iter()
+            .filter(|mapping| mapping.occupied)
+            .count();
+        let peers_flushed = self.peers.iter().filter(|peer| peer.occupied).count();
+        self.mappings.fill(Nat44UdpMappingSlot::default());
+        self.peers.fill(Nat44UdpPeerSlot::default());
+        self.config = config;
+        self.watermark_ms = None;
+        self.next_generation = 1;
+        self.counters.reconciliations = self.counters.reconciliations.saturating_add(1);
+        Nat44UdpReconcileReport {
+            mappings_flushed,
+            peers_flushed,
+        }
+    }
+
+    pub(crate) fn record_config_mismatch(&mut self) {
+        self.counters.config_mismatches = self.counters.config_mismatches.saturating_add(1);
+    }
+
+    pub(crate) fn plan_outbound(
+        &self,
+        internal_address: Ipv4Address,
+        internal_port: u16,
+        remote_address: Ipv4Address,
+        now_ms: u64,
+    ) -> Result<Nat44UdpOutboundPlan, Nat44UdpPlanError> {
+        self.check_clock(now_ms)?;
+        if let Some((mapping_index, mapping)) =
+            self.find_mapping(internal_address, internal_port, now_ms)
+        {
+            if self.peer_exists(mapping_index, mapping.generation, remote_address) {
+                let mut refreshed = mapping;
+                refreshed.last_outbound_ms = now_ms;
+                return Ok(Nat44UdpOutboundPlan {
+                    mapping_index,
+                    mapping: refreshed,
+                    peer_index: None,
+                    peer: None,
+                    mapping_created: false,
+                    mapping_expired: false,
+                    peer_created: false,
+                });
+            }
+            let Some(peer_index) = self.find_reusable_peer(now_ms) else {
+                return Err(Nat44UdpPlanError::PeerFull);
+            };
+            let mut refreshed = mapping;
+            refreshed.last_outbound_ms = now_ms;
+            return Ok(Nat44UdpOutboundPlan {
+                mapping_index,
+                mapping: refreshed,
+                peer_index: Some(peer_index),
+                peer: Some(Nat44UdpPeerSlot {
+                    occupied: true,
+                    mapping_index,
+                    mapping_generation: mapping.generation,
+                    remote_address,
+                }),
+                mapping_created: false,
+                mapping_expired: false,
+                peer_created: true,
+            });
+        }
+
+        let Some(mapping_index) = self.find_reusable_mapping(now_ms) else {
+            return Err(Nat44UdpPlanError::MappingFull);
+        };
+        let Some(peer_index) = self.find_reusable_peer(now_ms) else {
+            return Err(Nat44UdpPlanError::PeerFull);
+        };
+        let Some(public_port) = self.allocate_port(internal_address, internal_port, now_ms) else {
+            return Err(Nat44UdpPlanError::PortExhausted);
+        };
+        let generation = self.next_nonzero_generation();
+        let mapping_expired = self.mappings[mapping_index].occupied;
+        Ok(Nat44UdpOutboundPlan {
+            mapping_index,
+            mapping: Nat44UdpMappingSlot {
+                occupied: true,
+                generation,
+                inside: self.config.inside,
+                internal_address,
+                internal_port,
+                public_port,
+                last_outbound_ms: now_ms,
+            },
+            peer_index: Some(peer_index),
+            peer: Some(Nat44UdpPeerSlot {
+                occupied: true,
+                mapping_index,
+                mapping_generation: generation,
+                remote_address,
+            }),
+            mapping_created: true,
+            mapping_expired,
+            peer_created: true,
+        })
+    }
+
+    pub(crate) fn commit_outbound(&mut self, plan: Nat44UdpOutboundPlan, now_ms: u64) {
+        if plan.mapping_created {
+            for peer in self
+                .peers
+                .iter_mut()
+                .filter(|peer| peer.occupied && peer.mapping_index == plan.mapping_index)
+            {
+                *peer = Nat44UdpPeerSlot::default();
+            }
+        }
+        self.mappings[plan.mapping_index] = plan.mapping;
+        if let (Some(index), Some(peer)) = (plan.peer_index, plan.peer) {
+            self.peers[index] = peer;
+        }
+        self.watermark_ms = Some(now_ms);
+        if plan.mapping_created {
+            self.counters.mappings_created = self.counters.mappings_created.saturating_add(1);
+            if plan.mapping_expired {
+                self.counters.mappings_expired = self.counters.mappings_expired.saturating_add(1);
+            }
+            self.next_generation = plan.mapping.generation.wrapping_add(1).max(1);
+        } else {
+            self.counters.mappings_reused = self.counters.mappings_reused.saturating_add(1);
+        }
+        if plan.peer_created {
+            self.counters.peers_created = self.counters.peers_created.saturating_add(1);
+        }
+        self.counters.outbound_translated = self.counters.outbound_translated.saturating_add(1);
+    }
+
+    pub(crate) fn plan_inbound(
+        &self,
+        public_port: u16,
+        remote_address: Ipv4Address,
+        now_ms: u64,
+    ) -> Result<Nat44UdpInboundPlan, Nat44UdpPlanError> {
+        self.check_clock(now_ms)?;
+        let Some((mapping_index, mapping)) =
+            self.mappings
+                .iter()
+                .copied()
+                .enumerate()
+                .find(|(_, mapping)| {
+                    self.mapping_is_live(*mapping, now_ms) && mapping.public_port == public_port
+                })
+        else {
+            return Err(Nat44UdpPlanError::MappingMiss);
+        };
+        if !self.peer_exists(mapping_index, mapping.generation, remote_address) {
+            return Err(Nat44UdpPlanError::FilterDenied);
+        }
+        Ok(Nat44UdpInboundPlan {
+            mapping_index,
+            mapping_generation: mapping.generation,
+            internal_address: mapping.internal_address,
+            internal_port: mapping.internal_port,
+        })
+    }
+
+    pub(crate) fn commit_inbound(&mut self, plan: Nat44UdpInboundPlan, now_ms: u64) {
+        debug_assert!(self
+            .mappings
+            .get(plan.mapping_index)
+            .is_some_and(|mapping| {
+                mapping.occupied && mapping.generation == plan.mapping_generation
+            }));
+        self.watermark_ms = Some(now_ms);
+        self.counters.inbound_translated = self.counters.inbound_translated.saturating_add(1);
+    }
+
+    pub(crate) fn record_plan_error(&mut self, error: Nat44UdpPlanError) {
+        match error {
+            Nat44UdpPlanError::MappingMiss => {
+                self.counters.mapping_misses = self.counters.mapping_misses.saturating_add(1);
+            }
+            Nat44UdpPlanError::FilterDenied => {
+                self.counters.filter_denied = self.counters.filter_denied.saturating_add(1);
+            }
+            Nat44UdpPlanError::MappingFull => {
+                self.counters.mapping_full = self.counters.mapping_full.saturating_add(1);
+            }
+            Nat44UdpPlanError::PeerFull => {
+                self.counters.peer_full = self.counters.peer_full.saturating_add(1);
+            }
+            Nat44UdpPlanError::PortExhausted => {
+                self.counters.port_exhausted = self.counters.port_exhausted.saturating_add(1);
+            }
+            Nat44UdpPlanError::ClockRegression => {
+                self.counters.clock_regressions = self.counters.clock_regressions.saturating_add(1);
+            }
+        }
+    }
+
+    fn check_clock(&self, now_ms: u64) -> Result<(), Nat44UdpPlanError> {
+        if self
+            .watermark_ms
+            .is_some_and(|watermark| now_ms < watermark)
+        {
+            Err(Nat44UdpPlanError::ClockRegression)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn mapping_is_live(&self, mapping: Nat44UdpMappingSlot, now_ms: u64) -> bool {
+        mapping.occupied
+            && now_ms >= mapping.last_outbound_ms
+            && now_ms - mapping.last_outbound_ms < self.config.policy.idle_ttl_ms
+    }
+
+    fn find_mapping(
+        &self,
+        internal_address: Ipv4Address,
+        internal_port: u16,
+        now_ms: u64,
+    ) -> Option<(usize, Nat44UdpMappingSlot)> {
+        self.mappings
+            .iter()
+            .copied()
+            .enumerate()
+            .find(|(_, mapping)| {
+                self.mapping_is_live(*mapping, now_ms)
+                    && mapping.inside == self.config.inside
+                    && mapping.internal_address == internal_address
+                    && mapping.internal_port == internal_port
+            })
+    }
+
+    fn find_reusable_mapping(&self, now_ms: u64) -> Option<usize> {
+        self.mappings
+            .iter()
+            .position(|mapping| !self.mapping_is_live(*mapping, now_ms))
+    }
+
+    fn peer_exists(
+        &self,
+        mapping_index: usize,
+        mapping_generation: u64,
+        remote_address: Ipv4Address,
+    ) -> bool {
+        self.peers.iter().any(|peer| {
+            peer.occupied
+                && peer.mapping_index == mapping_index
+                && peer.mapping_generation == mapping_generation
+                && peer.remote_address == remote_address
+        })
+    }
+
+    fn find_reusable_peer(&self, now_ms: u64) -> Option<usize> {
+        self.peers.iter().position(|peer| {
+            if !peer.occupied {
+                return true;
+            }
+            self.mappings.get(peer.mapping_index).is_none_or(|mapping| {
+                !self.mapping_is_live(*mapping, now_ms)
+                    || mapping.generation != peer.mapping_generation
+            })
+        })
+    }
+
+    fn port_is_free(&self, port: u16, now_ms: u64) -> bool {
+        !self
+            .mappings
+            .iter()
+            .any(|mapping| self.mapping_is_live(*mapping, now_ms) && mapping.public_port == port)
+    }
+
+    fn allocate_port(
+        &self,
+        internal_address: Ipv4Address,
+        internal_port: u16,
+        now_ms: u64,
+    ) -> Option<u16> {
+        if (self.config.first_port..=self.config.last_port).contains(&internal_port)
+            && self.port_is_free(internal_port, now_ms)
+        {
+            return Some(internal_port);
+        }
+        let pool_size = u32::from(self.config.last_port) - u32::from(self.config.first_port) + 1;
+        let address = u32::from_be_bytes(internal_address.octets());
+        let mixed = self.config.policy.allocator_seed
+            ^ u64::from(address)
+            ^ u64::from(internal_port).rotate_left(17);
+        let start = u32::try_from(mixed % u64::from(pool_size)).ok()?;
+        for step in 0..pool_size {
+            let offset = (start + step) % pool_size;
+            let candidate = u16::try_from(u32::from(self.config.first_port) + offset).ok()?;
+            if self.port_is_free(candidate, now_ms) {
+                return Some(candidate);
+            }
+        }
+        None
+    }
+
+    fn next_nonzero_generation(&self) -> u64 {
+        self.next_generation.max(1)
+    }
+}
+
+fn address_is_host_unicast(snapshot: &ForwardingSnapshot<'_>, address: Ipv4Address) -> bool {
+    let octets = address.octets();
+    if octets[0] == 0 || octets[0] == 127 || octets[0] >= 224 || octets == [255; 4] {
+        return false;
+    }
+    !route::lookup(snapshot.routes, address).is_some_and(|selected| {
+        selected.is_prefix_network_address(address)
+            || selected.is_prefix_directed_broadcast(address)
+    })
+}
+
+fn snapshot_authority(snapshot: &ForwardingSnapshot<'_>) -> u64 {
+    fn mix(hash: u64, value: u64) -> u64 {
+        (hash ^ value).wrapping_mul(0x0000_0100_0000_01b3)
+    }
+
+    let mut hash = 0xcbf2_9ce4_8422_2325;
+    for interface in snapshot.interfaces {
+        hash = mix(hash, u64::from(interface.id.0));
+        for octet in interface.mac.0 {
+            hash = mix(hash, u64::from(octet));
+        }
+    }
+    hash = mix(hash, 0xff);
+    for binding in snapshot.local_ipv4 {
+        hash = mix(hash, u64::from(binding.interface.0));
+        hash = mix(
+            hash,
+            u64::from(u32::from_be_bytes(binding.address.octets())),
+        );
+    }
+    hash = mix(hash, 0xfe);
+    for route in snapshot.routes {
+        hash = mix(hash, u64::from(u32::from_be_bytes(route.prefix().octets())));
+        hash = mix(hash, u64::from(route.prefix_len()));
+        hash = mix(hash, u64::from(route.egress().0));
+        hash = mix(
+            hash,
+            route.next_hop().map_or(u64::MAX, |next| {
+                u64::from(u32::from_be_bytes(next.octets()))
+            }),
+        );
+    }
+    hash = mix(hash, 0xfd);
+    for neighbor in snapshot.neighbors {
+        hash = mix(hash, u64::from(neighbor.interface.0));
+        hash = mix(
+            hash,
+            u64::from(u32::from_be_bytes(neighbor.target.octets())),
+        );
+        for octet in neighbor.mac.0 {
+            hash = mix(hash, u64::from(octet));
+        }
+    }
+    hash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Interface, LocalIpv4Binding, MacAddress, Neighbor, Route};
+
+    const INSIDE: IfId = IfId(1);
+    const OUTSIDE: IfId = IfId(2);
+    const INTERNAL: Ipv4Address = Ipv4Address::from_octets([10, 0, 0, 10]);
+    const INTERNAL2: Ipv4Address = Ipv4Address::from_octets([10, 0, 0, 11]);
+    const PUBLIC: Ipv4Address = Ipv4Address::from_octets([203, 0, 113, 10]);
+    const REMOTE1: Ipv4Address = Ipv4Address::from_octets([198, 51, 100, 1]);
+    const REMOTE2: Ipv4Address = Ipv4Address::from_octets([198, 51, 100, 2]);
+
+    fn with_config<R>(policy: Nat44UdpPolicy, run: impl FnOnce(Nat44UdpConfig) -> R) -> R {
+        let routes = [
+            Route::new(Ipv4Address::from_octets([10, 0, 0, 0]), 24, INSIDE, None).unwrap(),
+            Route::new(
+                Ipv4Address::from_octets([0, 0, 0, 0]),
+                0,
+                OUTSIDE,
+                Some(Ipv4Address::from_octets([203, 0, 113, 1])),
+            )
+            .unwrap(),
+        ];
+        let interfaces = [
+            Interface {
+                id: INSIDE,
+                mac: MacAddress([2, 0, 0, 0, 0, 1]),
+            },
+            Interface {
+                id: OUTSIDE,
+                mac: MacAddress([2, 0, 0, 0, 0, 2]),
+            },
+        ];
+        let neighbors = [Neighbor {
+            interface: OUTSIDE,
+            target: Ipv4Address::from_octets([203, 0, 113, 1]),
+            mac: MacAddress([2, 0, 0, 0, 0, 3]),
+        }];
+        let bindings = [
+            LocalIpv4Binding {
+                interface: INSIDE,
+                address: Ipv4Address::from_octets([10, 0, 0, 1]),
+            },
+            LocalIpv4Binding {
+                interface: OUTSIDE,
+                address: PUBLIC,
+            },
+        ];
+        let snapshot =
+            ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &bindings).unwrap();
+        let config =
+            Nat44UdpConfig::new(&snapshot, INSIDE, OUTSIDE, PUBLIC, 40_000, 40_001, policy)
+                .unwrap();
+        run(config)
+    }
+
+    #[test]
+    fn eim_adf_expiry_and_generation_invalidate_stale_peers() {
+        let policy = Nat44UdpPolicy::new(NAT44_UDP_MIN_IDLE_TTL_MS, 11).unwrap();
+        with_config(policy, |config| {
+            let mut mappings = [Nat44UdpMappingSlot::default(); 1];
+            let mut peers = [Nat44UdpPeerSlot::default(); 2];
+            let mut runtime = Nat44UdpRuntime::new(config, &mut mappings, &mut peers);
+            let first = runtime.plan_outbound(INTERNAL, 40_000, REMOTE1, 0).unwrap();
+            assert_eq!(first.public_port(), 40_000);
+            runtime.commit_outbound(first, 0);
+            let second = runtime.plan_outbound(INTERNAL, 40_000, REMOTE2, 1).unwrap();
+            assert_eq!(second.public_port(), 40_000);
+            runtime.commit_outbound(second, 1);
+            assert!(runtime.plan_inbound(40_000, REMOTE1, 2).is_ok());
+            assert!(runtime.plan_inbound(40_000, REMOTE2, 2).is_ok());
+
+            assert!(matches!(
+                runtime.plan_inbound(40_000, REMOTE1, NAT44_UDP_MIN_IDLE_TTL_MS + 1),
+                Err(Nat44UdpPlanError::MappingMiss)
+            ));
+            let reused = runtime
+                .plan_outbound(INTERNAL2, 40_000, REMOTE2, NAT44_UDP_MIN_IDLE_TTL_MS + 1)
+                .unwrap();
+            runtime.commit_outbound(reused, NAT44_UDP_MIN_IDLE_TTL_MS + 1);
+            assert!(matches!(
+                runtime.plan_inbound(reused.public_port(), REMOTE1, NAT44_UDP_MIN_IDLE_TTL_MS + 1),
+                Err(Nat44UdpPlanError::FilterDenied)
+            ));
+            assert!(runtime
+                .plan_inbound(reused.public_port(), REMOTE2, NAT44_UDP_MIN_IDLE_TTL_MS + 1)
+                .is_ok());
+        });
+    }
+
+    #[test]
+    fn full_tables_do_not_evict_or_refresh_live_state_and_zero_capacity_is_safe() {
+        with_config(Nat44UdpPolicy::default(), |config| {
+            let mut mappings = [Nat44UdpMappingSlot::default(); 1];
+            let mut peers = [Nat44UdpPeerSlot::default(); 1];
+            let mut runtime = Nat44UdpRuntime::new(config, &mut mappings, &mut peers);
+            let first = runtime
+                .plan_outbound(INTERNAL, 40_000, REMOTE1, 10)
+                .unwrap();
+            runtime.commit_outbound(first, 10);
+            assert!(matches!(
+                runtime.plan_outbound(INTERNAL, 40_000, REMOTE2, 20),
+                Err(Nat44UdpPlanError::PeerFull)
+            ));
+            assert_eq!(runtime.mappings()[0].last_outbound_ms(), 10);
+            assert!(matches!(
+                runtime.plan_outbound(INTERNAL2, 40_001, REMOTE1, 20),
+                Err(Nat44UdpPlanError::MappingFull)
+            ));
+            assert_eq!(runtime.mappings()[0].internal_address(), INTERNAL);
+
+            let mut no_mappings = [];
+            let mut one_peer = [Nat44UdpPeerSlot::default(); 1];
+            let empty = Nat44UdpRuntime::new(config, &mut no_mappings, &mut one_peer);
+            assert!(matches!(
+                empty.plan_outbound(INTERNAL, 40_000, REMOTE1, 0),
+                Err(Nat44UdpPlanError::MappingFull)
+            ));
+            let mut one_mapping = [Nat44UdpMappingSlot::default(); 1];
+            let mut no_peers = [];
+            let empty = Nat44UdpRuntime::new(config, &mut one_mapping, &mut no_peers);
+            assert!(matches!(
+                empty.plan_outbound(INTERNAL, 40_000, REMOTE1, 0),
+                Err(Nat44UdpPlanError::PeerFull)
+            ));
+        });
+    }
+
+    #[test]
+    fn seeded_scan_wraps_once_after_a_preserved_port_collision() {
+        with_config(Nat44UdpPolicy::default(), |config| {
+            let mut mappings = [Nat44UdpMappingSlot::default(); 2];
+            let mut peers = [Nat44UdpPeerSlot::default(); 2];
+            let mut runtime = Nat44UdpRuntime::new(config, &mut mappings, &mut peers);
+            let last = runtime.plan_outbound(INTERNAL, 40_001, REMOTE1, 0).unwrap();
+            assert_eq!(last.public_port(), 40_001);
+            runtime.commit_outbound(last, 0);
+
+            // For INTERNAL2/50000 and seed zero the deterministic start is
+            // offset one. It collides with 40001, wraps, and selects 40000.
+            let wrapped = runtime
+                .plan_outbound(INTERNAL2, 50_000, REMOTE1, 0)
+                .unwrap();
+            assert_eq!(wrapped.public_port(), 40_000);
+            runtime.commit_outbound(wrapped, 0);
+            assert_ne!(
+                runtime.mappings()[0].public_port(),
+                runtime.mappings()[1].public_port()
+            );
+        });
+    }
+
+    #[test]
+    fn clock_regression_is_atomic_and_equal_time_recovers() {
+        with_config(Nat44UdpPolicy::default(), |config| {
+            let mut mappings = [Nat44UdpMappingSlot::default(); 1];
+            let mut peers = [Nat44UdpPeerSlot::default(); 1];
+            let mut runtime = Nat44UdpRuntime::new(config, &mut mappings, &mut peers);
+            let first = runtime
+                .plan_outbound(INTERNAL, 40_000, REMOTE1, 100)
+                .unwrap();
+            runtime.commit_outbound(first, 100);
+            let before = runtime.mappings()[0];
+            assert!(matches!(
+                runtime.plan_outbound(INTERNAL, 40_000, REMOTE1, 99),
+                Err(Nat44UdpPlanError::ClockRegression)
+            ));
+            assert_eq!(runtime.mappings()[0], before);
+            let equal = runtime
+                .plan_outbound(INTERNAL, 40_000, REMOTE1, 100)
+                .unwrap();
+            runtime.commit_outbound(equal, 100);
+            assert_eq!(runtime.mappings()[0].last_outbound_ms(), 100);
+        });
+    }
+
+    #[test]
+    fn reconcile_flushes_every_mapping_and_peer_before_rebinding() {
+        with_config(Nat44UdpPolicy::default(), |config| {
+            let mut mappings = [Nat44UdpMappingSlot::default(); 1];
+            let mut peers = [Nat44UdpPeerSlot::default(); 1];
+            let mut runtime = Nat44UdpRuntime::new(config, &mut mappings, &mut peers);
+            let first = runtime.plan_outbound(INTERNAL, 40_000, REMOTE1, 0).unwrap();
+            runtime.commit_outbound(first, 0);
+            let report = runtime.reconcile(config);
+            assert_eq!(
+                report,
+                Nat44UdpReconcileReport {
+                    mappings_flushed: 1,
+                    peers_flushed: 1,
+                }
+            );
+            assert!(runtime.mappings().iter().all(|slot| !slot.occupied));
+            assert!(runtime.peers().iter().all(|slot| !slot.occupied));
+            assert!(matches!(
+                runtime.plan_inbound(40_000, REMOTE1, 0),
+                Err(Nat44UdpPlanError::MappingMiss)
+            ));
+        });
+    }
+
+    #[test]
+    fn policy_and_config_reject_ambiguous_or_unsafe_authority() {
+        assert_eq!(
+            Nat44UdpPolicy::new(NAT44_UDP_MIN_IDLE_TTL_MS - 1, 0),
+            Err(Nat44UdpPolicyError::IdleTtlTooShort)
+        );
+        assert_eq!(
+            Nat44UdpPolicy::new(NAT44_UDP_MAX_IDLE_TTL_MS + 1, 0),
+            Err(Nat44UdpPolicyError::IdleTtlTooLong)
+        );
+        with_config(Nat44UdpPolicy::default(), |config| {
+            assert_eq!(config.policy().idle_ttl_ms(), NAT44_UDP_DEFAULT_IDLE_TTL_MS);
+            assert_ne!(config.inside(), config.outside());
+            assert_ne!(config.first_port(), 0);
+        });
+    }
+}

--- a/crates/core/src/nat44.rs
+++ b/crates/core/src/nat44.rs
@@ -452,14 +452,26 @@ impl<'a> Nat44UdpRuntime<'a> {
         self.counters.config_mismatches = self.counters.config_mismatches.saturating_add(1);
     }
 
+    pub(crate) fn observe_now(&mut self, now_ms: u64) -> Result<(), Nat44UdpPlanError> {
+        if self
+            .watermark_ms
+            .is_some_and(|watermark| now_ms < watermark)
+        {
+            self.counters.clock_regressions = self.counters.clock_regressions.saturating_add(1);
+            return Err(Nat44UdpPlanError::ClockRegression);
+        }
+        self.watermark_ms = Some(now_ms);
+        Ok(())
+    }
+
     pub(crate) fn plan_outbound(
-        &self,
+        &mut self,
         internal_address: Ipv4Address,
         internal_port: u16,
         remote_address: Ipv4Address,
         now_ms: u64,
     ) -> Result<Nat44UdpOutboundPlan, Nat44UdpPlanError> {
-        self.check_clock(now_ms)?;
+        self.observe_now(now_ms)?;
         if let Some((mapping_index, mapping)) =
             self.find_mapping(internal_address, internal_port, now_ms)
         {
@@ -563,12 +575,12 @@ impl<'a> Nat44UdpRuntime<'a> {
     }
 
     pub(crate) fn plan_inbound(
-        &self,
+        &mut self,
         public_port: u16,
         remote_address: Ipv4Address,
         now_ms: u64,
     ) -> Result<Nat44UdpInboundPlan, Nat44UdpPlanError> {
-        self.check_clock(now_ms)?;
+        self.observe_now(now_ms)?;
         let Some((mapping_index, mapping)) =
             self.mappings
                 .iter()
@@ -620,19 +632,9 @@ impl<'a> Nat44UdpRuntime<'a> {
                 self.counters.port_exhausted = self.counters.port_exhausted.saturating_add(1);
             }
             Nat44UdpPlanError::ClockRegression => {
-                self.counters.clock_regressions = self.counters.clock_regressions.saturating_add(1);
+                // `observe_now` owns this counter so a forwarding caller can
+                // record the typed plan error without double-counting it.
             }
-        }
-    }
-
-    fn check_clock(&self, now_ms: u64) -> Result<(), Nat44UdpPlanError> {
-        if self
-            .watermark_ms
-            .is_some_and(|watermark| now_ms < watermark)
-        {
-            Err(Nat44UdpPlanError::ClockRegression)
-        } else {
-            Ok(())
         }
     }
 
@@ -902,14 +904,14 @@ mod tests {
 
             let mut no_mappings = [];
             let mut one_peer = [Nat44UdpPeerSlot::default(); 1];
-            let empty = Nat44UdpRuntime::new(config, &mut no_mappings, &mut one_peer);
+            let mut empty = Nat44UdpRuntime::new(config, &mut no_mappings, &mut one_peer);
             assert!(matches!(
                 empty.plan_outbound(INTERNAL, 40_000, REMOTE1, 0),
                 Err(Nat44UdpPlanError::MappingFull)
             ));
             let mut one_mapping = [Nat44UdpMappingSlot::default(); 1];
             let mut no_peers = [];
-            let empty = Nat44UdpRuntime::new(config, &mut one_mapping, &mut no_peers);
+            let mut empty = Nat44UdpRuntime::new(config, &mut one_mapping, &mut no_peers);
             assert!(matches!(
                 empty.plan_outbound(INTERNAL, 40_000, REMOTE1, 0),
                 Err(Nat44UdpPlanError::PeerFull)
@@ -957,11 +959,74 @@ mod tests {
                 Err(Nat44UdpPlanError::ClockRegression)
             ));
             assert_eq!(runtime.mappings()[0], before);
+            assert_eq!(runtime.counters().clock_regressions, 1);
             let equal = runtime
                 .plan_outbound(INTERNAL, 40_000, REMOTE1, 100)
                 .unwrap();
             runtime.commit_outbound(equal, 100);
             assert_eq!(runtime.mappings()[0].last_outbound_ms(), 100);
+        });
+    }
+
+    #[test]
+    fn failed_lookup_and_capacity_operations_advance_the_watermark() {
+        let policy = Nat44UdpPolicy::new(NAT44_UDP_MIN_IDLE_TTL_MS, 0).unwrap();
+        with_config(policy, |config| {
+            let mut mappings = [Nat44UdpMappingSlot::default(); 1];
+            let mut peers = [Nat44UdpPeerSlot::default(); 1];
+            let mut runtime = Nat44UdpRuntime::new(config, &mut mappings, &mut peers);
+            let first = runtime.plan_outbound(INTERNAL, 40_000, REMOTE1, 0).unwrap();
+            runtime.commit_outbound(first, 0);
+            assert!(matches!(
+                runtime.plan_inbound(40_000, REMOTE1, NAT44_UDP_MIN_IDLE_TTL_MS),
+                Err(Nat44UdpPlanError::MappingMiss)
+            ));
+            assert!(matches!(
+                runtime.plan_inbound(40_000, REMOTE1, NAT44_UDP_MIN_IDLE_TTL_MS - 1),
+                Err(Nat44UdpPlanError::ClockRegression)
+            ));
+            assert!(matches!(
+                runtime.plan_inbound(40_000, REMOTE1, NAT44_UDP_MIN_IDLE_TTL_MS),
+                Err(Nat44UdpPlanError::MappingMiss)
+            ));
+        });
+
+        with_config(Nat44UdpPolicy::default(), |config| {
+            let mut mappings = [Nat44UdpMappingSlot::default(); 1];
+            let mut peers = [Nat44UdpPeerSlot::default(); 1];
+            let mut runtime = Nat44UdpRuntime::new(config, &mut mappings, &mut peers);
+            let first = runtime.plan_outbound(INTERNAL, 40_000, REMOTE1, 0).unwrap();
+            runtime.commit_outbound(first, 0);
+            assert!(matches!(
+                runtime.plan_inbound(40_000, REMOTE2, 100),
+                Err(Nat44UdpPlanError::FilterDenied)
+            ));
+            assert!(matches!(
+                runtime.plan_outbound(INTERNAL, 40_000, REMOTE1, 99),
+                Err(Nat44UdpPlanError::ClockRegression)
+            ));
+            assert!(runtime
+                .plan_outbound(INTERNAL, 40_000, REMOTE1, 100)
+                .is_ok());
+        });
+
+        with_config(Nat44UdpPolicy::default(), |config| {
+            let mut mappings = [Nat44UdpMappingSlot::default(); 1];
+            let mut peers = [Nat44UdpPeerSlot::default(); 2];
+            let mut runtime = Nat44UdpRuntime::new(config, &mut mappings, &mut peers);
+            let first = runtime.plan_outbound(INTERNAL, 40_000, REMOTE1, 0).unwrap();
+            runtime.commit_outbound(first, 0);
+            assert!(matches!(
+                runtime.plan_outbound(INTERNAL2, 40_001, REMOTE1, 200),
+                Err(Nat44UdpPlanError::MappingFull)
+            ));
+            assert!(matches!(
+                runtime.plan_outbound(INTERNAL, 40_000, REMOTE1, 199),
+                Err(Nat44UdpPlanError::ClockRegression)
+            ));
+            assert!(runtime
+                .plan_outbound(INTERNAL, 40_000, REMOTE1, 200)
+                .is_ok());
         });
     }
 

--- a/crates/io-sim/src/lib.rs
+++ b/crates/io-sim/src/lib.rs
@@ -4,11 +4,12 @@
 use std::{collections::VecDeque, convert::Infallible};
 
 use ruster_core::{
-    forward_batch, BatchCompletion, BatchReport, ConsumeReason, DropReason, ForwardingSnapshot,
-    GeneratedAllocationError, GeneratedArpTrace, GeneratedBatchCompletion, GeneratedIcmpv4Trace,
-    GeneratedIcmpv4TraceSink, GeneratedPacketBatch, GeneratedPacketIo, GeneratedPacketLease,
-    GeneratedPacketSlot, GeneratedSlotCompletion, GeneratedTraceSink, IfId, PacketBatch, PacketIo,
-    PacketLease, PacketSlot, SlotCompletion, TraceEvent, TraceSink,
+    forward_batch, forward_batch_with_nat44_udp, BatchCompletion, BatchReport, ConsumeReason,
+    DropReason, ForwardingSnapshot, GeneratedAllocationError, GeneratedArpTrace,
+    GeneratedBatchCompletion, GeneratedIcmpv4Trace, GeneratedIcmpv4TraceSink, GeneratedPacketBatch,
+    GeneratedPacketIo, GeneratedPacketLease, GeneratedPacketSlot, GeneratedSlotCompletion,
+    GeneratedTraceSink, IfId, MonotonicMillis, Nat44UdpConfig, Nat44UdpRuntime, PacketBatch,
+    PacketIo, PacketLease, PacketSlot, ResolutionRuntime, SlotCompletion, TraceEvent, TraceSink,
 };
 
 #[derive(Debug, Eq, PartialEq)]
@@ -37,6 +38,7 @@ pub enum FrameOrigin {
 pub enum RecycleCause {
     Forwarding(DropReason),
     Consumed(ConsumeReason),
+    TxRejected,
     LeaseAbandoned,
 }
 
@@ -79,6 +81,7 @@ pub struct SimIo {
     generated_max_frame: usize,
     generated_accept_budget: usize,
     fail_generated_finish: bool,
+    received_accept_budget: usize,
 }
 
 impl Default for SimIo {
@@ -93,6 +96,7 @@ impl Default for SimIo {
             generated_max_frame: 1_514,
             generated_accept_budget: usize::MAX,
             fail_generated_finish: false,
+            received_accept_budget: usize::MAX,
         }
     }
 }
@@ -157,6 +161,10 @@ impl SimIo {
         self.fail_generated_finish = true;
     }
 
+    pub fn set_received_accept_budget(&mut self, budget: usize) {
+        self.received_accept_budget = budget;
+    }
+
     pub fn run_once<T: TraceSink>(
         &mut self,
         budget: usize,
@@ -165,6 +173,23 @@ impl SimIo {
     ) -> Result<BatchReport<Infallible>, Infallible> {
         let batch = self.receive(budget)?;
         Ok(forward_batch(batch, snapshot, trace))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn run_nat44_udp_once<T: TraceSink>(
+        &mut self,
+        budget: usize,
+        snapshot: &ForwardingSnapshot<'_>,
+        resolution: &mut ResolutionRuntime<'_>,
+        config: &Nat44UdpConfig,
+        nat44_udp: Option<&mut Nat44UdpRuntime<'_>>,
+        now: MonotonicMillis,
+        trace: &mut T,
+    ) -> Result<BatchReport<Infallible>, Infallible> {
+        let batch = self.receive(budget)?;
+        Ok(forward_batch_with_nat44_udp(
+            batch, snapshot, resolution, config, nat44_udp, now, trace,
+        ))
     }
 }
 
@@ -178,6 +203,7 @@ impl PacketIo for SimIo {
             rx: &mut self.rx,
             tx: &mut self.tx,
             recycled: &mut self.recycled,
+            accept_budget: &mut self.received_accept_budget,
             remaining,
             counters: BatchCounters::default(),
         })
@@ -188,6 +214,7 @@ pub struct SimBatch<'a> {
     rx: &'a mut VecDeque<Slot>,
     tx: &'a mut VecDeque<TxFrame>,
     recycled: &'a mut VecDeque<RecycledFrame>,
+    accept_budget: &'a mut usize,
     remaining: usize,
     counters: BatchCounters,
 }
@@ -196,6 +223,7 @@ pub struct SimBatch<'a> {
 struct BatchCounters {
     tx_requested: usize,
     tx_accepted: usize,
+    tx_rejected: usize,
     recycled: usize,
 }
 
@@ -216,6 +244,7 @@ impl PacketBatch for SimBatch<'_> {
             slot: Some(slot),
             tx: self.tx,
             recycled: self.recycled,
+            accept_budget: self.accept_budget,
             counters: &mut self.counters,
         }))
     }
@@ -224,7 +253,7 @@ impl PacketBatch for SimBatch<'_> {
         BatchCompletion {
             tx_requested: self.counters.tx_requested,
             tx_accepted: self.counters.tx_accepted,
-            tx_rejected: 0,
+            tx_rejected: self.counters.tx_rejected,
             recycled: self.counters.recycled,
             error: None,
         }
@@ -235,6 +264,7 @@ pub struct SimSlot<'a> {
     slot: Option<Slot>,
     tx: &'a mut VecDeque<TxFrame>,
     recycled: &'a mut VecDeque<RecycledFrame>,
+    accept_budget: &'a mut usize,
     counters: &'a mut BatchCounters,
 }
 
@@ -252,16 +282,27 @@ impl PacketSlot for SimSlot<'_> {
         match completion {
             SlotCompletion::Transmit(egress) => {
                 self.counters.tx_requested += 1;
-                self.tx.push_back(TxFrame {
-                    sequence: slot.sequence,
-                    ingress: slot.ingress,
-                    egress,
-                    origin: FrameOrigin::Received {
+                if *self.accept_budget == 0 {
+                    self.counters.tx_rejected += 1;
+                    self.recycled.push_back(RecycledFrame {
+                        sequence: slot.sequence,
                         ingress: slot.ingress,
-                    },
-                    bytes: slot.bytes,
-                });
-                self.counters.tx_accepted += 1;
+                        cause: RecycleCause::TxRejected,
+                        bytes: slot.bytes,
+                    });
+                } else {
+                    *self.accept_budget -= 1;
+                    self.tx.push_back(TxFrame {
+                        sequence: slot.sequence,
+                        ingress: slot.ingress,
+                        egress,
+                        origin: FrameOrigin::Received {
+                            ingress: slot.ingress,
+                        },
+                        bytes: slot.bytes,
+                    });
+                    self.counters.tx_accepted += 1;
+                }
             }
             SlotCompletion::Recycle(reason) => {
                 self.recycle(slot, RecycleCause::Forwarding(reason));

--- a/crates/io-sim/tests/nat44_udp.rs
+++ b/crates/io-sim/tests/nat44_udp.rs
@@ -1,0 +1,1305 @@
+use ruster_core::{
+    internet_checksum, ipv4_header_checksum, rfc1624_update, DropReason, DynamicNeighborSlot,
+    ForwardingSnapshot, IfId, Interface, Ipv4Address, LocalIpv4Binding, MacAddress,
+    MonotonicMillis, Nat44UdpConfig, Nat44UdpConfigError, Nat44UdpDisposition, Nat44UdpMappingSlot,
+    Nat44UdpPeerSlot, Nat44UdpPolicy, Nat44UdpRuntime, Neighbor, NoTrace, ResolutionActionSlot,
+    ResolutionPolicy, ResolutionRuntime, ResolutionStateSlot, Route, TraceEvent,
+    NAT44_UDP_MIN_IDLE_TTL_MS,
+};
+use ruster_io_sim::{RecycleCause, SimIo, VecTrace};
+
+const LAN: IfId = IfId(1);
+const WAN: IfId = IfId(2);
+const DMZ: IfId = IfId(3);
+const LAN_MAC: MacAddress = MacAddress([0x02, 0, 0, 0, 0, 1]);
+const WAN_MAC: MacAddress = MacAddress([0x02, 0, 0, 0, 0, 2]);
+const DMZ_MAC: MacAddress = MacAddress([0x02, 0, 0, 0, 0, 3]);
+const HOST_MAC: MacAddress = MacAddress([0x02, 0, 0, 0, 0, 10]);
+const GATEWAY_MAC: MacAddress = MacAddress([0x02, 0, 0, 0, 0, 20]);
+const PUBLIC: Ipv4Address = Ipv4Address::from_octets([203, 0, 113, 10]);
+const LAN_LOCAL: Ipv4Address = Ipv4Address::from_octets([10, 0, 0, 1]);
+const HOST: Ipv4Address = Ipv4Address::from_octets([10, 0, 0, 10]);
+const HOST2: Ipv4Address = Ipv4Address::from_octets([10, 0, 0, 11]);
+const REMOTE1: Ipv4Address = Ipv4Address::from_octets([198, 51, 100, 20]);
+const REMOTE2: Ipv4Address = Ipv4Address::from_octets([192, 0, 2, 30]);
+const GATEWAY: Ipv4Address = Ipv4Address::from_octets([203, 0, 113, 1]);
+
+fn base() -> (
+    [Route; 2],
+    [Interface; 3],
+    [Neighbor; 3],
+    [LocalIpv4Binding; 2],
+) {
+    (
+        [
+            Route::new(Ipv4Address::from_octets([10, 0, 0, 0]), 24, LAN, None).unwrap(),
+            Route::new(
+                Ipv4Address::from_octets([0, 0, 0, 0]),
+                0,
+                WAN,
+                Some(GATEWAY),
+            )
+            .unwrap(),
+        ],
+        [
+            Interface {
+                id: LAN,
+                mac: LAN_MAC,
+            },
+            Interface {
+                id: WAN,
+                mac: WAN_MAC,
+            },
+            Interface {
+                id: DMZ,
+                mac: DMZ_MAC,
+            },
+        ],
+        [
+            Neighbor {
+                interface: LAN,
+                target: HOST,
+                mac: HOST_MAC,
+            },
+            Neighbor {
+                interface: LAN,
+                target: HOST2,
+                mac: MacAddress([0x02, 0, 0, 0, 0, 11]),
+            },
+            Neighbor {
+                interface: WAN,
+                target: GATEWAY,
+                mac: GATEWAY_MAC,
+            },
+        ],
+        [
+            LocalIpv4Binding {
+                interface: LAN,
+                address: LAN_LOCAL,
+            },
+            LocalIpv4Binding {
+                interface: WAN,
+                address: PUBLIC,
+            },
+        ],
+    )
+}
+
+fn config(snapshot: &ForwardingSnapshot<'_>, first: u16, last: u16) -> Nat44UdpConfig {
+    Nat44UdpConfig::new(
+        snapshot,
+        LAN,
+        WAN,
+        PUBLIC,
+        first,
+        last,
+        Nat44UdpPolicy::default(),
+    )
+    .unwrap()
+}
+
+fn resolution<'a>(
+    states: &'a mut [ResolutionStateSlot],
+    actions: &'a mut [ResolutionActionSlot],
+) -> ResolutionRuntime<'a> {
+    ResolutionRuntime::new(
+        ResolutionPolicy::new(1_000, 2_000).unwrap(),
+        states,
+        actions,
+    )
+}
+
+#[derive(Clone, Copy)]
+enum UdpChecksum {
+    Zero,
+    Valid,
+    Raw(u16),
+}
+
+#[allow(clippy::too_many_arguments)]
+fn udp_frame(
+    source: Ipv4Address,
+    destination: Ipv4Address,
+    source_port: u16,
+    destination_port: u16,
+    ttl: u8,
+    flags_fragment: u16,
+    payload: &[u8],
+    ip_padding: &[u8],
+    checksum_mode: UdpChecksum,
+) -> Vec<u8> {
+    let udp_len = 8 + payload.len();
+    let total_len = 20 + udp_len + ip_padding.len();
+    let mut frame = vec![0_u8; 14 + total_len + 3];
+    frame[0..6].copy_from_slice(&LAN_MAC.0);
+    frame[6..12].copy_from_slice(&HOST_MAC.0);
+    frame[12..14].copy_from_slice(&0x0800_u16.to_be_bytes());
+    frame[14] = 0x45;
+    frame[15] = 0xb8;
+    frame[16..18].copy_from_slice(&u16::try_from(total_len).unwrap().to_be_bytes());
+    frame[18..20].copy_from_slice(&0x4242_u16.to_be_bytes());
+    frame[20..22].copy_from_slice(&flags_fragment.to_be_bytes());
+    frame[22] = ttl;
+    frame[23] = 17;
+    frame[26..30].copy_from_slice(&source.octets());
+    frame[30..34].copy_from_slice(&destination.octets());
+    frame[34..36].copy_from_slice(&source_port.to_be_bytes());
+    frame[36..38].copy_from_slice(&destination_port.to_be_bytes());
+    frame[38..40].copy_from_slice(&u16::try_from(udp_len).unwrap().to_be_bytes());
+    frame[42..42 + payload.len()].copy_from_slice(payload);
+    frame[42 + payload.len()..42 + payload.len() + ip_padding.len()].copy_from_slice(ip_padding);
+    let udp_checksum = match checksum_mode {
+        UdpChecksum::Zero => 0,
+        UdpChecksum::Raw(value) => value,
+        UdpChecksum::Valid => compute_udp_checksum(&frame, source, destination, udp_len),
+    };
+    frame[40..42].copy_from_slice(&udp_checksum.to_be_bytes());
+    let ip_checksum = ipv4_header_checksum(&frame[14..34]);
+    frame[24..26].copy_from_slice(&ip_checksum.to_be_bytes());
+    frame
+}
+
+fn compute_udp_checksum(
+    frame: &[u8],
+    source: Ipv4Address,
+    destination: Ipv4Address,
+    udp_len: usize,
+) -> u16 {
+    let mut bytes = Vec::with_capacity(12 + udp_len);
+    bytes.extend_from_slice(&source.octets());
+    bytes.extend_from_slice(&destination.octets());
+    bytes.extend_from_slice(&[0, 17]);
+    bytes.extend_from_slice(&u16::try_from(udp_len).unwrap().to_be_bytes());
+    bytes.extend_from_slice(&frame[34..34 + udp_len]);
+    bytes[18] = 0;
+    bytes[19] = 0;
+    let checksum = internet_checksum(&bytes);
+    if checksum == 0 {
+        0xffff
+    } else {
+        checksum
+    }
+}
+
+fn udp_checksum_valid(frame: &[u8]) -> bool {
+    let source = Ipv4Address::from_octets(frame[26..30].try_into().unwrap());
+    let destination = Ipv4Address::from_octets(frame[30..34].try_into().unwrap());
+    let udp_len = usize::from(u16::from_be_bytes(frame[38..40].try_into().unwrap()));
+    let mut bytes = Vec::with_capacity(12 + udp_len);
+    bytes.extend_from_slice(&source.octets());
+    bytes.extend_from_slice(&destination.octets());
+    bytes.extend_from_slice(&[0, 17]);
+    bytes.extend_from_slice(&u16::try_from(udp_len).unwrap().to_be_bytes());
+    bytes.extend_from_slice(&frame[34..34 + udp_len]);
+    internet_checksum(&bytes) == 0
+}
+
+fn assert_drop(io: &mut SimIo, reason: DropReason, original: &[u8]) {
+    let recycled = io.pop_recycled().unwrap();
+    assert_eq!(recycled.cause, RecycleCause::Forwarding(reason));
+    assert_eq!(recycled.bytes, original);
+}
+
+fn refresh_ipv4_checksum(frame: &mut [u8]) {
+    let header_len = usize::from(frame[14] & 0x0f) * 4;
+    frame[24..26].fill(0);
+    let checksum = ipv4_header_checksum(&frame[14..14 + header_len]);
+    frame[24..26].copy_from_slice(&checksum.to_be_bytes());
+}
+
+fn arp_reply(sender: Ipv4Address, target: Ipv4Address, sender_mac: MacAddress) -> Vec<u8> {
+    let mut frame = vec![0_u8; 60];
+    frame[0..6].copy_from_slice(&WAN_MAC.0);
+    frame[6..12].copy_from_slice(&sender_mac.0);
+    frame[12..14].copy_from_slice(&0x0806_u16.to_be_bytes());
+    frame[14..16].copy_from_slice(&1_u16.to_be_bytes());
+    frame[16..18].copy_from_slice(&0x0800_u16.to_be_bytes());
+    frame[18..22].copy_from_slice(&[6, 4, 0, 2]);
+    frame[22..28].copy_from_slice(&sender_mac.0);
+    frame[28..32].copy_from_slice(&sender.octets());
+    frame[32..38].copy_from_slice(&WAN_MAC.0);
+    frame[38..42].copy_from_slice(&target.octets());
+    frame
+}
+
+#[test]
+fn nat_config_rejects_missing_or_ambiguous_authority_and_invalid_pool() {
+    let (routes, interfaces, neighbors, bindings) = base();
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &bindings).unwrap();
+    let policy = Nat44UdpPolicy::default();
+    assert_eq!(
+        Nat44UdpConfig::new(&snapshot, LAN, LAN, PUBLIC, 40_000, 40_001, policy),
+        Err(Nat44UdpConfigError::InterfacesEqual)
+    );
+    assert_eq!(
+        Nat44UdpConfig::new(&snapshot, IfId(99), WAN, PUBLIC, 40_000, 40_001, policy),
+        Err(Nat44UdpConfigError::InsideInterfaceMissing)
+    );
+    assert_eq!(
+        Nat44UdpConfig::new(&snapshot, WAN, LAN, PUBLIC, 40_000, 40_001, policy),
+        Err(Nat44UdpConfigError::PublicBindingWrongInterface)
+    );
+    assert_eq!(
+        Nat44UdpConfig::new(
+            &snapshot,
+            LAN,
+            WAN,
+            Ipv4Address::from_octets([0; 4]),
+            40_000,
+            40_001,
+            policy
+        ),
+        Err(Nat44UdpConfigError::PublicAddressNotHostUnicast)
+    );
+    assert_eq!(
+        Nat44UdpConfig::new(&snapshot, LAN, WAN, PUBLIC, 0, 40_001, policy),
+        Err(Nat44UdpConfigError::PortPoolIncludesZero)
+    );
+    assert_eq!(
+        Nat44UdpConfig::new(&snapshot, LAN, WAN, PUBLIC, 40_001, 40_000, policy),
+        Err(Nat44UdpConfigError::PortPoolReversed)
+    );
+}
+
+#[test]
+fn exact_bidirectional_wire_and_same_batch_visibility() {
+    let (routes, interfaces, neighbors, bindings) = base();
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &bindings).unwrap();
+    let config = config(&snapshot, 40_000, 40_010);
+    let mut mappings = [Nat44UdpMappingSlot::default(); 2];
+    let mut peers = [Nat44UdpPeerSlot::default(); 4];
+    let mut nat = Nat44UdpRuntime::new(config, &mut mappings, &mut peers);
+    let mut rs = [ResolutionStateSlot::EMPTY; 1];
+    let mut ra = [ResolutionActionSlot::EMPTY; 1];
+    let mut resolution = resolution(&mut rs, &mut ra);
+    let outbound = udp_frame(
+        HOST,
+        REMOTE1,
+        40_000,
+        53,
+        64,
+        0x4000,
+        &[1, 2, 3, 4, 5],
+        &[0xaa, 0xbb],
+        UdpChecksum::Valid,
+    );
+    let inbound = udp_frame(
+        REMOTE1,
+        PUBLIC,
+        9_999,
+        40_000,
+        50,
+        0x4000,
+        &[9, 8, 7],
+        &[],
+        UdpChecksum::Valid,
+    );
+    let mut io = SimIo::new();
+    io.inject(LAN, outbound);
+    io.inject(WAN, inbound);
+    let mut trace = VecTrace::default();
+    let report = io
+        .run_nat44_udp_once(
+            2,
+            &snapshot,
+            &mut resolution,
+            &config,
+            Some(&mut nat),
+            MonotonicMillis(0),
+            &mut trace,
+        )
+        .unwrap();
+    assert_eq!((report.tx_requested, report.dropped), (2, 0));
+
+    let out = io.pop_tx().unwrap();
+    assert_eq!(out.egress, WAN);
+    assert_eq!(&out.bytes[0..6], &GATEWAY_MAC.0);
+    assert_eq!(&out.bytes[6..12], &WAN_MAC.0);
+    assert_eq!(&out.bytes[26..30], &PUBLIC.octets());
+    assert_eq!(
+        u16::from_be_bytes(out.bytes[34..36].try_into().unwrap()),
+        40_000
+    );
+    assert_eq!(out.bytes[22], 63);
+    assert_eq!(ipv4_header_checksum(&out.bytes[14..34]), 0);
+    assert!(udp_checksum_valid(&out.bytes));
+    assert_eq!(&out.bytes[47..49], &[0xaa, 0xbb]);
+    assert_eq!(&out.bytes[out.bytes.len() - 3..], &[0, 0, 0]);
+
+    let inbound = io.pop_tx().unwrap();
+    assert_eq!(inbound.egress, LAN);
+    assert_eq!(&inbound.bytes[0..6], &HOST_MAC.0);
+    assert_eq!(&inbound.bytes[6..12], &LAN_MAC.0);
+    assert_eq!(&inbound.bytes[30..34], &HOST.octets());
+    assert_eq!(
+        u16::from_be_bytes(inbound.bytes[36..38].try_into().unwrap()),
+        40_000
+    );
+    assert_eq!(inbound.bytes[22], 49);
+    assert_eq!(ipv4_header_checksum(&inbound.bytes[14..34]), 0);
+    assert!(udp_checksum_valid(&inbound.bytes));
+    assert_eq!(nat.counters().outbound_translated, 1);
+    assert_eq!(nat.counters().inbound_translated, 1);
+    assert!(matches!(
+        trace.events(),
+        [
+            TraceEvent::Ipv4Validated { ingress: LAN, .. },
+            TraceEvent::Routed { egress: WAN, .. },
+            TraceEvent::Nat44Udp {
+                ingress: LAN,
+                disposition: Nat44UdpDisposition::OutboundTranslated { .. }
+            },
+            TraceEvent::TxRequested { egress: WAN },
+            TraceEvent::Ipv4Validated { ingress: WAN, .. },
+            TraceEvent::Routed { egress: LAN, .. },
+            TraceEvent::Nat44Udp {
+                ingress: WAN,
+                disposition: Nat44UdpDisposition::InboundTranslated { .. }
+            },
+            TraceEvent::TxRequested { egress: LAN },
+            TraceEvent::BatchCompleted {
+                tx_accepted: 2,
+                tx_rejected: 0
+            }
+        ]
+    ));
+}
+
+#[test]
+fn eim_reuses_public_tuple_and_adf_keys_only_remote_address() {
+    let (routes, interfaces, neighbors, bindings) = base();
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &bindings).unwrap();
+    let config = config(&snapshot, 40_000, 40_010);
+    let mut mappings = [Nat44UdpMappingSlot::default(); 1];
+    let mut peers = [Nat44UdpPeerSlot::default(); 2];
+    let mut nat = Nat44UdpRuntime::new(config, &mut mappings, &mut peers);
+    let mut rs = [ResolutionStateSlot::EMPTY; 1];
+    let mut ra = [ResolutionActionSlot::EMPTY; 1];
+    let mut resolution = resolution(&mut rs, &mut ra);
+    let mut io = SimIo::new();
+    for (remote, port) in [(REMOTE1, 53), (REMOTE2, 4_444)] {
+        io.inject(
+            LAN,
+            udp_frame(
+                HOST,
+                remote,
+                40_000,
+                port,
+                64,
+                0x4000,
+                &[],
+                &[],
+                UdpChecksum::Zero,
+            ),
+        );
+    }
+    io.run_nat44_udp_once(
+        2,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(1),
+        &mut NoTrace,
+    )
+    .unwrap();
+    for _ in 0..2 {
+        let tx = io.pop_tx().unwrap();
+        assert_eq!(
+            u16::from_be_bytes(tx.bytes[34..36].try_into().unwrap()),
+            40_000
+        );
+        assert_eq!(u16::from_be_bytes(tx.bytes[40..42].try_into().unwrap()), 0);
+    }
+    assert_eq!(nat.counters().mappings_created, 1);
+    assert_eq!(nat.counters().mappings_reused, 1);
+    assert_eq!(nat.counters().peers_created, 2);
+
+    io.inject(
+        WAN,
+        udp_frame(
+            REMOTE1,
+            PUBLIC,
+            65_000,
+            40_000,
+            64,
+            0x4000,
+            &[],
+            &[],
+            UdpChecksum::Zero,
+        ),
+    );
+    io.run_nat44_udp_once(
+        1,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(2),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_eq!(io.pop_tx().unwrap().egress, LAN);
+
+    let denied = udp_frame(
+        Ipv4Address::from_octets([198, 51, 100, 21]),
+        PUBLIC,
+        53,
+        40_000,
+        64,
+        0x4000,
+        &[],
+        &[],
+        UdpChecksum::Zero,
+    );
+    io.inject(WAN, denied.clone());
+    io.run_nat44_udp_once(
+        1,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(3),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_drop(&mut io, DropReason::Nat44UdpFilterDenied, &denied);
+}
+
+#[test]
+fn allocator_preserves_then_falls_back_without_overload_and_exhausts() {
+    let (routes, interfaces, neighbors, bindings) = base();
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &bindings).unwrap();
+    let config = config(&snapshot, 40_000, 40_001);
+    let mut mappings = [Nat44UdpMappingSlot::default(); 3];
+    let mut peers = [Nat44UdpPeerSlot::default(); 3];
+    let mut nat = Nat44UdpRuntime::new(config, &mut mappings, &mut peers);
+    let mut rs = [ResolutionStateSlot::EMPTY; 1];
+    let mut ra = [ResolutionActionSlot::EMPTY; 1];
+    let mut resolution = resolution(&mut rs, &mut ra);
+    let mut io = SimIo::new();
+    for host in [HOST, HOST2] {
+        io.inject(
+            LAN,
+            udp_frame(
+                host,
+                REMOTE1,
+                40_000,
+                53,
+                64,
+                0x4000,
+                &[],
+                &[],
+                UdpChecksum::Zero,
+            ),
+        );
+    }
+    io.run_nat44_udp_once(
+        2,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(0),
+        &mut NoTrace,
+    )
+    .unwrap();
+    let first = u16::from_be_bytes(io.pop_tx().unwrap().bytes[34..36].try_into().unwrap());
+    let second = u16::from_be_bytes(io.pop_tx().unwrap().bytes[34..36].try_into().unwrap());
+    assert_eq!(first, 40_000);
+    assert_eq!(second, 40_001);
+
+    let third_host = Ipv4Address::from_octets([10, 0, 0, 12]);
+    let packet = udp_frame(
+        third_host,
+        REMOTE1,
+        50_000,
+        53,
+        64,
+        0x4000,
+        &[],
+        &[],
+        UdpChecksum::Zero,
+    );
+    io.inject(LAN, packet.clone());
+    io.run_nat44_udp_once(
+        1,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(1),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_drop(&mut io, DropReason::Nat44UdpPortExhausted, &packet);
+}
+
+#[test]
+fn exact_idle_expiry_outbound_refresh_and_inbound_no_refresh() {
+    let (routes, interfaces, neighbors, bindings) = base();
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &bindings).unwrap();
+    let policy = Nat44UdpPolicy::new(NAT44_UDP_MIN_IDLE_TTL_MS, 7).unwrap();
+    let config = Nat44UdpConfig::new(&snapshot, LAN, WAN, PUBLIC, 40_000, 40_000, policy).unwrap();
+    let mut mappings = [Nat44UdpMappingSlot::default(); 1];
+    let mut peers = [Nat44UdpPeerSlot::default(); 1];
+    let mut nat = Nat44UdpRuntime::new(config, &mut mappings, &mut peers);
+    let mut rs = [ResolutionStateSlot::EMPTY; 1];
+    let mut ra = [ResolutionActionSlot::EMPTY; 1];
+    let mut resolution = resolution(&mut rs, &mut ra);
+    let outbound = || {
+        udp_frame(
+            HOST,
+            REMOTE1,
+            40_000,
+            53,
+            64,
+            0x4000,
+            &[],
+            &[],
+            UdpChecksum::Zero,
+        )
+    };
+    let inbound = || {
+        udp_frame(
+            REMOTE1,
+            PUBLIC,
+            53,
+            40_000,
+            64,
+            0x4000,
+            &[],
+            &[],
+            UdpChecksum::Zero,
+        )
+    };
+    let mut io = SimIo::new();
+    io.inject(LAN, outbound());
+    io.run_nat44_udp_once(
+        1,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(0),
+        &mut NoTrace,
+    )
+    .unwrap();
+    io.pop_tx();
+    io.inject(WAN, inbound());
+    io.run_nat44_udp_once(
+        1,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(NAT44_UDP_MIN_IDLE_TTL_MS - 1),
+        &mut NoTrace,
+    )
+    .unwrap();
+    io.pop_tx();
+    let expired = inbound();
+    io.inject(WAN, expired.clone());
+    io.run_nat44_udp_once(
+        1,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(NAT44_UDP_MIN_IDLE_TTL_MS),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_drop(&mut io, DropReason::Nat44UdpMappingMiss, &expired);
+
+    io.inject(LAN, outbound());
+    io.run_nat44_udp_once(
+        1,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(NAT44_UDP_MIN_IDLE_TTL_MS),
+        &mut NoTrace,
+    )
+    .unwrap();
+    io.pop_tx();
+    io.inject(LAN, outbound());
+    io.run_nat44_udp_once(
+        1,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(NAT44_UDP_MIN_IDLE_TTL_MS + 100),
+        &mut NoTrace,
+    )
+    .unwrap();
+    io.pop_tx();
+    io.inject(WAN, inbound());
+    io.run_nat44_udp_once(
+        1,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(2 * NAT44_UDP_MIN_IDLE_TTL_MS + 99),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_eq!(io.pop_tx().unwrap().egress, LAN);
+    let exact = inbound();
+    io.inject(WAN, exact.clone());
+    io.run_nat44_udp_once(
+        1,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(2 * NAT44_UDP_MIN_IDLE_TTL_MS + 100),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_drop(&mut io, DropReason::Nat44UdpMappingMiss, &exact);
+}
+
+#[test]
+fn structural_and_policy_failures_are_byte_and_state_atomic() {
+    let (routes, interfaces, neighbors, bindings) = base();
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &bindings).unwrap();
+    let base_config = config(&snapshot, 40_000, 40_000);
+    let mut mappings = [Nat44UdpMappingSlot::default(); 1];
+    let mut peers = [Nat44UdpPeerSlot::default(); 1];
+    let mut nat = Nat44UdpRuntime::new(base_config, &mut mappings, &mut peers);
+    let mut rs = [ResolutionStateSlot::EMPTY; 1];
+    let mut ra = [ResolutionActionSlot::EMPTY; 1];
+    let mut resolution = resolution(&mut rs, &mut ra);
+    let cases = [
+        (
+            udp_frame(
+                HOST,
+                REMOTE1,
+                40_000,
+                53,
+                64,
+                0,
+                &[],
+                &[],
+                UdpChecksum::Zero,
+            ),
+            DropReason::Nat44UdpNonAtomicIpv4Unsupported,
+        ),
+        (
+            udp_frame(
+                HOST,
+                REMOTE1,
+                40_000,
+                53,
+                64,
+                0x4001,
+                &[],
+                &[],
+                UdpChecksum::Zero,
+            ),
+            DropReason::Nat44UdpNonAtomicIpv4Unsupported,
+        ),
+        (
+            udp_frame(
+                HOST,
+                REMOTE1,
+                40_000,
+                53,
+                64,
+                0x2000,
+                &[],
+                &[],
+                UdpChecksum::Zero,
+            ),
+            DropReason::Nat44UdpNonAtomicIpv4Unsupported,
+        ),
+        (
+            udp_frame(
+                HOST,
+                REMOTE1,
+                0,
+                53,
+                64,
+                0x4000,
+                &[],
+                &[],
+                UdpChecksum::Zero,
+            ),
+            DropReason::Nat44UdpSourcePortZero,
+        ),
+        (
+            udp_frame(
+                HOST,
+                PUBLIC,
+                40_000,
+                53,
+                64,
+                0x4000,
+                &[],
+                &[],
+                UdpChecksum::Zero,
+            ),
+            DropReason::Nat44UdpHairpinUnsupported,
+        ),
+    ];
+    let mut io = SimIo::new();
+    for (packet, reason) in cases {
+        io.inject(LAN, packet.clone());
+        io.run_nat44_udp_once(
+            1,
+            &snapshot,
+            &mut resolution,
+            &base_config,
+            Some(&mut nat),
+            MonotonicMillis(0),
+            &mut NoTrace,
+        )
+        .unwrap();
+        assert_drop(&mut io, reason, &packet);
+        assert_eq!(
+            nat.mappings()
+                .iter()
+                .filter(|slot| slot.is_occupied())
+                .count(),
+            0
+        );
+    }
+}
+
+#[test]
+fn checksum_zero_invalid_nonzero_and_odd_or_padded_udp_are_algebraic() {
+    let (routes, interfaces, neighbors, bindings) = base();
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &bindings).unwrap();
+    let config = config(&snapshot, 40_000, 40_010);
+    let mut mappings = [Nat44UdpMappingSlot::default(); 5];
+    let mut peers = [Nat44UdpPeerSlot::default(); 5];
+    let mut nat = Nat44UdpRuntime::new(config, &mut mappings, &mut peers);
+    let mut rs = [ResolutionStateSlot::EMPTY; 1];
+    let mut ra = [ResolutionActionSlot::EMPTY; 1];
+    let mut resolution = resolution(&mut rs, &mut ra);
+    let mut io = SimIo::new();
+    for (host, port, mode, payload, padding) in [
+        (HOST, 40_000, UdpChecksum::Zero, &[1][..], &[9, 9][..]),
+        (HOST2, 40_001, UdpChecksum::Valid, &[1, 2, 3][..], &[][..]),
+        (
+            Ipv4Address::from_octets([10, 0, 0, 12]),
+            40_002,
+            UdpChecksum::Raw(0x1234),
+            &[1, 2, 3, 4][..],
+            &[][..],
+        ),
+    ] {
+        io.inject(
+            LAN,
+            udp_frame(host, REMOTE1, port, 53, 64, 0x4000, payload, padding, mode),
+        );
+    }
+    let negative_zero_input = (1_u16..=u16::MAX)
+        .find(|checksum| {
+            let old = HOST.octets();
+            let new = PUBLIC.octets();
+            let updated = rfc1624_update(
+                rfc1624_update(
+                    rfc1624_update(
+                        *checksum,
+                        u16::from_be_bytes([old[0], old[1]]),
+                        u16::from_be_bytes([new[0], new[1]]),
+                    ),
+                    u16::from_be_bytes([old[2], old[3]]),
+                    u16::from_be_bytes([new[2], new[3]]),
+                ),
+                40_003,
+                40_003,
+            );
+            updated == 0
+        })
+        .unwrap();
+    io.inject(
+        LAN,
+        udp_frame(
+            HOST,
+            REMOTE2,
+            40_003,
+            53,
+            64,
+            0x4000,
+            &[],
+            &[],
+            UdpChecksum::Raw(negative_zero_input),
+        ),
+    );
+    io.inject(
+        LAN,
+        udp_frame(
+            HOST2,
+            REMOTE2,
+            40_004,
+            53,
+            64,
+            0x4000,
+            &[],
+            &[],
+            UdpChecksum::Raw(0xffff),
+        ),
+    );
+    io.run_nat44_udp_once(
+        5,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(0),
+        &mut NoTrace,
+    )
+    .unwrap();
+    let zero = io.pop_tx().unwrap();
+    assert_eq!(
+        u16::from_be_bytes(zero.bytes[40..42].try_into().unwrap()),
+        0
+    );
+    let valid = io.pop_tx().unwrap();
+    assert!(udp_checksum_valid(&valid.bytes));
+    let invalid = io.pop_tx().unwrap();
+    assert!(!udp_checksum_valid(&invalid.bytes));
+    assert_ne!(
+        u16::from_be_bytes(invalid.bytes[40..42].try_into().unwrap()),
+        0x1234
+    );
+    let negative_zero = io.pop_tx().unwrap();
+    assert_eq!(
+        u16::from_be_bytes(negative_zero.bytes[40..42].try_into().unwrap()),
+        0xffff
+    );
+    let input_ffff = io.pop_tx().unwrap();
+    assert_ne!(
+        u16::from_be_bytes(input_ffff.bytes[40..42].try_into().unwrap()),
+        0
+    );
+}
+
+#[test]
+fn absent_runtime_and_stale_snapshot_authority_fail_closed() {
+    let (routes, interfaces, neighbors, bindings) = base();
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &bindings).unwrap();
+    let config = config(&snapshot, 40_000, 40_000);
+    let packet = udp_frame(
+        HOST,
+        REMOTE1,
+        40_000,
+        53,
+        64,
+        0x4000,
+        &[],
+        &[],
+        UdpChecksum::Zero,
+    );
+    let mut rs = [ResolutionStateSlot::EMPTY; 1];
+    let mut ra = [ResolutionActionSlot::EMPTY; 1];
+    let mut resolution = resolution(&mut rs, &mut ra);
+    let mut io = SimIo::new();
+    io.inject(LAN, packet.clone());
+    io.run_nat44_udp_once(
+        1,
+        &snapshot,
+        &mut resolution,
+        &config,
+        None,
+        MonotonicMillis(0),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_drop(&mut io, DropReason::Nat44UdpRuntimeUnavailable, &packet);
+
+    let mut changed_neighbors = neighbors;
+    changed_neighbors[2].mac = MacAddress([2, 9, 9, 9, 9, 9]);
+    let changed =
+        ForwardingSnapshot::new(&routes, &interfaces, &changed_neighbors, &bindings).unwrap();
+    let mut mappings = [Nat44UdpMappingSlot::default(); 1];
+    let mut peers = [Nat44UdpPeerSlot::default(); 1];
+    let mut nat = Nat44UdpRuntime::new(config, &mut mappings, &mut peers);
+    io.inject(LAN, packet.clone());
+    io.run_nat44_udp_once(
+        1,
+        &changed,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(0),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_drop(&mut io, DropReason::Nat44UdpConfigMismatch, &packet);
+}
+
+#[test]
+fn backend_reject_keeps_tx_request_mapping_and_filter_state() {
+    let (routes, interfaces, neighbors, bindings) = base();
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &bindings).unwrap();
+    let config = config(&snapshot, 40_000, 40_000);
+    let mut mappings = [Nat44UdpMappingSlot::default(); 1];
+    let mut peers = [Nat44UdpPeerSlot::default(); 1];
+    let mut nat = Nat44UdpRuntime::new(config, &mut mappings, &mut peers);
+    let mut rs = [ResolutionStateSlot::EMPTY; 1];
+    let mut ra = [ResolutionActionSlot::EMPTY; 1];
+    let mut resolution = resolution(&mut rs, &mut ra);
+    let mut io = SimIo::new();
+    io.set_received_accept_budget(0);
+    io.inject(
+        LAN,
+        udp_frame(
+            HOST,
+            REMOTE1,
+            40_000,
+            53,
+            64,
+            0x4000,
+            &[],
+            &[],
+            UdpChecksum::Zero,
+        ),
+    );
+    let rejected = io
+        .run_nat44_udp_once(
+            1,
+            &snapshot,
+            &mut resolution,
+            &config,
+            Some(&mut nat),
+            MonotonicMillis(0),
+            &mut NoTrace,
+        )
+        .unwrap();
+    assert_eq!(rejected.completion.tx_requested, 1);
+    assert_eq!(rejected.completion.tx_rejected, 1);
+    assert_eq!(io.pop_recycled().unwrap().cause, RecycleCause::TxRejected);
+    assert_eq!(nat.counters().mappings_created, 1);
+
+    io.set_received_accept_budget(1);
+    io.inject(
+        WAN,
+        udp_frame(
+            REMOTE1,
+            PUBLIC,
+            999,
+            40_000,
+            64,
+            0x4000,
+            &[],
+            &[],
+            UdpChecksum::Zero,
+        ),
+    );
+    let inbound = io
+        .run_nat44_udp_once(
+            1,
+            &snapshot,
+            &mut resolution,
+            &config,
+            Some(&mut nat),
+            MonotonicMillis(1),
+            &mut NoTrace,
+        )
+        .unwrap();
+    assert_eq!(inbound.tx_requested, 1);
+    assert_eq!(io.pop_tx().unwrap().egress, LAN);
+}
+
+#[test]
+fn malformed_udp_options_and_unsupported_transport_never_create_state() {
+    let (routes, interfaces, neighbors, bindings) = base();
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &bindings).unwrap();
+    let config = config(&snapshot, 40_000, 40_010);
+    let mut mappings = [Nat44UdpMappingSlot::default(); 2];
+    let mut peers = [Nat44UdpPeerSlot::default(); 2];
+    let mut nat = Nat44UdpRuntime::new(config, &mut mappings, &mut peers);
+    let mut rs = [ResolutionStateSlot::EMPTY; 1];
+    let mut ra = [ResolutionActionSlot::EMPTY; 1];
+    let mut resolution = resolution(&mut rs, &mut ra);
+    let template = udp_frame(
+        HOST,
+        REMOTE1,
+        40_000,
+        53,
+        64,
+        0x4000,
+        &[],
+        &[],
+        UdpChecksum::Zero,
+    );
+    let mut truncated = template.clone();
+    truncated[16..18].copy_from_slice(&27_u16.to_be_bytes());
+    refresh_ipv4_checksum(&mut truncated);
+    let mut too_small = template.clone();
+    too_small[38..40].copy_from_slice(&7_u16.to_be_bytes());
+    let mut too_large = template.clone();
+    too_large[38..40].copy_from_slice(&9_u16.to_be_bytes());
+    let mut options = template.clone();
+    options.splice(34..34, [1, 1, 1, 0]);
+    options[14] = 0x46;
+    let total = u16::from_be_bytes(options[16..18].try_into().unwrap()) + 4;
+    options[16..18].copy_from_slice(&total.to_be_bytes());
+    refresh_ipv4_checksum(&mut options);
+    let mut tcp = template.clone();
+    tcp[23] = 6;
+    refresh_ipv4_checksum(&mut tcp);
+    let cases = [
+        (truncated, DropReason::Nat44UdpHeaderTruncated),
+        (too_small, DropReason::Nat44UdpLengthTooSmall),
+        (too_large, DropReason::Nat44UdpLengthExceedsIpv4Payload),
+        (options, DropReason::Ipv4OptionsUnsupported),
+        (tcp, DropReason::Nat44UdpUnsupportedTransport),
+    ];
+    let mut io = SimIo::new();
+    for (packet, reason) in cases {
+        io.inject(LAN, packet.clone());
+        io.run_nat44_udp_once(
+            1,
+            &snapshot,
+            &mut resolution,
+            &config,
+            Some(&mut nat),
+            MonotonicMillis(0),
+            &mut NoTrace,
+        )
+        .unwrap();
+        assert_drop(&mut io, reason, &packet);
+        assert_eq!(nat.counters().mappings_created, 0);
+    }
+}
+
+#[test]
+fn wrong_ingress_unrelated_traffic_and_icmp_are_explicitly_non_nat() {
+    let (routes, interfaces, neighbors, bindings) = base();
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &bindings).unwrap();
+    let config = config(&snapshot, 40_000, 40_000);
+    let mut mappings = [Nat44UdpMappingSlot::default(); 1];
+    let mut peers = [Nat44UdpPeerSlot::default(); 1];
+    let mut nat = Nat44UdpRuntime::new(config, &mut mappings, &mut peers);
+    let mut rs = [ResolutionStateSlot::EMPTY; 1];
+    let mut ra = [ResolutionActionSlot::EMPTY; 1];
+    let mut resolution = resolution(&mut rs, &mut ra);
+    let mut io = SimIo::new();
+    let wrong = udp_frame(
+        REMOTE1,
+        PUBLIC,
+        53,
+        40_000,
+        64,
+        0x4000,
+        &[],
+        &[],
+        UdpChecksum::Zero,
+    );
+    io.inject(DMZ, wrong.clone());
+    io.run_nat44_udp_once(
+        1,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(0),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_drop(&mut io, DropReason::Nat44UdpWrongIngress, &wrong);
+
+    let unrelated = udp_frame(
+        REMOTE1,
+        REMOTE2,
+        53,
+        99,
+        64,
+        0x4000,
+        &[],
+        &[],
+        UdpChecksum::Zero,
+    );
+    io.inject(WAN, unrelated);
+    io.run_nat44_udp_once(
+        1,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(0),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_eq!(io.pop_tx().unwrap().egress, WAN);
+    assert_eq!(nat.counters().outbound_translated, 0);
+
+    let mut icmp = udp_frame(
+        REMOTE1,
+        PUBLIC,
+        8,
+        0,
+        64,
+        0x4000,
+        &[],
+        &[],
+        UdpChecksum::Zero,
+    );
+    icmp[23] = 1;
+    refresh_ipv4_checksum(&mut icmp);
+    io.inject(WAN, icmp.clone());
+    io.run_nat44_udp_once(
+        1,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(1),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_drop(&mut io, DropReason::Icmpv4ChecksumInvalid, &icmp);
+    assert_eq!(nat.counters().outbound_translated, 0);
+    assert_eq!(nat.counters().inbound_translated, 0);
+}
+
+#[test]
+fn route_ttl_neighbor_and_reverse_authority_fail_before_nat_state() {
+    let (routes, interfaces, neighbors, bindings) = base();
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &bindings).unwrap();
+    let base_config = config(&snapshot, 40_000, 40_000);
+    let mut mappings = [Nat44UdpMappingSlot::default(); 1];
+    let mut peers = [Nat44UdpPeerSlot::default(); 1];
+    let mut nat = Nat44UdpRuntime::new(base_config, &mut mappings, &mut peers);
+    let mut rs = [ResolutionStateSlot::EMPTY; 1];
+    let mut ra = [ResolutionActionSlot::EMPTY; 1];
+    let mut cache = [DynamicNeighborSlot::EMPTY; 1];
+    let mut resolution = ResolutionRuntime::with_dynamic_neighbors(
+        ResolutionPolicy::new(1_000, 2_000).unwrap(),
+        &mut rs,
+        &mut ra,
+        &mut cache,
+    );
+    let ttl = udp_frame(
+        HOST,
+        REMOTE1,
+        40_000,
+        53,
+        1,
+        0x4000,
+        &[],
+        &[],
+        UdpChecksum::Zero,
+    );
+    let spoof = udp_frame(
+        REMOTE2,
+        REMOTE1,
+        40_000,
+        53,
+        64,
+        0x4000,
+        &[],
+        &[],
+        UdpChecksum::Zero,
+    );
+    let mut io = SimIo::new();
+    for (packet, reason) in [
+        (ttl, DropReason::Ipv4TtlExpired),
+        (spoof, DropReason::Nat44UdpReverseAuthorityMismatch),
+    ] {
+        io.inject(LAN, packet.clone());
+        io.run_nat44_udp_once(
+            1,
+            &snapshot,
+            &mut resolution,
+            &base_config,
+            Some(&mut nat),
+            MonotonicMillis(0),
+            &mut NoTrace,
+        )
+        .unwrap();
+        assert_drop(&mut io, reason, &packet);
+        assert_eq!(nat.counters().mappings_created, 0);
+    }
+
+    let no_default = [routes[0]];
+    let route_miss_snapshot =
+        ForwardingSnapshot::new(&no_default, &interfaces, &neighbors[..2], &bindings).unwrap();
+    let route_miss_config = config(&route_miss_snapshot, 40_000, 40_000);
+    let mut miss_maps = [Nat44UdpMappingSlot::default(); 1];
+    let mut miss_peers = [Nat44UdpPeerSlot::default(); 1];
+    let mut miss_nat = Nat44UdpRuntime::new(route_miss_config, &mut miss_maps, &mut miss_peers);
+    let packet = udp_frame(
+        HOST,
+        REMOTE1,
+        40_000,
+        53,
+        64,
+        0x4000,
+        &[],
+        &[],
+        UdpChecksum::Zero,
+    );
+    io.inject(LAN, packet.clone());
+    io.run_nat44_udp_once(
+        1,
+        &route_miss_snapshot,
+        &mut resolution,
+        &route_miss_config,
+        Some(&mut miss_nat),
+        MonotonicMillis(0),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_drop(&mut io, DropReason::RouteMiss, &packet);
+    assert_eq!(miss_nat.counters().mappings_created, 0);
+
+    let unresolved_snapshot =
+        ForwardingSnapshot::new(&routes, &interfaces, &neighbors[..2], &bindings).unwrap();
+    let unresolved_config = config(&unresolved_snapshot, 40_000, 40_000);
+    let mut unresolved_maps = [Nat44UdpMappingSlot::default(); 1];
+    let mut unresolved_peers = [Nat44UdpPeerSlot::default(); 1];
+    let mut unresolved_nat = Nat44UdpRuntime::new(
+        unresolved_config,
+        &mut unresolved_maps,
+        &mut unresolved_peers,
+    );
+    io.inject(LAN, packet.clone());
+    io.run_nat44_udp_once(
+        1,
+        &unresolved_snapshot,
+        &mut resolution,
+        &unresolved_config,
+        Some(&mut unresolved_nat),
+        MonotonicMillis(0),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_drop(&mut io, DropReason::NeighborUnresolved, &packet);
+    assert_eq!(unresolved_nat.counters().mappings_created, 0);
+    assert_eq!(resolution.counters().queued, 1);
+
+    io.inject(WAN, arp_reply(GATEWAY, PUBLIC, GATEWAY_MAC));
+    io.run_nat44_udp_once(
+        1,
+        &unresolved_snapshot,
+        &mut resolution,
+        &unresolved_config,
+        Some(&mut unresolved_nat),
+        MonotonicMillis(1),
+        &mut NoTrace,
+    )
+    .unwrap();
+    io.pop_recycled();
+    io.inject(LAN, packet);
+    io.run_nat44_udp_once(
+        1,
+        &unresolved_snapshot,
+        &mut resolution,
+        &unresolved_config,
+        Some(&mut unresolved_nat),
+        MonotonicMillis(1),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_eq!(io.pop_tx().unwrap().egress, WAN);
+    assert_eq!(unresolved_nat.counters().mappings_created, 1);
+}

--- a/crates/io-sim/tests/nat44_udp.rs
+++ b/crates/io-sim/tests/nat44_udp.rs
@@ -1162,6 +1162,169 @@ fn wrong_ingress_unrelated_traffic_and_icmp_are_explicitly_non_nat() {
 }
 
 #[test]
+fn outside_to_inside_lpm_bypass_is_always_fail_closed_before_neighbor_work() {
+    let (routes, interfaces, neighbors, bindings) = base();
+    let snapshot =
+        ForwardingSnapshot::new(&routes, &interfaces, &neighbors[2..], &bindings).unwrap();
+    let config = config(&snapshot, 40_000, 40_000);
+    let mut mappings = [Nat44UdpMappingSlot::default(); 1];
+    let mut peers = [Nat44UdpPeerSlot::default(); 1];
+    let mut nat = Nat44UdpRuntime::new(config, &mut mappings, &mut peers);
+    let mut rs = [ResolutionStateSlot::EMPTY; 2];
+    let mut ra = [ResolutionActionSlot::EMPTY; 2];
+    let mut resolution = resolution(&mut rs, &mut ra);
+    let mut io = SimIo::new();
+
+    let empty_runtime = udp_frame(
+        REMOTE1,
+        HOST,
+        53,
+        40_000,
+        64,
+        0x4000,
+        &[],
+        &[],
+        UdpChecksum::Zero,
+    );
+    io.inject(WAN, empty_runtime.clone());
+    io.run_nat44_udp_once(
+        1,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(0),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_drop(
+        &mut io,
+        DropReason::Nat44ExternalToInternalBypass,
+        &empty_runtime,
+    );
+    assert!(nat.mappings().iter().all(|mapping| !mapping.is_occupied()));
+    assert!(nat.peers().iter().all(|peer| !peer.is_occupied()));
+    assert_eq!(nat.counters(), Default::default());
+    assert_eq!(resolution.counters().queued, 0);
+
+    io.inject(
+        LAN,
+        udp_frame(
+            HOST,
+            REMOTE1,
+            40_000,
+            53,
+            64,
+            0x4000,
+            &[],
+            &[],
+            UdpChecksum::Zero,
+        ),
+    );
+    io.run_nat44_udp_once(
+        1,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(0),
+        &mut NoTrace,
+    )
+    .unwrap();
+    io.pop_tx();
+    let mapping_before = nat.mappings()[0];
+    let peer_before = nat.peers()[0];
+    let counters_before = nat.counters();
+    let resolution_before = resolution.counters();
+
+    let mut tcp = udp_frame(
+        REMOTE1,
+        HOST,
+        53,
+        40_000,
+        64,
+        0x4000,
+        &[],
+        &[],
+        UdpChecksum::Zero,
+    );
+    tcp[23] = 6;
+    refresh_ipv4_checksum(&mut tcp);
+    let cases = [
+        udp_frame(
+            REMOTE1,
+            HOST,
+            53,
+            40_000,
+            64,
+            0x4000,
+            &[],
+            &[],
+            UdpChecksum::Zero,
+        ),
+        udp_frame(
+            REMOTE2,
+            HOST,
+            53,
+            40_000,
+            64,
+            0x4000,
+            &[],
+            &[],
+            UdpChecksum::Zero,
+        ),
+        tcp,
+    ];
+    for packet in cases {
+        io.inject(WAN, packet.clone());
+        io.run_nat44_udp_once(
+            1,
+            &snapshot,
+            &mut resolution,
+            &config,
+            Some(&mut nat),
+            MonotonicMillis(100),
+            &mut NoTrace,
+        )
+        .unwrap();
+        assert_drop(&mut io, DropReason::Nat44ExternalToInternalBypass, &packet);
+        assert_eq!(nat.mappings()[0], mapping_before);
+        assert_eq!(nat.peers()[0], peer_before);
+        assert_eq!(nat.counters(), counters_before);
+        assert_eq!(resolution.counters(), resolution_before);
+    }
+
+    let absent_runtime = udp_frame(
+        REMOTE1,
+        HOST,
+        53,
+        40_000,
+        64,
+        0x4000,
+        &[],
+        &[],
+        UdpChecksum::Zero,
+    );
+    io.inject(WAN, absent_runtime.clone());
+    io.run_nat44_udp_once(
+        1,
+        &snapshot,
+        &mut resolution,
+        &config,
+        None,
+        MonotonicMillis(100),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_drop(
+        &mut io,
+        DropReason::Nat44ExternalToInternalBypass,
+        &absent_runtime,
+    );
+    assert_eq!(resolution.counters(), resolution_before);
+}
+
+#[test]
 fn route_ttl_neighbor_and_reverse_authority_fail_before_nat_state() {
     let (routes, interfaces, neighbors, bindings) = base();
     let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &bindings).unwrap();
@@ -1302,4 +1465,160 @@ fn route_ttl_neighbor_and_reverse_authority_fail_before_nat_state() {
     .unwrap();
     assert_eq!(io.pop_tx().unwrap().egress, WAN);
     assert_eq!(unresolved_nat.counters().mappings_created, 1);
+}
+
+#[test]
+fn later_forwarding_and_structural_failures_still_advance_nat_time() {
+    let (routes, interfaces, neighbors, bindings) = base();
+    let snapshot =
+        ForwardingSnapshot::new(&routes, &interfaces, &neighbors[2..], &bindings).unwrap();
+    let config = config(&snapshot, 40_000, 40_000);
+    let mut mappings = [Nat44UdpMappingSlot::default(); 1];
+    let mut peers = [Nat44UdpPeerSlot::default(); 1];
+    let mut nat = Nat44UdpRuntime::new(config, &mut mappings, &mut peers);
+    let mut rs = [ResolutionStateSlot::EMPTY; 2];
+    let mut ra = [ResolutionActionSlot::EMPTY; 2];
+    let mut resolution = resolution(&mut rs, &mut ra);
+    let mut io = SimIo::new();
+    let outbound = || {
+        udp_frame(
+            HOST,
+            REMOTE1,
+            40_000,
+            53,
+            64,
+            0x4000,
+            &[],
+            &[],
+            UdpChecksum::Zero,
+        )
+    };
+    let inbound = || {
+        udp_frame(
+            REMOTE1,
+            PUBLIC,
+            53,
+            40_000,
+            64,
+            0x4000,
+            &[],
+            &[],
+            UdpChecksum::Zero,
+        )
+    };
+
+    io.inject(LAN, outbound());
+    io.run_nat44_udp_once(
+        1,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(0),
+        &mut NoTrace,
+    )
+    .unwrap();
+    io.pop_tx();
+
+    let neighbor_failure = inbound();
+    io.inject(WAN, neighbor_failure.clone());
+    io.run_nat44_udp_once(
+        1,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(100),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_drop(&mut io, DropReason::NeighborUnresolved, &neighbor_failure);
+    assert_eq!(nat.mappings()[0].last_outbound_ms(), 0);
+    assert_eq!(nat.counters().inbound_translated, 0);
+    let resolution_after_failure = resolution.counters();
+
+    let older = inbound();
+    io.inject(WAN, older.clone());
+    io.run_nat44_udp_once(
+        1,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(99),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_drop(&mut io, DropReason::Nat44UdpClockRegression, &older);
+    assert_eq!(resolution.counters(), resolution_after_failure);
+
+    let equal = inbound();
+    io.inject(WAN, equal.clone());
+    io.run_nat44_udp_once(
+        1,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(100),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_drop(&mut io, DropReason::NeighborUnresolved, &equal);
+
+    let malformed = udp_frame(
+        HOST,
+        REMOTE1,
+        40_000,
+        53,
+        64,
+        0,
+        &[],
+        &[],
+        UdpChecksum::Zero,
+    );
+    io.inject(LAN, malformed.clone());
+    io.run_nat44_udp_once(
+        1,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(200),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_drop(
+        &mut io,
+        DropReason::Nat44UdpNonAtomicIpv4Unsupported,
+        &malformed,
+    );
+
+    let older = outbound();
+    io.inject(LAN, older.clone());
+    io.run_nat44_udp_once(
+        1,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(199),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_drop(&mut io, DropReason::Nat44UdpClockRegression, &older);
+
+    io.inject(LAN, outbound());
+    io.run_nat44_udp_once(
+        1,
+        &snapshot,
+        &mut resolution,
+        &config,
+        Some(&mut nat),
+        MonotonicMillis(200),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_eq!(io.pop_tx().unwrap().egress, WAN);
+    assert_eq!(nat.mappings()[0].last_outbound_ms(), 200);
 }

--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -342,9 +342,55 @@ local SPAを名乗り、そのlocal addressをTPAにしたrequestも通常reques
 するだけで、conflict状態やdefensive announcementを生成しません。正常なlocal target requestを
 追加policyでdropしないことを優先した明示deviationです。
 
+## UDP NAT44/NAPT vertical slice
+
+NATは既存wrapperへ暗黙に入れず、`forward_batch_with_nat44_udp`、またはgenerated ICMP
+errorも含む`forward_batch_with_nat44_udp_and_icmpv4_errors`という合成service APIで
+ARP resolutionと同じworker tickへ明示的にbindします。config公開済みでruntime storageが
+無い場合、またはruntime/config/snapshot authority fingerprintが不一致ならdomain crossingを
+fail closedにします。新snapshot公開時はそのsnapshotでconfigをvalidateし、
+`Nat44UdpRuntime::reconcile`でmapping/peerを全flushします。旧generationのpeerが新mappingを
+許可することはありません。
+
+mapping keyは`(inside IfId, internal IPv4, internal UDP port)`でremote endpointを含めない
+Endpoint-Independent Mappingです。別のremoteへ送っても同じpublic tupleを使います。
+filter peerは`(mapping slot, mapping generation, remote IPv4)`で、既知IPの任意remote UDP
+portを許し、未接触IPをbyte不変dropします。outboundでpeer slotを確保できなければmappingを
+refreshせずdropし、filterを緩めません。live mappingをevictせず、port overloadもしません。
+内部portがpool内かつfreeなら保存し、それ以外はcaller seedを混ぜたstartからinclusive poolを
+一周だけscanします。randomness、parity、low-class preservationは保証しません。
+
+対象packetの順序は次です。
+
+1. common Ethernet/IPv4 validationとoptions rejection。
+2. outboundはoriginal destinationのLPM、TTL、selected outside egress、static/fresh dynamic
+   neighborを先に確定。source reverse-LPMがinsideであることを確認。
+3. inbound public UDPはlocal deliveryより先にinterceptし、mapping/ADF lookup後、
+   translated internal destinationを通常LPMしinside neighborを確定。
+4. DF=1/MF=0/offset=0、UDP header/length、全offset、mapping/peer/port transactionを
+   mutationなしでplan。
+5. L2、TTL、IPv4 address、UDP port、IPv4/UDP checksumの完全なrewrite planを適用。
+6. mapping/peer/refreshをinfallible commitし、最後にRX leaseをTX requestへcommit。
+
+core dropはpacket bytesとmapping/peer stateを変更しません。outbound TX requestでmapping
+idle timeとADF peerをcommitするため、backend aggregate rejectでもrollbackしません。
+same batchの後続inboundは直前outboundのstateを見ます。inboundはmapping idle timeをrefresh
+しません。clock regressionはcounter/trace以外を変更せず、直前watermarkと等しい時刻で回復
+します。default idle TTLは300秒、minimum 120秒、exact boundaryでexpiredです。
+
+RFC 768のUDP lengthは8以上かつIPv4 payload以下を要求し、短いUDP lengthの後ろにあるIP
+paddingは保存します。checksum zeroはzeroのままです。nonzero checksumはRFC 1624で
+translated IPv4 address wordsとportを更新し、算術結果zeroをUDP wireの`0xffff`へencode
+します。入力nonzero checksumを新規にfull validationしないrouter profileです。IPv4 IDは
+RFC 6864 atomic datagramとして保存します。
+
+fragment handling/reassembly、hairpinning、ICMP error translationとPMTU、TCP/ICMP query
+NAT、static port forward、複数public address、port randomization/parity、full packet
+filter/firewallはdeferredです。RFC 3022/4787/7857の全機能準拠は主張しません。
+
 eager dynamic-cache scan/flush、unresolved packet hold queue、gratuitous ARP生成、
 ARP Probe/Announcement生成、proxy ARP、VLAN、Address Conflict Detection、実装済み
-Echo Reply/Time Exceeded/Destination Unreachable Network以外のICMP生成、NAT、firewall、
+Echo Reply/Time Exceeded/Destination Unreachable Network以外のICMP生成、firewall、
 config parser、pcap、AF_XDP、DPDK、binary、thread、
 benchmarkはこの
 sliceのscope外です。

--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -375,8 +375,16 @@ refreshせずdropし、filterを緩めません。live mappingをevictせず、p
 core dropはpacket bytesとmapping/peer stateを変更しません。outbound TX requestでmapping
 idle timeとADF peerをcommitするため、backend aggregate rejectでもrollbackしません。
 same batchの後続inboundは直前outboundのstateを見ます。inboundはmapping idle timeをrefresh
-しません。clock regressionはcounter/trace以外を変更せず、直前watermarkと等しい時刻で回復
-します。default idle TTLは300秒、minimum 120秒、exact boundaryでexpiredです。
+しません。NAT runtimeへ到達した非退行operationは、mapping/filter miss、capacity/port
+exhaustion、後続route/neighbor failure、structural/policy dropでもoperation開始時にwatermarkを
+進めます。これによりexact expiryを観測した後の古い時刻でmapping/ADFが復活しません。
+clock regressionはcounter/trace以外を変更せずfail closedにし、直前watermarkと等しい時刻で
+回復します。default idle TTLは300秒、minimum 120秒、exact boundaryでexpiredです。
+
+outside ingressから通常LPMがinside egressを選んだpacketは、宛先public UDPのauthorized
+DNAT pathを先に完了した場合を除き、protocol/runtime/mappingの有無にかかわらず
+`Nat44ExternalToInternalBypass`でdropします。この境界はneighbor lookup/ARP scheduleより前で、
+single-domain traditional NATを迂回する外部から内部への直接転送を許可しません。
 
 RFC 768のUDP lengthは8以上かつIPv4 payload以下を要求し、短いUDP lengthの後ろにあるIP
 paddingは保存します。checksum zeroはzeroのままです。nonzero checksumはRFC 1624で

--- a/docs/requirements-v0.2.md
+++ b/docs/requirements-v0.2.md
@@ -131,6 +131,26 @@ Statusは`implemented`、`deferred`、`deviation`のいずれかです。test名
 | SIM-001 FIFO/budget/mixed batch | deterministic test requirement | `mixed_batch_is_fifo_budgeted_and_reports_requested_accepted_recycled` | implemented | なし |
 | SIM-002 mixed IPv4/ARP FIFO and budget | deterministic test requirement | `mixed_ipv4_and_arp_batch_is_fifo_budgeted_and_deterministic` | implemented | protocol混在でもsequenceとbudgetを保持 |
 | SIM-003 mixed RX/generated FIFO and typed origin | deterministic test requirement | `mixed_rx_and_generated_tx_are_fifo_budgeted_and_origin_typed` | implemented | RX batch finish後に生成しoriginを型で区別 |
+| NAT44-001 opt-in single-domain UDP NAPT | RFC 3022 §§2–4, architecture contract | `exact_bidirectional_wire_and_same_batch_visibility` | implemented | one inside/outside/public IPv4。既存forwarding wrapperはNATなしの挙動を維持 |
+| NAT44-002 Endpoint-Independent Mapping | RFC 4787 REQ-1 | `eim_reuses_public_tuple_and_adf_keys_only_remote_address` | implemented | keyはinside/internal IPv4/internal UDP port。remote endpointを含めない |
+| NAT44-003 Address-Dependent Filtering | RFC 4787 filtering taxonomy, local profile | `eim_reuses_public_tuple_and_adf_keys_only_remote_address` | implemented | contacted remote IPv4だけ許可しremote portは任意。unknown IPはbyte不変drop |
+| NAT44-004 unique deterministic public port | RFC 4787 REQ-3, local bounded allocator | `allocator_preserves_then_falls_back_without_overload_and_exhausts` | implemented | internal portを可能なら保存し、seeded startからpoolを一周。overload/live evictionなし |
+| NAT44-005 fixed caller-backed state/generation | architecture contract | `full_tables_do_not_evict_or_refresh_live_state_and_zero_capacity_is_safe` | implemented | mapping/peer zero/full safe、generationでstale peerを無効化、`!Send + !Sync` |
+| NAT44-006 idle timer and refresh direction | RFC 4787 REQ-5, RFC 7857 timer updates | `exact_idle_expiry_outbound_refresh_and_inbound_no_refresh` | implemented | default 300s/minimum 120s、exact expiry。outbound TX requestだけrefresh |
+| NAT44-007 monotonic clock atomicity | architecture contract | `clock_regression_is_atomic_and_equal_time_recovers` | implemented | regressionはcounter/trace以外を変更せずequal timeで回復 |
+| NAT44-008 atomic IPv4-only profile | RFC 6864 §§4.1–4.2 | `structural_and_policy_failures_are_byte_and_state_atomic` | deviation | DF=1/MF=0/offset=0だけ変換。DF=0を含むfragment-capable datagramはtyped drop |
+| NAT44-009 UDP length and padding | RFC 768 | `checksum_zero_invalid_nonzero_and_odd_or_padded_udp_are_algebraic` | implemented | UDP length 8..=IPv4 payload。UDP後のIP/link paddingを保存 |
+| NAT44-010 incremental address/port checksum | RFC 1624 §4, RFC 768 | `checksum_zero_invalid_nonzero_and_odd_or_padded_udp_are_algebraic` | implemented | UDP zeroを保存。nonzeroはaddress/port更新、negative zeroを`0xffff` encode |
+| NAT44-011 original route/neighbor before state | RFC 1812 §§5.2.4–5.2.7, architecture contract | `route_ttl_neighbor_and_reverse_authority_fail_before_nat_state` | implemented | route/TTL/egress/static-or-dynamic neighbor失敗でmapping/peerなし |
+| NAT44-012 internal source authority | RFC 1812 §5.3.7, local anti-spoof policy | `route_ttl_neighbor_and_reverse_authority_fail_before_nat_state` | implemented | non-host/local/public sourceを拒否しsource reverse-LPMはinside必須 |
+| NAT44-013 inbound intercept before local | RFC 3022 translation direction | `exact_bidirectional_wire_and_same_batch_visibility` | implemented | outside/public UDPをordinary local consumeより先にmapping/ADFへ渡す |
+| NAT44-014 transactional rewrite/state/TX request | architecture contract | `backend_reject_keeps_tx_request_mapping_and_filter_state` | implemented | full plan後bytes→state→lease commit。backend rejectでもTX-request stateを保持 |
+| NAT44-015 publication mismatch and flush | control-plane publication contract | `absent_runtime_and_stale_snapshot_authority_fail_closed` | implemented | runtime absent/mismatchはfail closed。`reconcile`は全mapping/peerをflush |
+| NAT44-016 malformed/unsupported fail closed | RFC 768, local security boundary | `malformed_udp_options_and_unsupported_transport_never_create_state` | implemented | truncated/invalid length/options/TCP crossingでprivate sourceを漏らさずstateなし |
+| NAT44-017 hairpinning | RFC 4787 REQ-9 | `structural_and_policy_failures_are_byte_and_state_atomic` | deferred | inside→own publicはWANへ漏らさずtyped drop。hairpin translation未実装 |
+| NAT44-018 fragment translation | RFC 3022 §6.3, RFC 4787 REQ-14 | `structural_and_policy_failures_are_byte_and_state_atomic` | deferred | fragment association/reassembly未実装。atomic DF=1だけの初期profile |
+| NAT44-019 ICMP error translation and PMTU | RFC 3022 §§4.3, 6.3 | `wrong_ingress_unrelated_traffic_and_icmp_are_explicitly_non_nat` | deferred | incoming ICMPはmappingをrefresh/deleteせず従来local path。embedded tuple/PMTU translationなし |
+| NAT44-020 other transports/features | RFC 3022, RFC 4787, RFC 7857 | — | deferred | TCP/ICMP query NAT、static forwards、multi-public、port randomization/parity、full packet filter/firewall |
 
 ## RFC deviation rule
 

--- a/docs/requirements-v0.2.md
+++ b/docs/requirements-v0.2.md
@@ -136,8 +136,8 @@ Statusは`implemented`、`deferred`、`deviation`のいずれかです。test名
 | NAT44-003 Address-Dependent Filtering | RFC 4787 filtering taxonomy, local profile | `eim_reuses_public_tuple_and_adf_keys_only_remote_address` | implemented | contacted remote IPv4だけ許可しremote portは任意。unknown IPはbyte不変drop |
 | NAT44-004 unique deterministic public port | RFC 4787 REQ-3, local bounded allocator | `allocator_preserves_then_falls_back_without_overload_and_exhausts` | implemented | internal portを可能なら保存し、seeded startからpoolを一周。overload/live evictionなし |
 | NAT44-005 fixed caller-backed state/generation | architecture contract | `full_tables_do_not_evict_or_refresh_live_state_and_zero_capacity_is_safe` | implemented | mapping/peer zero/full safe、generationでstale peerを無効化、`!Send + !Sync` |
-| NAT44-006 idle timer and refresh direction | RFC 4787 REQ-5, RFC 7857 timer updates | `exact_idle_expiry_outbound_refresh_and_inbound_no_refresh` | implemented | default 300s/minimum 120s、exact expiry。outbound TX requestだけrefresh |
-| NAT44-007 monotonic clock atomicity | architecture contract | `clock_regression_is_atomic_and_equal_time_recovers` | implemented | regressionはcounter/trace以外を変更せずequal timeで回復 |
+| NAT44-006 idle timer and refresh direction | RFC 4787 REQ-5/REQ-6, RFC 7857 §§7–7.1 | `exact_idle_expiry_outbound_refresh_and_inbound_no_refresh` | implemented | default 300s/minimum 120s、exact expiry。outbound TX requestだけrefreshし、inboundはrefreshしない |
+| NAT44-007 monotonic clock atomicity | architecture contract | `failed_lookup_and_capacity_operations_advance_the_watermark` | implemented | non-regressed operationはdropでもwatermarkを進める。regressionはcounter/trace以外を変更せずequal timeで回復 |
 | NAT44-008 atomic IPv4-only profile | RFC 6864 §§4.1–4.2 | `structural_and_policy_failures_are_byte_and_state_atomic` | deviation | DF=1/MF=0/offset=0だけ変換。DF=0を含むfragment-capable datagramはtyped drop |
 | NAT44-009 UDP length and padding | RFC 768 | `checksum_zero_invalid_nonzero_and_odd_or_padded_udp_are_algebraic` | implemented | UDP length 8..=IPv4 payload。UDP後のIP/link paddingを保存 |
 | NAT44-010 incremental address/port checksum | RFC 1624 §4, RFC 768 | `checksum_zero_invalid_nonzero_and_odd_or_padded_udp_are_algebraic` | implemented | UDP zeroを保存。nonzeroはaddress/port更新、negative zeroを`0xffff` encode |
@@ -151,6 +151,7 @@ Statusは`implemented`、`deferred`、`deviation`のいずれかです。test名
 | NAT44-018 fragment translation | RFC 3022 §6.3, RFC 4787 REQ-14 | `structural_and_policy_failures_are_byte_and_state_atomic` | deferred | fragment association/reassembly未実装。atomic DF=1だけの初期profile |
 | NAT44-019 ICMP error translation and PMTU | RFC 3022 §§4.3, 6.3 | `wrong_ingress_unrelated_traffic_and_icmp_are_explicitly_non_nat` | deferred | incoming ICMPはmappingをrefresh/deleteせず従来local path。embedded tuple/PMTU translationなし |
 | NAT44-020 other transports/features | RFC 3022, RFC 4787, RFC 7857 | — | deferred | TCP/ICMP query NAT、static forwards、multi-public、port randomization/parity、full packet filter/firewall |
+| NAT44-021 external-to-internal bypass prevention | RFC 3022 traditional NAT domain boundary, local security policy | `outside_to_inside_lpm_bypass_is_always_fail_closed_before_neighbor_work` | implemented | authorized public UDP DNAT以外のoutside→inside LPMをprotocol/runtime/state非依存でneighbor処理前にdrop |
 
 ## RFC deviation rule
 


### PR DESCRIPTION
## Summary
- add an opt-in, caller-backed UDP NAT44/NAPT runtime with protocol-dependent endpoint-independent mappings
- enforce address-dependent filtering with separate generation-keyed peer storage
- perform atomic bidirectional L2/IPv4/UDP rewrites with deterministic bounded port allocation and exact checksum handling
- add exact idle expiry, monotonic fail-closed state, snapshot reconciliation, and external-to-internal bypass protection
- keep existing forwarding APIs behavior-compatible when NAT is absent

## Validation
- 154 workspace target tests
- 8 compile-fail doctests
- fmt, check, clippy `-D warnings`, rustdoc `-D warnings`
- requirements ledger and diff checks
- independent RFC/checksum review: all severity 0
- independent state/transaction review: all severity 0

## Scope
This first NAT slice supports only atomic IPv4 UDP datagrams (`DF=1`, no fragments), one public address/domain, dynamic outbound mappings, and no hairpin. Fragment handling, TCP/ICMP NAT, embedded ICMP translation/PMTU, static forwards, multi-public pools, port randomization/parity, and firewall policy remain explicitly deferred.