### PR TITLE
test(core): harden RX accounting contracts

### DIFF
--- a/crates/core/src/forwarding.rs
+++ b/crates/core/src/forwarding.rs
@@ -654,12 +654,47 @@ impl TraceSink for NoTrace {
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct BatchReport<E> {
+    /// RX slots leased from the backend and terminally handled by the core.
     pub received: usize,
     /// Packets requested for TX; this does not mean backend or wire acceptance.
     pub tx_requested: usize,
+    /// RX slots completed with a forwarding [`DropReason`].
     pub dropped: usize,
+    /// RX slots completed with a typed [`ConsumeReason`].
     pub consumed: usize,
+    /// Backend completion for the same batch.
     pub completion: BatchCompletion<E>,
+}
+
+impl<E> BatchReport<E> {
+    /// Returns whether core terminal outcomes and backend accounting agree.
+    ///
+    /// A valid report satisfies all of the following:
+    ///
+    /// - every received slot is requested for TX, dropped, or consumed;
+    /// - the core and backend report the same number of TX requests;
+    /// - backend `recycled` is exactly core drops plus consumes; and
+    /// - [`BatchCompletion::invariants_hold`] is true.
+    ///
+    /// A returned report cannot contain an abandoned lease: abandonment is
+    /// the RAII fallback for an interrupted packet path, while normal
+    /// forwarding explicitly drops or consumes every non-TX packet.
+    #[must_use]
+    pub const fn invariants_hold(&self) -> bool {
+        let Some(core_terminal) = self.tx_requested.checked_add(self.dropped) else {
+            return false;
+        };
+        let Some(core_terminal) = core_terminal.checked_add(self.consumed) else {
+            return false;
+        };
+        let Some(core_recycled) = self.dropped.checked_add(self.consumed) else {
+            return false;
+        };
+        core_terminal == self.received
+            && self.tx_requested == self.completion.tx_requested
+            && core_recycled == self.completion.recycled
+            && self.completion.invariants_hold()
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -1442,18 +1477,19 @@ where
         }
     }
     let completion = batch.finish();
-    debug_assert_eq!(received, tx_requested + dropped + consumed);
     trace.record(TraceEvent::BatchCompleted {
         tx_accepted: completion.tx_accepted,
         tx_rejected: completion.tx_rejected,
     });
-    BatchReport {
+    let report = BatchReport {
         received,
         tx_requested,
         dropped,
         consumed,
         completion,
-    }
+    };
+    debug_assert!(report.invariants_hold());
+    report
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -4536,12 +4572,12 @@ fn apply_icmpv4_echo_reply(
 
 #[cfg(test)]
 mod tests {
-    use super::{decide_ipv4, DropReason};
+    use super::{decide_ipv4, BatchReport, DropReason};
     use crate::{
-        ipv4_header_checksum, ForwardingSnapshot, IfId, Interface, Ipv4Address, LocalIpv4Binding,
-        MacAddress, MonotonicMillis, Nat44Icmpv4ErrorPolicy, Nat44UdpConfig, Nat44UdpMappingSlot,
-        Nat44UdpPeerSlot, Nat44UdpPolicy, Nat44UdpRuntime, NoTrace, ResolutionActionSlot,
-        ResolutionPolicy, ResolutionRuntime, ResolutionStateSlot, Route,
+        ipv4_header_checksum, BatchCompletion, ForwardingSnapshot, IfId, Interface, Ipv4Address,
+        LocalIpv4Binding, MacAddress, MonotonicMillis, Nat44Icmpv4ErrorPolicy, Nat44UdpConfig,
+        Nat44UdpMappingSlot, Nat44UdpPeerSlot, Nat44UdpPolicy, Nat44UdpRuntime, NoTrace,
+        ResolutionActionSlot, ResolutionPolicy, ResolutionRuntime, ResolutionStateSlot, Route,
     };
 
     const LAN: IfId = IfId(1);
@@ -4550,6 +4586,45 @@ mod tests {
     const INTERNAL: Ipv4Address = Ipv4Address::from_octets([10, 0, 0, 10]);
     const REMOTE: Ipv4Address = Ipv4Address::from_octets([198, 51, 100, 20]);
     const ROUTER: Ipv4Address = Ipv4Address::from_octets([198, 51, 100, 1]);
+
+    fn report(
+        core: (usize, usize, usize, usize),
+        backend: (usize, usize, usize, usize),
+    ) -> BatchReport<()> {
+        let (received, tx_requested, dropped, consumed) = core;
+        let (completion_tx_requested, tx_accepted, tx_rejected, recycled) = backend;
+        BatchReport {
+            received,
+            tx_requested,
+            dropped,
+            consumed,
+            completion: BatchCompletion {
+                tx_requested: completion_tx_requested,
+                tx_accepted,
+                tx_rejected,
+                recycled,
+                error: None,
+            },
+        }
+    }
+
+    #[test]
+    fn batch_report_invariants_cover_core_and_backend_accounting() {
+        assert!(report((5, 2, 2, 1), (2, 1, 1, 3)).invariants_hold());
+        assert!(!report((6, 2, 2, 1), (2, 1, 1, 3)).invariants_hold());
+        assert!(!report((5, 2, 2, 1), (1, 1, 0, 3)).invariants_hold());
+        assert!(!report((5, 2, 2, 1), (2, 2, 1, 3)).invariants_hold());
+        assert!(!report((5, 2, 2, 1), (2, 1, 1, 2)).invariants_hold());
+    }
+
+    #[test]
+    fn batch_report_invariants_reject_counter_overflow() {
+        assert!(!report(
+            (usize::MAX, usize::MAX, 1, 0),
+            (usize::MAX, usize::MAX, 0, 1),
+        )
+        .invariants_hold());
+    }
 
     fn frag_needed_frame() -> Vec<u8> {
         let mut frame = vec![0_u8; 14 + 20 + 8 + 20 + 8];

--- a/crates/core/src/forwarding.rs
+++ b/crates/core/src/forwarding.rs
@@ -835,6 +835,15 @@ impl PacketDecision {
     }
 }
 
+/// Forwards every packet offered by one fresh backend batch.
+///
+/// # Fresh-batch precondition
+///
+/// `batch` must be passed directly from [`crate::PacketIo::receive`]:
+/// [`PacketBatch::next_packet`] must not have been called and no lifecycle
+/// completion or accounting may predate this invocation. [`BatchCompletion`]
+/// reports whole-batch totals, so these forwarding APIs deliberately do not
+/// accept partially processed or pre-accounted batches.
 pub fn forward_batch<B, T>(
     batch: B,
     snapshot: &ForwardingSnapshot<'_>,
@@ -851,6 +860,8 @@ where
 
 /// Forwards RX packets and queues resolution actions without allocating TX
 /// frames. Generated execution must start only after this function returns.
+///
+/// The [`forward_batch`] fresh-batch precondition applies.
 pub fn forward_batch_with_resolution<B, T>(
     batch: B,
     snapshot: &ForwardingSnapshot<'_>,
@@ -882,6 +893,8 @@ where
 /// actions into separate caller-backed worker-local runtimes.
 ///
 /// Generated packet execution must happen after this function returns.
+///
+/// The [`forward_batch`] fresh-batch precondition applies.
 pub fn forward_batch_with_resolution_and_icmpv4_errors<B, T>(
     batch: B,
     snapshot: &ForwardingSnapshot<'_>,
@@ -917,6 +930,8 @@ where
 /// cross the configured inside/outside boundary. This lets a control plane
 /// publish configuration before runtime storage without leaking private
 /// addresses. Generated ARP execution remains a separate post-RX phase.
+///
+/// The [`forward_batch`] fresh-batch precondition applies.
 pub fn forward_batch_with_nat44_udp<B, T>(
     batch: B,
     snapshot: &ForwardingSnapshot<'_>,
@@ -952,6 +967,8 @@ where
 /// TTL expiry, route miss, and direct ARP failure capture happen before NAT
 /// mutation and therefore quote the original datagram. Generated packet
 /// execution still starts only after this RX function returns.
+///
+/// The [`forward_batch`] fresh-batch precondition applies.
 #[allow(clippy::too_many_arguments)]
 pub fn forward_batch_with_nat44_udp_and_icmpv4_errors<B, T>(
     batch: B,
@@ -984,6 +1001,8 @@ where
 }
 
 /// Runs one outbound-initiated TCP NAPT domain with ARP resolution.
+///
+/// The [`forward_batch`] fresh-batch precondition applies.
 pub fn forward_batch_with_nat44_tcp<B, T>(
     batch: B,
     snapshot: &ForwardingSnapshot<'_>,
@@ -1014,6 +1033,8 @@ where
 }
 
 /// Composes TCP NAPT with generated ICMPv4 errors in one RX phase.
+///
+/// The [`forward_batch`] fresh-batch precondition applies.
 #[allow(clippy::too_many_arguments)]
 pub fn forward_batch_with_nat44_tcp_and_icmpv4_errors<B, T>(
     batch: B,
@@ -1046,6 +1067,8 @@ where
 }
 
 /// Runs independent UDP and TCP NAPT state for one matching address realm.
+///
+/// The [`forward_batch`] fresh-batch precondition applies.
 #[allow(clippy::too_many_arguments)]
 pub fn forward_batch_with_nat44_udp_and_tcp<B, T>(
     batch: B,
@@ -1079,6 +1102,8 @@ where
 }
 
 /// Full UDP/TCP NAPT and generated ICMPv4-error composition.
+///
+/// The [`forward_batch`] fresh-batch precondition applies.
 #[allow(clippy::too_many_arguments)]
 pub fn forward_batch_with_nat44_udp_and_tcp_and_icmpv4_errors<B, T>(
     batch: B,
@@ -1116,6 +1141,8 @@ where
 ///
 /// ARP, router-local traffic, and router-originated generated packets remain
 /// outside this service. A missing or mismatched runtime fails closed.
+///
+/// The [`forward_batch`] fresh-batch precondition applies.
 #[allow(clippy::too_many_arguments)]
 pub fn forward_batch_with_firewall<B, T>(
     batch: B,
@@ -1148,6 +1175,8 @@ where
 
 /// Runs the opt-in stateful firewall and appends one typed policy record for
 /// every packet that reaches rule or established-flow evaluation.
+///
+/// The [`forward_batch`] fresh-batch precondition applies.
 #[allow(clippy::too_many_arguments)]
 pub fn forward_batch_with_firewall_audited<B, T>(
     batch: B,
@@ -1181,6 +1210,8 @@ where
 
 /// Composes the stateful firewall with the existing generated ICMPv4 error
 /// capture path. Firewall authorization precedes TTL error capture.
+///
+/// The [`forward_batch`] fresh-batch precondition applies.
 #[allow(clippy::too_many_arguments)]
 pub fn forward_batch_with_firewall_and_icmpv4_errors<B, T>(
     batch: B,
@@ -1213,6 +1244,8 @@ where
 }
 
 /// Audited variant of [`forward_batch_with_firewall_and_icmpv4_errors`].
+///
+/// The [`forward_batch`] fresh-batch precondition applies.
 #[allow(clippy::too_many_arguments)]
 pub fn forward_batch_with_firewall_and_icmpv4_errors_audited<B, T>(
     batch: B,
@@ -1246,6 +1279,8 @@ where
 }
 
 /// Composes independent UDP/TCP NAPT with one canonical-tuple firewall.
+///
+/// The [`forward_batch`] fresh-batch precondition applies.
 #[allow(clippy::too_many_arguments)]
 pub fn forward_batch_with_nat44_udp_and_tcp_and_firewall<B, T>(
     batch: B,
@@ -1282,6 +1317,8 @@ where
 
 /// Audited variant of
 /// [`forward_batch_with_nat44_udp_and_tcp_and_firewall`].
+///
+/// The [`forward_batch`] fresh-batch precondition applies.
 #[allow(clippy::too_many_arguments)]
 pub fn forward_batch_with_nat44_udp_and_tcp_and_firewall_audited<B, T>(
     batch: B,
@@ -1477,10 +1514,6 @@ where
         }
     }
     let completion = batch.finish();
-    trace.record(TraceEvent::BatchCompleted {
-        tx_accepted: completion.tx_accepted,
-        tx_rejected: completion.tx_rejected,
-    });
     let report = BatchReport {
         received,
         tx_requested,
@@ -1488,7 +1521,17 @@ where
         consumed,
         completion,
     };
-    debug_assert!(report.invariants_hold());
+    let invariants_hold = report.invariants_hold();
+    debug_assert!(
+        invariants_hold,
+        "backend batch accounting violates the forwarding contract"
+    );
+    if invariants_hold {
+        trace.record(TraceEvent::BatchCompleted {
+            tx_accepted: report.completion.tx_accepted,
+            tx_rejected: report.completion.tx_rejected,
+        });
+    }
     report
 }
 
@@ -4572,13 +4615,15 @@ fn apply_icmpv4_echo_reply(
 
 #[cfg(test)]
 mod tests {
-    use super::{decide_ipv4, BatchReport, DropReason};
+    use super::{decide_ipv4, forward_batch, BatchReport, DropReason};
     use crate::{
         ipv4_header_checksum, BatchCompletion, ForwardingSnapshot, IfId, Interface, Ipv4Address,
         LocalIpv4Binding, MacAddress, MonotonicMillis, Nat44Icmpv4ErrorPolicy, Nat44UdpConfig,
         Nat44UdpMappingSlot, Nat44UdpPeerSlot, Nat44UdpPolicy, Nat44UdpRuntime, NoTrace,
-        ResolutionActionSlot, ResolutionPolicy, ResolutionRuntime, ResolutionStateSlot, Route,
+        PacketBatch, PacketLease, PacketSlot, ResolutionActionSlot, ResolutionPolicy,
+        ResolutionRuntime, ResolutionStateSlot, Route, SlotCompletion, TraceEvent, TraceSink,
     };
+    use std::panic::{catch_unwind, AssertUnwindSafe};
 
     const LAN: IfId = IfId(1);
     const WAN: IfId = IfId(2);
@@ -4624,6 +4669,92 @@ mod tests {
             (usize::MAX, usize::MAX, 0, 1),
         )
         .invariants_hold());
+    }
+
+    struct NeverLeasedSlot;
+
+    impl PacketSlot for NeverLeasedSlot {
+        fn ingress(&self) -> IfId {
+            unreachable!("accounting-only batch never leases a slot")
+        }
+
+        fn bytes_mut(&mut self) -> &mut [u8] {
+            unreachable!("accounting-only batch never leases a slot")
+        }
+
+        fn complete(self, _completion: SlotCompletion) {
+            unreachable!("accounting-only batch never leases a slot")
+        }
+    }
+
+    struct AccountingOnlyBatch {
+        completion: BatchCompletion<()>,
+    }
+
+    impl PacketBatch for AccountingOnlyBatch {
+        type Error = ();
+        type Slot<'a> = NeverLeasedSlot;
+
+        fn next_packet(&mut self) -> Option<PacketLease<Self::Slot<'_>>> {
+            None
+        }
+
+        fn finish(self) -> BatchCompletion<Self::Error> {
+            self.completion
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingTrace {
+        events: Vec<TraceEvent>,
+    }
+
+    impl TraceSink for RecordingTrace {
+        fn record(&mut self, event: TraceEvent) {
+            self.events.push(event);
+        }
+    }
+
+    fn assert_invalid_batch_has_no_terminal_trace(completion: BatchCompletion<()>) {
+        let snapshot = ForwardingSnapshot::new(&[], &[], &[], &[]).unwrap();
+        let mut trace = RecordingTrace::default();
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            forward_batch(AccountingOnlyBatch { completion }, &snapshot, &mut trace)
+        }));
+        if cfg!(debug_assertions) {
+            assert!(result.is_err(), "debug builds reject invalid accounting");
+        } else {
+            assert!(result.is_ok(), "release builds return the invalid report");
+        }
+        assert!(
+            !trace
+                .events
+                .iter()
+                .any(|event| matches!(event, TraceEvent::BatchCompleted { .. })),
+            "invalid accounting must not publish a terminal batch trace"
+        );
+    }
+
+    #[test]
+    fn preaccounted_batch_violates_fresh_batch_precondition_before_terminal_trace() {
+        assert_invalid_batch_has_no_terminal_trace(BatchCompletion {
+            tx_requested: 1,
+            tx_accepted: 1,
+            tx_rejected: 0,
+            recycled: 0,
+            error: None,
+        });
+    }
+
+    #[test]
+    fn malformed_backend_completion_is_rejected_before_terminal_trace() {
+        assert_invalid_batch_has_no_terminal_trace(BatchCompletion {
+            tx_requested: 0,
+            tx_accepted: 1,
+            tx_rejected: 0,
+            recycled: 0,
+            error: Some(()),
+        });
     }
 
     fn frag_needed_frame() -> Vec<u8> {

--- a/crates/core/src/io.rs
+++ b/crates/core/src/io.rs
@@ -20,13 +20,23 @@ pub trait PacketBatch {
     /// Returns a core-owned lease, never a backend's raw slot.
     fn next_packet(&mut self) -> Option<PacketLease<Self::Slot<'_>>>;
 
-    /// Flushes requested transmissions and always returns their accounting.
+    /// Flushes requested transmissions and returns accounting for the entire
+    /// batch lifetime, starting when the backend created the batch.
     ///
     /// [`BatchCompletion::invariants_hold`] must return `true`, including when
     /// `error` is present. The backend must recycle or free every rejected
     /// slot before returning. Rejected TX slots are accounted in
     /// [`BatchCompletion::tx_rejected`], not
     /// [`BatchCompletion::recycled`].
+    ///
+    /// For an AF_XDP backend, `tx_accepted` means that a descriptor was
+    /// published to the TX producer before this method returned. It does not
+    /// mean that the frame reached the wire or appeared on the completion
+    /// queue. An error from a wakeup after publication leaves that descriptor
+    /// accepted and in flight. `tx_rejected` means the descriptor was not
+    /// published and its frame was reclaimed before return. Published frames
+    /// remain backend-owned until completion and are not counted as
+    /// `recycled`.
     fn finish(self) -> BatchCompletion<Self::Error>;
 }
 
@@ -136,6 +146,9 @@ pub struct BatchCompletion<E> {
     /// Slots completed with [`SlotCompletion::Transmit`].
     pub tx_requested: usize,
     /// Requested TX slots accepted by the backend.
+    ///
+    /// For AF_XDP this is the number of descriptors published to the TX
+    /// producer, not wire delivery or completion-queue ownership return.
     pub tx_accepted: usize,
     /// Requested TX slots rejected and reclaimed by the backend.
     pub tx_rejected: usize,
@@ -143,7 +156,8 @@ pub struct BatchCompletion<E> {
     /// [`SlotCompletion::Consume`], or [`SlotCompletion::LeaseAbandoned`].
     ///
     /// This excludes rejected TX slots and slots that were never leased from
-    /// the batch.
+    /// the batch. For AF_XDP it also excludes published TX frames waiting for
+    /// completion; those remain backend-owned.
     pub recycled: usize,
     /// A backend error that occurred while preserving all accounting above.
     pub error: Option<E>,

--- a/crates/core/src/io.rs
+++ b/crates/core/src/io.rs
@@ -22,9 +22,11 @@ pub trait PacketBatch {
 
     /// Flushes requested transmissions and always returns their accounting.
     ///
-    /// `tx_accepted + tx_rejected == tx_requested` must hold, including when
+    /// [`BatchCompletion::invariants_hold`] must return `true`, including when
     /// `error` is present. The backend must recycle or free every rejected
-    /// slot before returning.
+    /// slot before returning. Rejected TX slots are accounted in
+    /// [`BatchCompletion::tx_rejected`], not
+    /// [`BatchCompletion::recycled`].
     fn finish(self) -> BatchCompletion<Self::Error>;
 }
 
@@ -56,6 +58,28 @@ pub enum ConsumeReason {
 ///
 /// The `Rc` marker makes this type `!Send + !Sync`; moving a live backend slot
 /// across workers is therefore rejected at compile time.
+///
+/// ```compile_fail
+/// fn require_send<T: Send>() {}
+/// require_send::<ruster_core::PacketLease<MySlot>>();
+/// # struct MySlot;
+/// # impl ruster_core::PacketSlot for MySlot {
+/// #   fn ingress(&self) -> ruster_core::IfId { ruster_core::IfId(1) }
+/// #   fn bytes_mut(&mut self) -> &mut [u8] { &mut [] }
+/// #   fn complete(self, _: ruster_core::SlotCompletion) {}
+/// # }
+/// ```
+///
+/// ```compile_fail
+/// fn require_sync<T: Sync>() {}
+/// require_sync::<ruster_core::PacketLease<MySlot>>();
+/// # struct MySlot;
+/// # impl ruster_core::PacketSlot for MySlot {
+/// #   fn ingress(&self) -> ruster_core::IfId { ruster_core::IfId(1) }
+/// #   fn bytes_mut(&mut self) -> &mut [u8] { &mut [] }
+/// #   fn complete(self, _: ruster_core::SlotCompletion) {}
+/// # }
+/// ```
 pub struct PacketLease<S: PacketSlot> {
     slot: Option<S>,
     _worker_local: PhantomData<Rc<()>>,
@@ -109,9 +133,71 @@ impl<S: PacketSlot> Drop for PacketLease<S> {
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct BatchCompletion<E> {
+    /// Slots completed with [`SlotCompletion::Transmit`].
     pub tx_requested: usize,
+    /// Requested TX slots accepted by the backend.
     pub tx_accepted: usize,
+    /// Requested TX slots rejected and reclaimed by the backend.
     pub tx_rejected: usize,
+    /// RX slots completed with [`SlotCompletion::Recycle`],
+    /// [`SlotCompletion::Consume`], or [`SlotCompletion::LeaseAbandoned`].
+    ///
+    /// This excludes rejected TX slots and slots that were never leased from
+    /// the batch.
     pub recycled: usize,
+    /// A backend error that occurred while preserving all accounting above.
     pub error: Option<E>,
+}
+
+impl<E> BatchCompletion<E> {
+    /// Returns whether requested TX slots are partitioned exactly into
+    /// accepted and rejected slots.
+    ///
+    /// The invariant is independent of `error`: backends must preserve it on
+    /// both successful and failed finishes.
+    #[must_use]
+    pub const fn invariants_hold(&self) -> bool {
+        let Some(accounted) = self.tx_accepted.checked_add(self.tx_rejected) else {
+            return false;
+        };
+        accounted == self.tx_requested
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BatchCompletion;
+
+    #[test]
+    fn batch_completion_invariant_is_exact_even_with_error() {
+        let completion = BatchCompletion {
+            tx_requested: 3,
+            tx_accepted: 1,
+            tx_rejected: 2,
+            recycled: 4,
+            error: Some("injected"),
+        };
+        assert!(completion.invariants_hold());
+
+        let invalid = BatchCompletion {
+            tx_requested: 3,
+            tx_accepted: 1,
+            tx_rejected: 1,
+            recycled: 4,
+            error: None::<&str>,
+        };
+        assert!(!invalid.invariants_hold());
+    }
+
+    #[test]
+    fn batch_completion_invariant_rejects_counter_overflow() {
+        let completion = BatchCompletion {
+            tx_requested: 0,
+            tx_accepted: usize::MAX,
+            tx_rejected: 1,
+            recycled: 0,
+            error: None::<()>,
+        };
+        assert!(!completion.invariants_hold());
+    }
 }

--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -22,10 +22,19 @@ leaseしていないslotはRX backendの所有下に残ります。coreからUME
 simの`BatchCompletion.recycled`にはdropとconsumeの両方を数えます。両者の区別は
 `BatchReport.consumed`、typed `RecycleCause`、terminal traceで保持します。
 
+`forward_batch*`へ渡すbatchは`PacketIo::receive`が返したfreshなbatchに限ります。
+事前に`next_packet`を呼んだり、leaseを完了したりしてはならず、batch lifecycle counterは
+zeroから始まります。`BatchCompletion`はforwarding関数の差分ではなくbatch生成からの
+全期間を集計するため、partial/pre-accounted batchはservice APIの対象外です。
+
 `receive`はbackend固有errorを返せます。`finish`はerror時にも失われないcompletionを
 必ず返し、TX requested/accepted/rejectedを分けます。常に
 `accepted + rejected == requested`で、reject slotはbackendがreturn前にrecycle/free
-します。これによりAF_XDP ring fullやDPDK partial TXでもrequestを成功と誤認しません。
+します。AF_XDPのacceptedは`finish`のreturn前にTX producerへdescriptorをpublishしたことを
+意味し、wire送信やcompletion queue到着を意味しません。publish後のwakeup errorでもその
+descriptorはaccepted/in-flightのままです。rejectedはpublishされずreturn前にreclaimされます。
+publish済みframeはcompletionまでbackend所有で、`recycled`には数えません。これにより
+AF_XDP ring fullやDPDK partial TXでもrequestを成功と誤認しません。
 
 ## forwarding transaction
 


### PR DESCRIPTION
## Summary
- add overflow-safe RX completion/report invariants
- make fresh-batch accounting and recycle semantics explicit
- validate accounting before terminal trace publication
- define AF_XDP TX producer publication versus wakeup/CQ ownership
- add compile-fail and adversarial accounting coverage

## Validation
- full repository gates passed at the ready implementation SHA
- independent backend lifecycle review approved the fixed SHA with no blocking findings

## Compatibility
Trait and report shapes are unchanged. Forwarding now explicitly requires a fresh, untouched batch, matching the v0.2 ownership model.