### PR TITLE
feat(core): expose full NAT firewall ICMP composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ silent dropします。lookupはrule scan、reverse match、activity/phase/count
 行いません。NATを伴わないplain forwarded RELATEDはdeferredで、既存の
 `FIREWALL_RELATED_ICMPV4_UNSUPPORTED` discriminantは予約したままです。
 
+UDP/TCP NAT44、firewall、router-originated ICMPv4 errorを同じworkerへbindする場合は、
+`forward_batch_with_nat44_udp_and_tcp_and_firewall_and_icmpv4_errors`または監査付きvariantを
+選び、`Icmpv4ErrorRuntime`を必須で渡します。firewall deny、authority failure、route missは
+silentのままで、認可後のeligible TTL expiryはSNAT前の受信IPv4をquoteしてactionをqueueします。
+RX batchとgenerated TXは融合せず、既定のworker tick順どおりRX完了後に生成します。生成packet
+そのものはfirewallの対象外です。既存のICMP runtimeを取らないcombined APIは変更しません。
+
 ## 開発
 
 stable Rustだけで検証できます。

--- a/crates/core/src/forwarding.rs
+++ b/crates/core/src/forwarding.rs
@@ -1354,6 +1354,84 @@ where
     )
 }
 
+/// Composes independent UDP/TCP NAPT, one canonical-tuple firewall, and
+/// generated ICMPv4 error capture in one ordered RX phase.
+///
+/// Firewall authorization precedes TTL error capture. Generated execution
+/// remains a separate post-RX phase.
+#[allow(clippy::too_many_arguments)]
+pub fn forward_batch_with_nat44_udp_and_tcp_and_firewall_and_icmpv4_errors<B, T>(
+    batch: B,
+    snapshot: &ForwardingSnapshot<'_>,
+    resolution: &mut ResolutionRuntime<'_>,
+    icmpv4_errors: &mut Icmpv4ErrorRuntime<'_>,
+    udp_config: &Nat44UdpConfig,
+    nat44_udp: Option<&mut Nat44UdpRuntime<'_>>,
+    tcp_config: &Nat44TcpConfig,
+    nat44_tcp: Option<&mut Nat44TcpRuntime<'_>>,
+    firewall_config: &FirewallConfig<'_>,
+    firewall: Option<&mut FirewallRuntime<'_, '_>>,
+    now: MonotonicMillis,
+    trace: &mut T,
+) -> BatchReport<B::Error>
+where
+    B: PacketBatch,
+    T: TraceSink,
+{
+    forward_batch_inner(
+        batch,
+        snapshot,
+        Some((resolution, now)),
+        Some((icmpv4_errors, now)),
+        Some(udp_config),
+        nat44_udp,
+        Some(tcp_config),
+        nat44_tcp,
+        Some(firewall_config),
+        firewall,
+        None,
+        trace,
+    )
+}
+
+/// Audited variant of
+/// [`forward_batch_with_nat44_udp_and_tcp_and_firewall_and_icmpv4_errors`].
+#[allow(clippy::too_many_arguments)]
+pub fn forward_batch_with_nat44_udp_and_tcp_and_firewall_and_icmpv4_errors_audited<B, T>(
+    batch: B,
+    snapshot: &ForwardingSnapshot<'_>,
+    resolution: &mut ResolutionRuntime<'_>,
+    icmpv4_errors: &mut Icmpv4ErrorRuntime<'_>,
+    udp_config: &Nat44UdpConfig,
+    nat44_udp: Option<&mut Nat44UdpRuntime<'_>>,
+    tcp_config: &Nat44TcpConfig,
+    nat44_tcp: Option<&mut Nat44TcpRuntime<'_>>,
+    firewall_config: &FirewallConfig<'_>,
+    firewall: Option<&mut FirewallRuntime<'_, '_>>,
+    audit: &mut FirewallAuditBuffer<'_>,
+    now: MonotonicMillis,
+    trace: &mut T,
+) -> BatchReport<B::Error>
+where
+    B: PacketBatch,
+    T: TraceSink,
+{
+    forward_batch_inner(
+        batch,
+        snapshot,
+        Some((resolution, now)),
+        Some((icmpv4_errors, now)),
+        Some(udp_config),
+        nat44_udp,
+        Some(tcp_config),
+        nat44_tcp,
+        Some(firewall_config),
+        firewall,
+        Some(audit),
+        trace,
+    )
+}
+
 #[allow(clippy::too_many_arguments)]
 fn forward_batch_inner<B, T>(
     mut batch: B,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -33,6 +33,8 @@ pub use forwarding::{
     forward_batch_with_nat44_tcp, forward_batch_with_nat44_tcp_and_icmpv4_errors,
     forward_batch_with_nat44_udp, forward_batch_with_nat44_udp_and_icmpv4_errors,
     forward_batch_with_nat44_udp_and_tcp, forward_batch_with_nat44_udp_and_tcp_and_firewall,
+    forward_batch_with_nat44_udp_and_tcp_and_firewall_and_icmpv4_errors,
+    forward_batch_with_nat44_udp_and_tcp_and_firewall_and_icmpv4_errors_audited,
     forward_batch_with_nat44_udp_and_tcp_and_firewall_audited,
     forward_batch_with_nat44_udp_and_tcp_and_icmpv4_errors, forward_batch_with_resolution,
     forward_batch_with_resolution_and_icmpv4_errors, BatchReport, DropReason, ForwardingSnapshot,

--- a/crates/io-sim/src/lib.rs
+++ b/crates/io-sim/src/lib.rs
@@ -8,6 +8,8 @@ use ruster_core::{
     forward_batch_with_firewall_audited, forward_batch_with_nat44_tcp,
     forward_batch_with_nat44_udp, forward_batch_with_nat44_udp_and_tcp,
     forward_batch_with_nat44_udp_and_tcp_and_firewall,
+    forward_batch_with_nat44_udp_and_tcp_and_firewall_and_icmpv4_errors,
+    forward_batch_with_nat44_udp_and_tcp_and_firewall_and_icmpv4_errors_audited,
     forward_batch_with_nat44_udp_and_tcp_and_firewall_audited, BatchCompletion, BatchReport,
     ConsumeReason, DropReason, FirewallAuditBuffer, FirewallConfig, FirewallRuntime,
     ForwardingSnapshot, GeneratedAllocationError, GeneratedArpTrace, GeneratedBatchCompletion,
@@ -355,6 +357,78 @@ impl SimIo {
             now,
             trace,
         ))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn run_nat44_udp_and_tcp_with_firewall_and_icmpv4_errors_once<T: TraceSink>(
+        &mut self,
+        budget: usize,
+        snapshot: &ForwardingSnapshot<'_>,
+        resolution: &mut ResolutionRuntime<'_>,
+        icmpv4_errors: &mut ruster_core::Icmpv4ErrorRuntime<'_>,
+        udp_config: &Nat44UdpConfig,
+        nat44_udp: Option<&mut Nat44UdpRuntime<'_>>,
+        tcp_config: &Nat44TcpConfig,
+        nat44_tcp: Option<&mut Nat44TcpRuntime<'_>>,
+        firewall_config: &FirewallConfig<'_>,
+        firewall: Option<&mut FirewallRuntime<'_, '_>>,
+        now: MonotonicMillis,
+        trace: &mut T,
+    ) -> Result<BatchReport<Infallible>, Infallible> {
+        let batch = self.receive(budget)?;
+        Ok(
+            forward_batch_with_nat44_udp_and_tcp_and_firewall_and_icmpv4_errors(
+                batch,
+                snapshot,
+                resolution,
+                icmpv4_errors,
+                udp_config,
+                nat44_udp,
+                tcp_config,
+                nat44_tcp,
+                firewall_config,
+                firewall,
+                now,
+                trace,
+            ),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn run_nat44_udp_and_tcp_with_firewall_and_icmpv4_errors_audited_once<T: TraceSink>(
+        &mut self,
+        budget: usize,
+        snapshot: &ForwardingSnapshot<'_>,
+        resolution: &mut ResolutionRuntime<'_>,
+        icmpv4_errors: &mut ruster_core::Icmpv4ErrorRuntime<'_>,
+        udp_config: &Nat44UdpConfig,
+        nat44_udp: Option<&mut Nat44UdpRuntime<'_>>,
+        tcp_config: &Nat44TcpConfig,
+        nat44_tcp: Option<&mut Nat44TcpRuntime<'_>>,
+        firewall_config: &FirewallConfig<'_>,
+        firewall: Option<&mut FirewallRuntime<'_, '_>>,
+        audit: &mut FirewallAuditBuffer<'_>,
+        now: MonotonicMillis,
+        trace: &mut T,
+    ) -> Result<BatchReport<Infallible>, Infallible> {
+        let batch = self.receive(budget)?;
+        Ok(
+            forward_batch_with_nat44_udp_and_tcp_and_firewall_and_icmpv4_errors_audited(
+                batch,
+                snapshot,
+                resolution,
+                icmpv4_errors,
+                udp_config,
+                nat44_udp,
+                tcp_config,
+                nat44_tcp,
+                firewall_config,
+                firewall,
+                audit,
+                now,
+                trace,
+            ),
+        )
     }
 }
 

--- a/crates/io-sim/tests/stateful_firewall.rs
+++ b/crates/io-sim/tests/stateful_firewall.rs
@@ -251,6 +251,28 @@ fn assert_drop(io: &mut SimIo, reason: DropReason, original: &[u8]) {
     assert_eq!(dropped.bytes, original);
 }
 
+type CombinedStateSnapshot = (
+    Vec<Nat44UdpMappingSlot>,
+    Vec<Nat44UdpPeerSlot>,
+    Vec<Nat44TcpMappingSlot>,
+    Vec<Nat44TcpSessionSlot>,
+    Vec<FirewallStateSlot>,
+);
+
+fn combined_state_snapshot(
+    udp: &Nat44UdpRuntime<'_>,
+    tcp: &Nat44TcpRuntime<'_>,
+    firewall: &FirewallRuntime<'_, '_>,
+) -> CombinedStateSnapshot {
+    (
+        udp.mappings().to_vec(),
+        udp.peers().to_vec(),
+        tcp.mappings().to_vec(),
+        tcp.sessions().to_vec(),
+        firewall.states().to_vec(),
+    )
+}
+
 fn rewrite_ipv4_header(frame: &mut [u8]) {
     let header_len = usize::from(frame[14] & 0x0f) * 4;
     frame[24..26].fill(0);
@@ -965,6 +987,63 @@ fn full_nat_firewall_composition_queues_and_dispatches_only_authorized_icmpv4_er
     );
     assert_eq!(errors.pending_actions(), 0);
 
+    let mut authorized_audit_storage = [FirewallAuditRecord::default(); 1];
+    let mut authorized_audit = FirewallAuditBuffer::new(&mut authorized_audit_storage);
+    let mut audited_ttl = udp_frame(HOST, REMOTE, 12_349, 53, 0x4000, false);
+    set_ttl(&mut audited_ttl, 1);
+    let audited_ipv4_total_len =
+        usize::from(u16::from_be_bytes([audited_ttl[16], audited_ttl[17]]));
+    let audited_quote = audited_ttl[14..14 + audited_ipv4_total_len].to_vec();
+    let audited_state_before = combined_state_snapshot(&udp, &tcp, &firewall);
+    io.inject(LAN, audited_ttl.clone());
+    io.run_nat44_udp_and_tcp_with_firewall_and_icmpv4_errors_audited_once(
+        1,
+        &snapshot,
+        &mut resolution_runtime,
+        &mut errors,
+        &udp_config,
+        Some(&mut udp),
+        &tcp_config,
+        Some(&mut tcp),
+        &allow_config,
+        Some(&mut firewall),
+        &mut authorized_audit,
+        MonotonicMillis(101),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_drop(&mut io, DropReason::Ipv4TtlExpired, &audited_ttl);
+    assert_eq!(errors.pending_actions(), 1);
+    assert_eq!(resolution_runtime.pending_actions(), 0);
+    assert_eq!(resolution_runtime.pending_states(), 0);
+    assert_eq!(
+        combined_state_snapshot(&udp, &tcp, &firewall),
+        audited_state_before
+    );
+    assert_eq!(authorized_audit.records().len(), 1);
+    assert_eq!(
+        authorized_audit.records()[0].disposition.verdict,
+        FirewallVerdict::Allow
+    );
+
+    let audited_generated = execute_one_icmpv4_error(
+        &mut io,
+        &mut errors,
+        MonotonicMillis(101),
+        &mut NoGeneratedIcmpv4Trace,
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(audited_generated.action.quote_len(), audited_quote.len());
+    let audited_generated_frame = io.pop_tx().unwrap();
+    assert_eq!(audited_generated_frame.origin, FrameOrigin::Generated);
+    assert_eq!(&audited_generated_frame.bytes[34..36], &[11, 0]);
+    assert_eq!(
+        &audited_generated_frame.bytes[42..42 + audited_quote.len()],
+        audited_quote.as_slice()
+    );
+    assert_eq!(errors.pending_actions(), 0);
+
     let deny_rules = [rule(
         30,
         FirewallInterface::Interface(LAN),
@@ -983,6 +1062,7 @@ fn full_nat_firewall_composition_queues_and_dispatches_only_authorized_icmpv4_er
     let mut audit = FirewallAuditBuffer::new(&mut audit_storage);
     let mut denied = udp_frame(HOST, REMOTE, 12_346, 53, 0x4000, false);
     set_ttl(&mut denied, 1);
+    let denied_state_before = combined_state_snapshot(&udp, &tcp, &deny_firewall);
     io.inject(LAN, denied.clone());
     io.run_nat44_udp_and_tcp_with_firewall_and_icmpv4_errors_audited_once(
         1,
@@ -996,13 +1076,18 @@ fn full_nat_firewall_composition_queues_and_dispatches_only_authorized_icmpv4_er
         &deny_config,
         Some(&mut deny_firewall),
         &mut audit,
-        MonotonicMillis(2),
+        MonotonicMillis(102),
         &mut NoTrace,
     )
     .unwrap();
     assert_drop(&mut io, DropReason::FirewallRuleDenied, &denied);
     assert_eq!(errors.pending_actions(), 0);
     assert_eq!(resolution_runtime.pending_actions(), 0);
+    assert_eq!(resolution_runtime.pending_states(), 0);
+    assert_eq!(
+        combined_state_snapshot(&udp, &tcp, &deny_firewall),
+        denied_state_before
+    );
     assert_eq!(audit.records().len(), 1);
     assert_eq!(
         audit.records()[0].disposition.verdict,
@@ -1012,6 +1097,7 @@ fn full_nat_firewall_composition_queues_and_dispatches_only_authorized_icmpv4_er
     let mismatched_firewall_config = firewall_config(&snapshot, &rules, 2);
     let mut authority = udp_frame(HOST, REMOTE, 12_347, 53, 0x4000, false);
     set_ttl(&mut authority, 1);
+    let authority_state_before = combined_state_snapshot(&udp, &tcp, &firewall);
     io.inject(LAN, authority.clone());
     io.run_nat44_udp_and_tcp_with_firewall_and_icmpv4_errors_once(
         1,
@@ -1024,13 +1110,18 @@ fn full_nat_firewall_composition_queues_and_dispatches_only_authorized_icmpv4_er
         Some(&mut tcp),
         &mismatched_firewall_config,
         Some(&mut firewall),
-        MonotonicMillis(3),
+        MonotonicMillis(103),
         &mut NoTrace,
     )
     .unwrap();
     assert_drop(&mut io, DropReason::FirewallConfigMismatch, &authority);
     assert_eq!(errors.pending_actions(), 0);
     assert_eq!(resolution_runtime.pending_actions(), 0);
+    assert_eq!(resolution_runtime.pending_states(), 0);
+    assert_eq!(
+        combined_state_snapshot(&udp, &tcp, &firewall),
+        authority_state_before
+    );
 
     let no_remote_routes = [routes[0]];
     let route_snapshot =
@@ -1079,6 +1170,7 @@ fn full_nat_firewall_composition_queues_and_dispatches_only_authorized_icmpv4_er
         resolution(&mut route_resolution_states, &mut route_resolution_actions);
     let mut no_route = udp_frame(HOST, REMOTE, 12_348, 53, 0x4000, false);
     set_ttl(&mut no_route, 1);
+    let route_state_before = combined_state_snapshot(&route_udp, &route_tcp, &route_firewall);
     io.inject(LAN, no_route.clone());
     io.run_nat44_udp_and_tcp_with_firewall_and_icmpv4_errors_once(
         1,
@@ -1091,13 +1183,18 @@ fn full_nat_firewall_composition_queues_and_dispatches_only_authorized_icmpv4_er
         Some(&mut route_tcp),
         &route_firewall_config,
         Some(&mut route_firewall),
-        MonotonicMillis(4),
+        MonotonicMillis(104),
         &mut NoTrace,
     )
     .unwrap();
     assert_drop(&mut io, DropReason::FirewallRouteUnavailable, &no_route);
     assert_eq!(errors.pending_actions(), 0);
     assert_eq!(route_resolution.pending_actions(), 0);
+    assert_eq!(route_resolution.pending_states(), 0);
+    assert_eq!(
+        combined_state_snapshot(&route_udp, &route_tcp, &route_firewall),
+        route_state_before
+    );
 }
 
 #[test]

--- a/crates/io-sim/tests/stateful_firewall.rs
+++ b/crates/io-sim/tests/stateful_firewall.rs
@@ -1,17 +1,18 @@
 use ruster_core::{
-    internet_checksum, ipv4_header_checksum, DropReason, DynamicNeighborSlot, FirewallAction,
-    FirewallAuditBuffer, FirewallAuditRecord, FirewallConfig, FirewallConnectionClass,
-    FirewallDisposition, FirewallFailure, FirewallHashKey, FirewallInterface, FirewallIpv4Prefix,
-    FirewallPolicy, FirewallPolicySource, FirewallPortRange, FirewallProtocol, FirewallRule,
-    FirewallRuleId, FirewallRuntime, FirewallStateSlot, FirewallTcpPhase, FirewallVerdict,
-    ForwardingSnapshot, Icmpv4ErrorActionSlot, Icmpv4ErrorPolicy, Icmpv4ErrorRuntime,
-    Icmpv4ErrorStateSlot, IfId, Interface, Ipv4Address, LocalIpv4Binding, MacAddress,
-    MonotonicMillis, Nat44Icmpv4ErrorPolicy, Nat44TcpConfig, Nat44TcpMappingSlot, Nat44TcpPolicy,
-    Nat44TcpRuntime, Nat44TcpSessionSlot, Nat44UdpConfig, Nat44UdpMappingSlot, Nat44UdpPeerSlot,
-    Nat44UdpPolicy, Nat44UdpRuntime, Neighbor, NoTrace, ResolutionActionSlot, ResolutionPolicy,
-    ResolutionRuntime, ResolutionStateSlot, Route,
+    execute_one_icmpv4_error, internet_checksum, ipv4_header_checksum, DropReason,
+    DynamicNeighborSlot, FirewallAction, FirewallAuditBuffer, FirewallAuditRecord, FirewallConfig,
+    FirewallConnectionClass, FirewallDisposition, FirewallFailure, FirewallHashKey,
+    FirewallInterface, FirewallIpv4Prefix, FirewallPolicy, FirewallPolicySource, FirewallPortRange,
+    FirewallProtocol, FirewallRule, FirewallRuleId, FirewallRuntime, FirewallStateSlot,
+    FirewallTcpPhase, FirewallVerdict, ForwardingSnapshot, Icmpv4ErrorActionSlot,
+    Icmpv4ErrorPolicy, Icmpv4ErrorRuntime, Icmpv4ErrorStateSlot, IfId, Interface, Ipv4Address,
+    LocalIpv4Binding, MacAddress, MonotonicMillis, Nat44Icmpv4ErrorPolicy, Nat44TcpConfig,
+    Nat44TcpMappingSlot, Nat44TcpPolicy, Nat44TcpRuntime, Nat44TcpSessionSlot, Nat44UdpConfig,
+    Nat44UdpMappingSlot, Nat44UdpPeerSlot, Nat44UdpPolicy, Nat44UdpRuntime, Neighbor,
+    NoGeneratedIcmpv4Trace, NoTrace, ResolutionActionSlot, ResolutionPolicy, ResolutionRuntime,
+    ResolutionStateSlot, Route,
 };
-use ruster_io_sim::{RecycleCause, SimIo};
+use ruster_io_sim::{FrameOrigin, RecycleCause, SimIo};
 
 const LAN: IfId = IfId(1);
 const WAN: IfId = IfId(2);
@@ -862,6 +863,241 @@ fn firewall_transport_options_ports_checksums_and_ttl_fail_closed_before_state()
     assert_drop(&mut io, DropReason::Ipv4TtlExpired, &ttl);
     assert_eq!(firewall.states(), before);
     assert_eq!(errors.pending_actions(), 1);
+}
+
+#[test]
+fn full_nat_firewall_composition_queues_and_dispatches_only_authorized_icmpv4_errors() {
+    let (routes, interfaces, neighbors, bindings) = topology();
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &bindings).unwrap();
+    let udp_config = Nat44UdpConfig::new(
+        &snapshot,
+        LAN,
+        WAN,
+        WAN_LOCAL,
+        40_000,
+        40_001,
+        Nat44UdpPolicy::default(),
+    )
+    .unwrap();
+    let tcp_config = Nat44TcpConfig::new(
+        &snapshot,
+        LAN,
+        WAN,
+        WAN_LOCAL,
+        40_000,
+        40_001,
+        Nat44TcpPolicy::default(),
+    )
+    .unwrap();
+    let rules = [allow(FirewallProtocol::Udp), allow(FirewallProtocol::Tcp)];
+    let allow_config = firewall_config(&snapshot, &rules, 1);
+    let mut firewall_slots = [FirewallStateSlot::default(); 2];
+    let mut firewall = FirewallRuntime::new(allow_config, &mut firewall_slots);
+    let mut udp_mappings = [Nat44UdpMappingSlot::default(); 2];
+    let mut udp_peers = [Nat44UdpPeerSlot::default(); 2];
+    let mut udp = Nat44UdpRuntime::new(udp_config, &mut udp_mappings, &mut udp_peers);
+    let mut tcp_mappings = [Nat44TcpMappingSlot::default(); 2];
+    let mut tcp_sessions = [Nat44TcpSessionSlot::default(); 2];
+    let mut tcp = Nat44TcpRuntime::new(tcp_config, &mut tcp_mappings, &mut tcp_sessions);
+    let mut resolution_states = [ResolutionStateSlot::EMPTY; 1];
+    let mut resolution_actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut resolution_runtime = resolution(&mut resolution_states, &mut resolution_actions);
+    let mut error_states = [Icmpv4ErrorStateSlot::EMPTY; 1];
+    let mut error_actions = [Icmpv4ErrorActionSlot::EMPTY; 1];
+    let mut errors = Icmpv4ErrorRuntime::new(
+        Icmpv4ErrorPolicy::default(),
+        &mut error_states,
+        &mut error_actions,
+    );
+    let mut io = SimIo::new();
+
+    let mut ttl = udp_frame(HOST, REMOTE, 12_345, 53, 0x4000, false);
+    set_ttl(&mut ttl, 1);
+    let ipv4_total_len = usize::from(u16::from_be_bytes([ttl[16], ttl[17]]));
+    let original_quote = ttl[14..14 + ipv4_total_len].to_vec();
+    io.inject(LAN, ttl.clone());
+    io.run_nat44_udp_and_tcp_with_firewall_and_icmpv4_errors_once(
+        1,
+        &snapshot,
+        &mut resolution_runtime,
+        &mut errors,
+        &udp_config,
+        Some(&mut udp),
+        &tcp_config,
+        Some(&mut tcp),
+        &allow_config,
+        Some(&mut firewall),
+        MonotonicMillis(1),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_drop(&mut io, DropReason::Ipv4TtlExpired, &ttl);
+    assert_eq!(errors.pending_actions(), 1);
+    assert_eq!(resolution_runtime.pending_actions(), 0);
+    assert!(udp.mappings().iter().all(|slot| !slot.is_occupied()));
+    assert!(udp.peers().iter().all(|slot| !slot.is_occupied()));
+    assert!(tcp.mappings().iter().all(|slot| !slot.is_occupied()));
+    assert!(tcp.sessions().iter().all(|slot| !slot.is_occupied()));
+    assert!(firewall.states().iter().all(|slot| !slot.is_occupied()));
+
+    let generated = execute_one_icmpv4_error(
+        &mut io,
+        &mut errors,
+        MonotonicMillis(1),
+        &mut NoGeneratedIcmpv4Trace,
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(generated.action.quote_len(), original_quote.len());
+    assert_eq!(
+        (generated.completion.accepted, generated.completion.rejected),
+        (1, 0)
+    );
+    let generated_frame = io.pop_tx().unwrap();
+    assert_eq!(generated_frame.origin, FrameOrigin::Generated);
+    assert_eq!(generated_frame.egress, LAN);
+    assert_eq!(&generated_frame.bytes[26..30], &LAN_LOCAL.octets());
+    assert_eq!(&generated_frame.bytes[30..34], &HOST.octets());
+    assert_eq!(&generated_frame.bytes[34..36], &[11, 0]);
+    assert_eq!(
+        &generated_frame.bytes[42..42 + original_quote.len()],
+        original_quote.as_slice()
+    );
+    assert_eq!(errors.pending_actions(), 0);
+
+    let deny_rules = [rule(
+        30,
+        FirewallInterface::Interface(LAN),
+        FirewallInterface::Interface(WAN),
+        prefix(HOST, 32),
+        any_prefix(),
+        FirewallProtocol::Udp,
+        ports(12_346, 12_346),
+        ports(53, 53),
+        FirewallAction::Deny,
+    )];
+    let deny_config = firewall_config(&snapshot, &deny_rules, 1);
+    let mut deny_slots = [FirewallStateSlot::default(); 1];
+    let mut deny_firewall = FirewallRuntime::new(deny_config, &mut deny_slots);
+    let mut audit_storage = [FirewallAuditRecord::default(); 1];
+    let mut audit = FirewallAuditBuffer::new(&mut audit_storage);
+    let mut denied = udp_frame(HOST, REMOTE, 12_346, 53, 0x4000, false);
+    set_ttl(&mut denied, 1);
+    io.inject(LAN, denied.clone());
+    io.run_nat44_udp_and_tcp_with_firewall_and_icmpv4_errors_audited_once(
+        1,
+        &snapshot,
+        &mut resolution_runtime,
+        &mut errors,
+        &udp_config,
+        Some(&mut udp),
+        &tcp_config,
+        Some(&mut tcp),
+        &deny_config,
+        Some(&mut deny_firewall),
+        &mut audit,
+        MonotonicMillis(2),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_drop(&mut io, DropReason::FirewallRuleDenied, &denied);
+    assert_eq!(errors.pending_actions(), 0);
+    assert_eq!(resolution_runtime.pending_actions(), 0);
+    assert_eq!(audit.records().len(), 1);
+    assert_eq!(
+        audit.records()[0].disposition.verdict,
+        FirewallVerdict::Drop
+    );
+
+    let mismatched_firewall_config = firewall_config(&snapshot, &rules, 2);
+    let mut authority = udp_frame(HOST, REMOTE, 12_347, 53, 0x4000, false);
+    set_ttl(&mut authority, 1);
+    io.inject(LAN, authority.clone());
+    io.run_nat44_udp_and_tcp_with_firewall_and_icmpv4_errors_once(
+        1,
+        &snapshot,
+        &mut resolution_runtime,
+        &mut errors,
+        &udp_config,
+        Some(&mut udp),
+        &tcp_config,
+        Some(&mut tcp),
+        &mismatched_firewall_config,
+        Some(&mut firewall),
+        MonotonicMillis(3),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_drop(&mut io, DropReason::FirewallConfigMismatch, &authority);
+    assert_eq!(errors.pending_actions(), 0);
+    assert_eq!(resolution_runtime.pending_actions(), 0);
+
+    let no_remote_routes = [routes[0]];
+    let route_snapshot =
+        ForwardingSnapshot::new(&no_remote_routes, &interfaces, &neighbors, &bindings).unwrap();
+    let route_udp_config = Nat44UdpConfig::new(
+        &route_snapshot,
+        LAN,
+        WAN,
+        WAN_LOCAL,
+        40_000,
+        40_001,
+        Nat44UdpPolicy::default(),
+    )
+    .unwrap();
+    let route_tcp_config = Nat44TcpConfig::new(
+        &route_snapshot,
+        LAN,
+        WAN,
+        WAN_LOCAL,
+        40_000,
+        40_001,
+        Nat44TcpPolicy::default(),
+    )
+    .unwrap();
+    let route_rules = [allow(FirewallProtocol::Udp), allow(FirewallProtocol::Tcp)];
+    let route_firewall_config = firewall_config(&route_snapshot, &route_rules, 1);
+    let mut route_firewall_slots = [FirewallStateSlot::default(); 1];
+    let mut route_firewall = FirewallRuntime::new(route_firewall_config, &mut route_firewall_slots);
+    let mut route_udp_mappings = [Nat44UdpMappingSlot::default(); 1];
+    let mut route_udp_peers = [Nat44UdpPeerSlot::default(); 1];
+    let mut route_udp = Nat44UdpRuntime::new(
+        route_udp_config,
+        &mut route_udp_mappings,
+        &mut route_udp_peers,
+    );
+    let mut route_tcp_mappings = [Nat44TcpMappingSlot::default(); 1];
+    let mut route_tcp_sessions = [Nat44TcpSessionSlot::default(); 1];
+    let mut route_tcp = Nat44TcpRuntime::new(
+        route_tcp_config,
+        &mut route_tcp_mappings,
+        &mut route_tcp_sessions,
+    );
+    let mut route_resolution_states = [ResolutionStateSlot::EMPTY; 1];
+    let mut route_resolution_actions = [ResolutionActionSlot::EMPTY; 1];
+    let mut route_resolution =
+        resolution(&mut route_resolution_states, &mut route_resolution_actions);
+    let mut no_route = udp_frame(HOST, REMOTE, 12_348, 53, 0x4000, false);
+    set_ttl(&mut no_route, 1);
+    io.inject(LAN, no_route.clone());
+    io.run_nat44_udp_and_tcp_with_firewall_and_icmpv4_errors_once(
+        1,
+        &route_snapshot,
+        &mut route_resolution,
+        &mut errors,
+        &route_udp_config,
+        Some(&mut route_udp),
+        &route_tcp_config,
+        Some(&mut route_tcp),
+        &route_firewall_config,
+        Some(&mut route_firewall),
+        MonotonicMillis(4),
+        &mut NoTrace,
+    )
+    .unwrap();
+    assert_drop(&mut io, DropReason::FirewallRouteUnavailable, &no_route);
+    assert_eq!(errors.pending_actions(), 0);
+    assert_eq!(route_resolution.pending_actions(), 0);
 }
 
 #[test]

--- a/docs/architecture-v0.2.md
+++ b/docs/architecture-v0.2.md
@@ -524,6 +524,12 @@ offset、TCP/UDP以外のforward protocolはsilent typed dropで、ICMP/RSTを�
 RFC 791のfragment fieldsでMF=0/offset=0なら、DF=0とDF=1のどちらもunfragmented datagram
 として許可します。ここでRFC 6864のatomic datagramという用語は使いません。
 
+UDP/TCP NAT44、firewall、router-originated ICMPv4 error captureを全て有効にするworkerは
+`forward_batch_with_nat44_udp_and_tcp_and_firewall_and_icmpv4_errors`または監査付きvariantを
+選び、caller-backed `Icmpv4ErrorRuntime`を必須でbindします。既存のruntimeを取らない
+combined APIは非生成のままです。公開APIへfeature選択用のoptional runtimeを追加せず、
+capabilityはentry pointで明示します。
+
 ruleはstable `FirewallRuleId`を持つimmutable sliceで、ingress/egress `IfId|Any`、
 canonical source/destination prefix、TCP/UDP、inclusive source/destination port range、
 `AllowStateful|Deny`を持ちます。順序どおりfirst-matchし、matchなしはimplicit default deny
@@ -588,6 +594,15 @@ rule/default deny、state full、route/neighbor/NAT missでも戻しません。
 `FirewallClockRegression`またはNAT clock regressionになります。FW opt-in時のLPM missは
 egress不明のためrule評価せず`FirewallRouteUnavailable`でsilent dropし、Type 3/Code 0やARPを
 queueしません。NAT inboundもFW state/rule判定をTTL判定より先に行います。
+
+full compositionでもfirewall authorizationはTTL判定とgenerated error captureより先です。
+rule/default deny、runtime/config/snapshot authority failure、LPM missはICMP/ARPをqueueしない
+silent dropを維持します。認可済みpacketのTTL 0/1は既存のerror suppressionとreverse
+authorityを通過した場合にactionをqueueし、quoteはNAT rewrite前の受信IPv4 datagramです。
+TTL failureではNAT mapping/sessionとfirewall flowをcommitしません。captureはRX phaseだけで、
+generated実行をforwarding wrapper内へ融合しません。worker tick順は引き続き
+`publication/reconcile → RX → resolution timer poll → failure dispatch → generated ARP →
+generated ICMP`で、生成packetはfirewall domain外です。
 
 planが返すcreate/refresh replacementと論理的にliveなflowのactivity/phaseはcommitまで反映
 しません。一方、security watermarkと同様にlazy expiry housekeepingはprobe中に実行でき、

--- a/docs/requirements-v0.2.md
+++ b/docs/requirements-v0.2.md
@@ -202,6 +202,7 @@ Statusは`implemented`、`deferred`、`deviation`のいずれかです。test名
 | FW-020 keyed flow hashing | local hash-flood resistance contract | `secret_changes_hash_and_rotation_flushes_state` | implemented | caller-supplied fresh nonzero 128-bit secret、forward/reverse同home、generation前進のsame-key publishをtyped拒否、fresh rotationはstate flush、fast path random/syscallなし |
 | FW-021 expiry cluster repair | architecture complexity contract | `cleanup_budget_is_linear_for_n_and_two_n_capacity` | implemented | capacity 4以上は最大75% usable。attemptごとにdelete/shift/restart各最大1回、probe+maintenanceは定数倍N、繰返しでempty terminationを回復、live evictionなし |
 | FW-022 SipHash conformance and flow layout | SipHash-2-4 reference vectors, local canonical-key contract | `siphash_vectors_and_canonical_flow_layout_match_independent_references` | implemented | official length 0/1/7/8/15/16/63 vectorsと固定64-byte canonical flow layoutの独立hard-coded reference値を検証 |
+| FW-023 explicit full-service generated ICMPv4 composition | RFC 1812 §4.3.2, architecture composition contract | `full_nat_firewall_composition_queues_and_dispatches_only_authorized_icmpv4_errors` | implemented | UDP/TCP NAT44+FWの明示error APIで認可後TTL errorをpre-NAT quoteでqueue。deny/authority/route失敗はsilent、RX後のgenerated phaseでdispatch |
 
 ## RFC deviation rule
 


### PR DESCRIPTION
## Summary
- add regular and audited public full-service forwarding wrappers
- wire UDP/TCP NAT, firewall, and router-originated ICMP action capture together
- add RX-only SimIo mirrors while preserving post-RX generated dispatch
- specify and test authorized pre-NAT TTL quotes and silent failure paths

## Validation
- targeted FW-023 integration coverage passed
- full current repository gates passed at the fixed ready SHA
- independent home-router/lifecycle review approved after test strengthening

## Fast path
No shared Mutex, packet clone, per-packet String, trait object, allocation, or generated-I/O fusion.