### PR TITLE
feat(bench): add NIC-free datapath benchmark foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,13 @@
 version = 4
 
 [[package]]
+name = "ruster-bench"
+version = "0.2.0"
+dependencies = [
+ "ruster-core",
+]
+
+[[package]]
 name = "ruster-core"
 version = "0.2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/core", "crates/io-sim"]
+members = ["crates/bench", "crates/core", "crates/io-sim"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "ruster-bench"
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+ruster-core = { path = "../core" }

--- a/crates/bench/README.md
+++ b/crates/bench/README.md
@@ -19,8 +19,12 @@ two-pass controlを測定します。NAT/firewall/state pressureは後続slice�
 84 bytesです。`ip-mtu1500`はそれぞれ1514、1518、1538 bytesです。結果のJSONLにも
 全ての値を別fieldで保存します。
 
-fixture生成、buffer reset、batch acquisition、結果検証、formattingはtimed region外です。
-timed region内でcurrent worker threadのallocationを一つでも検出したrunは失敗します。
+fixture生成、結果検証、formattingはtimed region外です。buffer resetとbatch acquisitionの
+costは次のaggregate subtractionで結果から除外します。測定interval内でcurrent worker
+threadのallocationを一つでも検出したrunは失敗します。
+plain forwardingは同じ反復数の`reset + receive` intervalを別に一度測り、全反復を一つの
+intervalで測った値から差し引きます。packetごとのclock読取りを入れず、batchごとの
+`forward_batch`/finish境界を維持します。
 各packet bufferは測定直前のresetでCPU cacheへ触れるため、これはcoreのhot-cache
 microbenchmarkであり、NIC/backend DMAやcold-cache throughputの主張ではありません。
 

--- a/crates/bench/README.md
+++ b/crates/bench/README.md
@@ -1,0 +1,29 @@
+# ruster-bench
+
+`ruster-core`のpacket leaseと同じ境界を使う、NIC不要・外部crate依存なしの
+benchmark runnerです。`ruster-io-sim`の投入/capture用queueを測定に含めず、
+事前確保したbackend所有bufferをcoreへ借用させます。
+
+```bash
+cargo run --release -p ruster-bench -- \
+  --suite smoke --format human
+
+cargo run --release -p ruster-bench -- \
+  --suite datapath --format jsonl
+```
+
+現在のfoundation suiteはplain IPv4 forwardingとInternet checksumのone-pass /
+two-pass controlを測定します。NAT/firewall/state pressureは後続sliceです。
+
+`wire64`はbackend buffer 60 bytes、FCS込みEthernet 64 bytes、preamble/SFDとIFG込み
+84 bytesです。`ip-mtu1500`はそれぞれ1514、1518、1538 bytesです。結果のJSONLにも
+全ての値を別fieldで保存します。
+
+fixture生成、buffer reset、batch acquisition、結果検証、formattingはtimed region外です。
+timed region内でcurrent worker threadのallocationを一つでも検出したrunは失敗します。
+各packet bufferは測定直前のresetでCPU cacheへ触れるため、これはcoreのhot-cache
+microbenchmarkであり、NIC/backend DMAやcold-cache throughputの主張ではありません。
+
+比較するrunでは同じRust toolchain、target、`RUSTFLAGS`、CPU、governor、pinning、
+suite引数を使用し、実行commandとJSONLを一緒に保存してください。host固有の値を
+異なるmachine間でbaselineとして比較する用途は想定していません。

--- a/crates/bench/README.md
+++ b/crates/bench/README.md
@@ -25,6 +25,8 @@ threadのallocationを一つでも検出したrunは失敗します。
 plain forwardingは同じ反復数の`reset + receive` intervalを別に一度測り、全反復を一つの
 intervalで測った値から差し引きます。packetごとのclock読取りを入れず、batchごとの
 `forward_batch`/finish境界を維持します。
+短いcalibration probeでcontrolがmeasured intervalを上回った場合は反復数を増やします。
+正式sampleで同じ状態になった場合はzeroへ丸めず、両Durationを持つtyped errorで失敗します。
 各packet bufferは測定直前のresetでCPU cacheへ触れるため、これはcoreのhot-cache
 microbenchmarkであり、NIC/backend DMAやcold-cache throughputの主張ではありません。
 

--- a/crates/bench/src/allocation.rs
+++ b/crates/bench/src/allocation.rs
@@ -1,0 +1,63 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+
+struct CountingAllocator;
+
+thread_local! {
+    static ALLOCATION_COUNT: Cell<u64> = const { Cell::new(0) };
+}
+
+// SAFETY: every operation delegates unchanged pointers and layouts to the
+// standard system allocator. The counter is independent of allocation
+// ownership. A const thread-local Cell keeps concurrent test and runner
+// allocations from contaminating the measured worker.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: the caller supplies the GlobalAlloc layout contract.
+        let pointer = unsafe { System.alloc(layout) };
+        if !pointer.is_null() {
+            increment_count();
+        }
+        pointer
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: the caller supplies the GlobalAlloc layout contract.
+        let pointer = unsafe { System.alloc_zeroed(layout) };
+        if !pointer.is_null() {
+            increment_count();
+        }
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        // SAFETY: the caller guarantees that pointer and layout came from this
+        // allocator; this implementation delegates all allocations to System.
+        unsafe { System.dealloc(pointer, layout) };
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: the caller supplies the GlobalAlloc reallocation contract.
+        let new_pointer = unsafe { System.realloc(pointer, layout, new_size) };
+        if !new_pointer.is_null() {
+            increment_count();
+        }
+        new_pointer
+    }
+}
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: CountingAllocator = CountingAllocator;
+
+fn increment_count() {
+    ALLOCATION_COUNT.with(|count| count.set(count.get().saturating_add(1)));
+}
+
+/// Returns this thread's count of successful allocation or reallocation calls.
+///
+/// Benchmark timed regions run on the packet worker thread and compare
+/// snapshots, so unrelated test or process threads cannot contaminate a row.
+#[must_use]
+pub fn allocation_count() -> u64 {
+    ALLOCATION_COUNT.with(Cell::get)
+}

--- a/crates/bench/src/backend.rs
+++ b/crates/bench/src/backend.rs
@@ -1,0 +1,241 @@
+use std::convert::Infallible;
+
+use ruster_core::{
+    BatchCompletion, ConsumeReason, DropReason, IfId, PacketBatch, PacketIo, PacketLease,
+    PacketSlot, SlotCompletion,
+};
+
+/// Terminal state retained in a preallocated benchmark slot.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BenchCompletion {
+    Transmitted(IfId),
+    Recycled(DropReason),
+    Consumed(ConsumeReason),
+    LeaseAbandoned,
+}
+
+#[derive(Debug)]
+struct BenchSlot {
+    ingress: IfId,
+    bytes: Box<[u8]>,
+    completion: Option<BenchCompletion>,
+}
+
+/// A NIC-free packet backend whose buffers and slot metadata are allocated
+/// before measurement.
+///
+/// Unlike the simulation backend this backend does not capture or move packet
+/// buffers at completion. Core borrows each backend-owned buffer, and
+/// completion only updates fixed slot metadata.
+#[derive(Debug)]
+pub struct BenchBackend {
+    slots: Vec<BenchSlot>,
+}
+
+impl BenchBackend {
+    /// Allocates `slot_count` backend-owned buffers initialized from
+    /// `template`. This is cold setup and must not run in a timed region.
+    #[must_use]
+    pub fn new(slot_count: usize, ingress: IfId, template: &[u8]) -> Self {
+        let slots = (0..slot_count)
+            .map(|_| BenchSlot {
+                ingress,
+                bytes: template.to_vec().into_boxed_slice(),
+                completion: None,
+            })
+            .collect();
+        Self { slots }
+    }
+
+    #[must_use]
+    pub fn slot_count(&self) -> usize {
+        self.slots.len()
+    }
+
+    /// Restores packet bytes and clears terminal metadata outside measurement.
+    ///
+    /// The length must match the buffers chosen during construction.
+    pub fn reset(&mut self, template: &[u8]) {
+        for slot in &mut self.slots {
+            assert_eq!(
+                slot.bytes.len(),
+                template.len(),
+                "benchmark reset template length changed"
+            );
+            slot.bytes.copy_from_slice(template);
+            slot.completion = None;
+        }
+    }
+
+    #[must_use]
+    pub fn bytes(&self, index: usize) -> Option<&[u8]> {
+        self.slots.get(index).map(|slot| slot.bytes.as_ref())
+    }
+
+    #[must_use]
+    pub fn completion(&self, index: usize) -> Option<BenchCompletion> {
+        self.slots.get(index).and_then(|slot| slot.completion)
+    }
+}
+
+#[derive(Debug, Default)]
+struct BenchCounters {
+    tx_requested: usize,
+    tx_accepted: usize,
+    recycled: usize,
+}
+
+pub struct BenchBatch<'a> {
+    slots: &'a mut [BenchSlot],
+    next: usize,
+    counters: BenchCounters,
+}
+
+impl PacketIo for BenchBackend {
+    type Error = Infallible;
+    type Batch<'a> = BenchBatch<'a>;
+
+    fn receive(&mut self, budget: usize) -> Result<Self::Batch<'_>, Self::Error> {
+        let count = budget.min(self.slots.len());
+        Ok(BenchBatch {
+            slots: &mut self.slots[..count],
+            next: 0,
+            counters: BenchCounters::default(),
+        })
+    }
+}
+
+impl PacketBatch for BenchBatch<'_> {
+    type Error = Infallible;
+    type Slot<'a>
+        = BenchPacketSlot<'a>
+    where
+        Self: 'a;
+
+    fn next_packet(&mut self) -> Option<PacketLease<Self::Slot<'_>>> {
+        let slot = self.slots.get_mut(self.next)?;
+        self.next += 1;
+        Some(PacketLease::new(BenchPacketSlot {
+            slot,
+            counters: &mut self.counters,
+        }))
+    }
+
+    fn finish(self) -> BatchCompletion<Self::Error> {
+        BatchCompletion {
+            tx_requested: self.counters.tx_requested,
+            tx_accepted: self.counters.tx_accepted,
+            tx_rejected: 0,
+            recycled: self.counters.recycled,
+            error: None,
+        }
+    }
+}
+
+pub struct BenchPacketSlot<'a> {
+    slot: &'a mut BenchSlot,
+    counters: &'a mut BenchCounters,
+}
+
+impl PacketSlot for BenchPacketSlot<'_> {
+    fn ingress(&self) -> IfId {
+        self.slot.ingress
+    }
+
+    fn bytes_mut(&mut self) -> &mut [u8] {
+        self.slot.bytes.as_mut()
+    }
+
+    fn complete(self, completion: SlotCompletion) {
+        assert!(
+            self.slot.completion.is_none(),
+            "benchmark slot completed more than once"
+        );
+        self.slot.completion = Some(match completion {
+            SlotCompletion::Transmit(egress) => {
+                self.counters.tx_requested += 1;
+                self.counters.tx_accepted += 1;
+                BenchCompletion::Transmitted(egress)
+            }
+            SlotCompletion::Recycle(reason) => {
+                self.counters.recycled += 1;
+                BenchCompletion::Recycled(reason)
+            }
+            SlotCompletion::Consume(reason) => {
+                self.counters.recycled += 1;
+                BenchCompletion::Consumed(reason)
+            }
+            SlotCompletion::LeaseAbandoned => {
+                self.counters.recycled += 1;
+                BenchCompletion::LeaseAbandoned
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ruster_core::{DropReason, PacketBatch, PacketIo};
+
+    use super::*;
+
+    #[test]
+    fn budget_and_exactly_once_terminal_states_are_accounted() {
+        let mut backend = BenchBackend::new(3, IfId(1), &[0; 64]);
+        let mut batch = backend.receive(2).unwrap();
+        batch.next_packet().unwrap().commit(IfId(2));
+        batch.next_packet().unwrap().recycle(DropReason::RouteMiss);
+        assert!(batch.next_packet().is_none());
+        assert_eq!(
+            batch.finish(),
+            BatchCompletion {
+                tx_requested: 1,
+                tx_accepted: 1,
+                tx_rejected: 0,
+                recycled: 1,
+                error: None,
+            }
+        );
+        assert_eq!(
+            backend.completion(0),
+            Some(BenchCompletion::Transmitted(IfId(2)))
+        );
+        assert_eq!(
+            backend.completion(1),
+            Some(BenchCompletion::Recycled(DropReason::RouteMiss))
+        );
+        assert_eq!(backend.completion(2), None);
+    }
+
+    #[test]
+    fn abandoned_lease_is_recycled_and_reset_restores_storage() {
+        let template = [7_u8; 60];
+        let mut backend = BenchBackend::new(1, IfId(1), &template);
+        let mut batch = backend.receive(1).unwrap();
+        {
+            let mut packet = batch.next_packet().unwrap();
+            packet.bytes_mut()[0] = 9;
+        }
+        assert_eq!(batch.finish().recycled, 1);
+        assert_eq!(backend.completion(0), Some(BenchCompletion::LeaseAbandoned));
+        assert_eq!(backend.bytes(0).unwrap()[0], 9);
+        backend.reset(&template);
+        assert_eq!(backend.completion(0), None);
+        assert_eq!(backend.bytes(0), Some(template.as_slice()));
+    }
+
+    #[test]
+    fn consumed_slot_is_a_typed_recycled_completion() {
+        let mut backend = BenchBackend::new(1, IfId(1), &[0; 60]);
+        let mut batch = backend.receive(1).unwrap();
+        batch
+            .next_packet()
+            .unwrap()
+            .consume(ConsumeReason::ArpControl);
+        assert_eq!(batch.finish().recycled, 1);
+        assert_eq!(
+            backend.completion(0),
+            Some(BenchCompletion::Consumed(ConsumeReason::ArpControl))
+        );
+    }
+}

--- a/crates/bench/src/fixture.rs
+++ b/crates/bench/src/fixture.rs
@@ -1,0 +1,138 @@
+use ruster_core::{ipv4_header_checksum, ETHERNET_HEADER_LEN};
+
+const ETHERNET_FCS_BYTES: usize = 4;
+const ETHERNET_PREAMBLE_SFD_BYTES: usize = 8;
+const ETHERNET_INTER_PACKET_GAP_BYTES: usize = 12;
+
+/// Explicit packet-size conventions used by benchmark rows.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FrameSize {
+    /// Minimum Ethernet frame: 60 bytes in the backend buffer and 64 bytes
+    /// from destination MAC through FCS on the wire.
+    Wire64,
+    /// IPv4 MTU 1500: 1514 bytes in the backend buffer and 1518 bytes through
+    /// FCS on the wire.
+    Ipv4Mtu1500,
+}
+
+impl FrameSize {
+    pub const ALL: [Self; 2] = [Self::Wire64, Self::Ipv4Mtu1500];
+
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Wire64 => "wire64",
+            Self::Ipv4Mtu1500 => "ip-mtu1500",
+        }
+    }
+
+    #[must_use]
+    pub const fn backend_bytes(self) -> usize {
+        match self {
+            Self::Wire64 => 60,
+            Self::Ipv4Mtu1500 => 1_514,
+        }
+    }
+
+    #[must_use]
+    pub const fn ethernet_bytes_including_fcs(self) -> usize {
+        self.backend_bytes() + ETHERNET_FCS_BYTES
+    }
+
+    #[must_use]
+    pub const fn wire_bytes_with_preamble_ifg(self) -> usize {
+        self.ethernet_bytes_including_fcs()
+            + ETHERNET_PREAMBLE_SFD_BYTES
+            + ETHERNET_INTER_PACKET_GAP_BYTES
+    }
+
+    #[must_use]
+    pub const fn ipv4_total_bytes(self) -> usize {
+        self.backend_bytes() - ETHERNET_HEADER_LEN
+    }
+}
+
+/// Creates one deterministic, valid Ethernet/IPv4/UDP forwarding fixture.
+///
+/// UDP checksum zero is legal and keeps this foundation case focused on the
+/// plain IPv4 forwarding path. Later profile-specific benchmark slices own
+/// transport checksum fixtures.
+#[must_use]
+pub fn plain_ipv4_fixture(size: FrameSize, seed: u64) -> Vec<u8> {
+    let mut frame = vec![0_u8; size.backend_bytes()];
+    frame[0..6].copy_from_slice(&[0x02, 0, 0, 0, 0, 1]);
+    frame[6..12].copy_from_slice(&[0x02, 0, 0, 0, 0, 0x10]);
+    frame[12..14].copy_from_slice(&0x0800_u16.to_be_bytes());
+
+    let ip = ETHERNET_HEADER_LEN;
+    frame[ip] = 0x45;
+    frame[ip + 1] = 0;
+    frame[ip + 2..ip + 4].copy_from_slice(
+        &u16::try_from(size.ipv4_total_bytes())
+            .unwrap()
+            .to_be_bytes(),
+    );
+    frame[ip + 4..ip + 6].copy_from_slice(&0x1234_u16.to_be_bytes());
+    frame[ip + 6..ip + 8].copy_from_slice(&0x4000_u16.to_be_bytes());
+    frame[ip + 8] = 64;
+    frame[ip + 9] = 17;
+    frame[ip + 12..ip + 16].copy_from_slice(&[192, 0, 2, 10]);
+    frame[ip + 16..ip + 20].copy_from_slice(&[198, 51, 100, 10]);
+
+    let udp = ip + 20;
+    frame[udp..udp + 2].copy_from_slice(&12_345_u16.to_be_bytes());
+    frame[udp + 2..udp + 4].copy_from_slice(&443_u16.to_be_bytes());
+    frame[udp + 4..udp + 6].copy_from_slice(
+        &u16::try_from(size.ipv4_total_bytes() - 20)
+            .unwrap()
+            .to_be_bytes(),
+    );
+    frame[udp + 6..udp + 8].copy_from_slice(&0_u16.to_be_bytes());
+
+    let mut state = seed.max(1);
+    for byte in &mut frame[udp + 8..] {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        *byte = state as u8;
+    }
+
+    let checksum = ipv4_header_checksum(&frame[ip..ip + 20]);
+    frame[ip + 10..ip + 12].copy_from_slice(&checksum.to_be_bytes());
+    frame
+}
+
+#[cfg(test)]
+mod tests {
+    use ruster_core::validate_ipv4_frame;
+
+    use super::*;
+
+    #[test]
+    fn size_labels_state_backend_and_wire_conventions_exactly() {
+        assert_eq!(FrameSize::Wire64.backend_bytes(), 60);
+        assert_eq!(FrameSize::Wire64.ethernet_bytes_including_fcs(), 64);
+        assert_eq!(FrameSize::Wire64.wire_bytes_with_preamble_ifg(), 84);
+        assert_eq!(FrameSize::Wire64.ipv4_total_bytes(), 46);
+
+        assert_eq!(FrameSize::Ipv4Mtu1500.backend_bytes(), 1_514);
+        assert_eq!(FrameSize::Ipv4Mtu1500.ethernet_bytes_including_fcs(), 1_518);
+        assert_eq!(FrameSize::Ipv4Mtu1500.wire_bytes_with_preamble_ifg(), 1_538);
+        assert_eq!(FrameSize::Ipv4Mtu1500.ipv4_total_bytes(), 1_500);
+    }
+
+    #[test]
+    fn fixtures_are_valid_and_seed_deterministic() {
+        for size in FrameSize::ALL {
+            let first = plain_ipv4_fixture(size, 7);
+            let same = plain_ipv4_fixture(size, 7);
+            let other = plain_ipv4_fixture(size, 8);
+            assert_eq!(first, same);
+            assert_ne!(first, other);
+            let ipv4 = validate_ipv4_frame(&first).unwrap();
+            assert_eq!(ipv4.total_len, size.ipv4_total_bytes());
+            assert_eq!(ipv4.ttl, 64);
+            assert_eq!(first.len(), size.backend_bytes());
+        }
+    }
+}

--- a/crates/bench/src/lib.rs
+++ b/crates/bench/src/lib.rs
@@ -1,0 +1,15 @@
+#![doc = "Dependency-free, NIC-free benchmark support for `ruster-core`."]
+
+mod allocation;
+mod backend;
+mod fixture;
+mod output;
+mod runner;
+mod stats;
+
+pub use allocation::allocation_count;
+pub use backend::{BenchBackend, BenchCompletion};
+pub use fixture::{plain_ipv4_fixture, FrameSize};
+pub use output::{OutputFormat, ResultRow};
+pub use runner::{run, RunConfig, RunError, Suite};
+pub use stats::SampleStats;

--- a/crates/bench/src/main.rs
+++ b/crates/bench/src/main.rs
@@ -1,0 +1,189 @@
+use std::env;
+use std::process::ExitCode;
+use std::time::Duration;
+
+use ruster_bench::{run, OutputFormat, ResultRow, RunConfig, Suite};
+
+fn main() -> ExitCode {
+    match execute() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("ruster-bench: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn execute() -> Result<(), String> {
+    let Some((config, format)) = parse_args(env::args().skip(1))? else {
+        return Ok(());
+    };
+    let rows = run(&config).map_err(|error| error.to_string())?;
+    if matches!(format, OutputFormat::Human | OutputFormat::Both) {
+        println!(
+            "# ruster-bench schema=1 suite={} seed={} samples={} sample_ms={} warmup_ms={}",
+            suite_name(config.suite),
+            config.seed,
+            config.samples,
+            config.sample_time.as_millis(),
+            config.warmup_time.as_millis(),
+        );
+        println!("{}", ResultRow::human_header());
+        for row in &rows {
+            println!("{}", row.to_human_line());
+        }
+    }
+    if matches!(format, OutputFormat::JsonLines | OutputFormat::Both) {
+        for row in &rows {
+            println!("{}", row.to_json_line());
+        }
+    }
+    Ok(())
+}
+
+fn parse_args(
+    mut args: impl Iterator<Item = String>,
+) -> Result<Option<(RunConfig, OutputFormat)>, String> {
+    let mut suite = Suite::Smoke;
+    let mut format = OutputFormat::Human;
+    let mut seed = None;
+    let mut samples = None;
+    let mut sample_time = None;
+    let mut warmup_time = None;
+    let mut batches = None;
+    while let Some(argument) = args.next() {
+        match argument.as_str() {
+            "--suite" => {
+                let value = next_value(&mut args, "--suite")?;
+                suite = match value.as_str() {
+                    "smoke" => Suite::Smoke,
+                    "datapath" => Suite::Datapath,
+                    _ => return Err(format!("unknown suite {value:?}")),
+                };
+            }
+            "--format" => {
+                let value = next_value(&mut args, "--format")?;
+                format = match value.as_str() {
+                    "human" => OutputFormat::Human,
+                    "jsonl" => OutputFormat::JsonLines,
+                    "both" => OutputFormat::Both,
+                    _ => return Err(format!("unknown output format {value:?}")),
+                };
+            }
+            "--seed" => {
+                seed = Some(parse_value(next_value(&mut args, "--seed")?, "--seed")?);
+            }
+            "--samples" => {
+                samples = Some(parse_value(
+                    next_value(&mut args, "--samples")?,
+                    "--samples",
+                )?);
+            }
+            "--sample-ms" => {
+                let millis = parse_value(next_value(&mut args, "--sample-ms")?, "--sample-ms")?;
+                sample_time = Some(Duration::from_millis(millis));
+            }
+            "--warmup-ms" => {
+                let millis = parse_value(next_value(&mut args, "--warmup-ms")?, "--warmup-ms")?;
+                warmup_time = Some(Duration::from_millis(millis));
+            }
+            "--batches" => {
+                let value = next_value(&mut args, "--batches")?;
+                batches = Some(
+                    value
+                        .split(',')
+                        .map(|part| parse_value(part.to_owned(), "--batches"))
+                        .collect::<Result<Vec<_>, _>>()?,
+                );
+            }
+            "--help" | "-h" => {
+                print_help();
+                return Ok(None);
+            }
+            _ => return Err(format!("unknown argument {argument:?}; try --help")),
+        }
+    }
+    let mut config = match suite {
+        Suite::Smoke => RunConfig::smoke(),
+        Suite::Datapath => RunConfig::datapath(),
+    };
+    config.seed = seed.unwrap_or(config.seed);
+    config.samples = samples.unwrap_or(config.samples);
+    config.sample_time = sample_time.unwrap_or(config.sample_time);
+    config.warmup_time = warmup_time.unwrap_or(config.warmup_time);
+    config.batches = batches.unwrap_or(config.batches);
+    Ok(Some((config, format)))
+}
+
+fn next_value(args: &mut impl Iterator<Item = String>, option: &str) -> Result<String, String> {
+    args.next()
+        .ok_or_else(|| format!("{option} requires a value"))
+}
+
+fn parse_value<T: std::str::FromStr>(value: String, option: &str) -> Result<T, String> {
+    value
+        .parse()
+        .map_err(|_| format!("{option} has invalid value {value:?}"))
+}
+
+fn suite_name(suite: Suite) -> &'static str {
+    match suite {
+        Suite::Smoke => "smoke",
+        Suite::Datapath => "datapath",
+    }
+}
+
+fn print_help() {
+    println!(
+        "\
+NIC-free ruster-core benchmark foundation
+
+Usage: ruster-bench [OPTIONS]
+  --suite smoke|datapath
+  --format human|jsonl|both
+  --seed U64
+  --samples N
+  --sample-ms N
+  --warmup-ms N
+  --batches N[,N...]
+
+Timed regions exclude fixture reset and batch acquisition. Any successful
+allocation observed inside a timed region fails the run."
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn later_cli_values_override_suite_defaults_deterministically() {
+        let arguments = [
+            "--suite",
+            "datapath",
+            "--samples",
+            "3",
+            "--batches",
+            "1,64",
+            "--format",
+            "jsonl",
+        ]
+        .into_iter()
+        .map(str::to_owned);
+        let (config, format) = parse_args(arguments).unwrap().unwrap();
+        assert_eq!(config.suite, Suite::Datapath);
+        assert_eq!(config.samples, 3);
+        assert_eq!(config.batches, [1, 64]);
+        assert_eq!(format, OutputFormat::JsonLines);
+    }
+
+    #[test]
+    fn option_order_does_not_change_suite_overrides() {
+        let arguments = ["--samples", "3", "--suite", "datapath"]
+            .into_iter()
+            .map(str::to_owned);
+        let (config, _) = parse_args(arguments).unwrap().unwrap();
+        assert_eq!(config.suite, Suite::Datapath);
+        assert_eq!(config.samples, 3);
+    }
+}

--- a/crates/bench/src/output.rs
+++ b/crates/bench/src/output.rs
@@ -1,0 +1,123 @@
+use crate::{FrameSize, SampleStats};
+
+pub const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OutputFormat {
+    Human,
+    JsonLines,
+    Both,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ResultRow {
+    pub case: &'static str,
+    pub size: FrameSize,
+    pub batch: usize,
+    pub checksum_passes: u8,
+    pub seed: u64,
+    pub repetitions_per_sample: usize,
+    pub timed_allocations: u64,
+    pub stats: SampleStats,
+    pub digest: u16,
+}
+
+impl ResultRow {
+    #[must_use]
+    pub fn human_header() -> &'static str {
+        "case                 size         batch passes  p50 ns/op  p95 ns/op   Mops/s allocs"
+    }
+
+    #[must_use]
+    pub fn to_human_line(&self) -> String {
+        format!(
+            "{:<20} {:<12} {:>5} {:>6} {:>10.2} {:>10.2} {:>8.3} {:>6}",
+            self.case,
+            self.size.label(),
+            self.batch,
+            self.checksum_passes,
+            self.stats.p50_ns,
+            self.stats.p95_ns,
+            self.stats.million_per_second(),
+            self.timed_allocations,
+        )
+    }
+
+    #[must_use]
+    pub fn to_json_line(&self) -> String {
+        format!(
+            concat!(
+                "{{\"schema_version\":{},\"kind\":\"measurement\",",
+                "\"case\":\"{}\",\"size\":\"{}\",",
+                "\"backend_bytes\":{},\"ethernet_bytes_including_fcs\":{},",
+                "\"wire_bytes_with_preamble_ifg\":{},\"ipv4_total_bytes\":{},",
+                "\"batch\":{},\"checksum_passes\":{},\"seed\":{},",
+                "\"samples\":{},\"repetitions_per_sample\":{},",
+                "\"min_ns_per_op\":{:.6},\"p50_ns_per_op\":{:.6},",
+                "\"p95_ns_per_op\":{:.6},\"mad_ns_per_op\":{:.6},",
+                "\"million_ops_per_second\":{:.6},",
+                "\"timed_allocations\":{},\"digest\":{}}}"
+            ),
+            SCHEMA_VERSION,
+            self.case,
+            self.size.label(),
+            self.size.backend_bytes(),
+            self.size.ethernet_bytes_including_fcs(),
+            self.size.wire_bytes_with_preamble_ifg(),
+            self.size.ipv4_total_bytes(),
+            self.batch,
+            self.checksum_passes,
+            self.seed,
+            self.stats.samples,
+            self.repetitions_per_sample,
+            self.stats.min_ns,
+            self.stats.p50_ns,
+            self.stats.p95_ns,
+            self.stats.mad_ns,
+            self.stats.million_per_second(),
+            self.timed_allocations,
+            self.digest,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_line_has_stable_schema_and_unambiguous_wire_metadata() {
+        let row = ResultRow {
+            case: "plain-ipv4",
+            size: FrameSize::Wire64,
+            batch: 32,
+            checksum_passes: 0,
+            seed: 7,
+            repetitions_per_sample: 10,
+            timed_allocations: 0,
+            stats: SampleStats {
+                samples: 3,
+                min_ns: 1.0,
+                p50_ns: 2.0,
+                p95_ns: 3.0,
+                mad_ns: 1.0,
+            },
+            digest: 42,
+        };
+        assert_eq!(
+            row.to_json_line(),
+            concat!(
+                "{\"schema_version\":1,\"kind\":\"measurement\",",
+                "\"case\":\"plain-ipv4\",\"size\":\"wire64\",",
+                "\"backend_bytes\":60,\"ethernet_bytes_including_fcs\":64,",
+                "\"wire_bytes_with_preamble_ifg\":84,\"ipv4_total_bytes\":46,",
+                "\"batch\":32,\"checksum_passes\":0,\"seed\":7,",
+                "\"samples\":3,\"repetitions_per_sample\":10,",
+                "\"min_ns_per_op\":1.000000,\"p50_ns_per_op\":2.000000,",
+                "\"p95_ns_per_op\":3.000000,\"mad_ns_per_op\":1.000000,",
+                "\"million_ops_per_second\":500.000000,",
+                "\"timed_allocations\":0,\"digest\":42}"
+            )
+        );
+    }
+}

--- a/crates/bench/src/output.rs
+++ b/crates/bench/src/output.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use crate::{FrameSize, SampleStats};
 
 pub const SCHEMA_VERSION: u32 = 1;
@@ -45,6 +47,8 @@ impl ResultRow {
 
     #[must_use]
     pub fn to_json_line(&self) -> String {
+        let case = escape_json(self.case);
+        let size = escape_json(self.size.label());
         format!(
             concat!(
                 "{{\"schema_version\":{},\"kind\":\"measurement\",",
@@ -59,8 +63,8 @@ impl ResultRow {
                 "\"timed_allocations\":{},\"digest\":{}}}"
             ),
             SCHEMA_VERSION,
-            self.case,
-            self.size.label(),
+            case,
+            size,
             self.size.backend_bytes(),
             self.size.ethernet_bytes_including_fcs(),
             self.size.wire_bytes_with_preamble_ifg(),
@@ -79,6 +83,27 @@ impl ResultRow {
             self.digest,
         )
     }
+}
+
+fn escape_json(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        match character {
+            '"' => escaped.push_str("\\\""),
+            '\\' => escaped.push_str("\\\\"),
+            '\u{0008}' => escaped.push_str("\\b"),
+            '\u{000c}' => escaped.push_str("\\f"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            '\u{0000}'..='\u{001f}' => {
+                write!(escaped, "\\u{:04x}", u32::from(character))
+                    .expect("writing to String cannot fail");
+            }
+            _ => escaped.push(character),
+        }
+    }
+    escaped
 }
 
 #[cfg(test)]
@@ -119,5 +144,30 @@ mod tests {
                 "\"timed_allocations\":0,\"digest\":42}"
             )
         );
+    }
+
+    #[test]
+    fn json_line_escapes_hostile_public_string_values() {
+        let row = ResultRow {
+            case: "quote\" slash\\ controls\n\r\t\u{0008}\u{000c}\u{0001}",
+            size: FrameSize::Wire64,
+            batch: 1,
+            checksum_passes: 0,
+            seed: 1,
+            repetitions_per_sample: 1,
+            timed_allocations: 0,
+            stats: SampleStats {
+                samples: 1,
+                min_ns: 1.0,
+                p50_ns: 1.0,
+                p95_ns: 1.0,
+                mad_ns: 0.0,
+            },
+            digest: 0,
+        };
+        let json = row.to_json_line();
+        assert!(json.contains("\"case\":\"quote\\\" slash\\\\ controls\\n\\r\\t\\b\\f\\u0001\""));
+        assert!(!json.contains('\u{0001}'));
+        assert_eq!(escape_json("雪"), "雪");
     }
 }

--- a/crates/bench/src/runner.rs
+++ b/crates/bench/src/runner.rs
@@ -1,0 +1,439 @@
+use std::fmt;
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use ruster_core::{
+    forward_batch, internet_checksum, validate_ipv4_frame, ForwardingSnapshot, IfId, Interface,
+    Ipv4Address, LocalIpv4Binding, MacAddress, Neighbor, NoTrace, PacketIo, Route,
+};
+
+use crate::{
+    allocation_count, plain_ipv4_fixture, BenchBackend, BenchCompletion, FrameSize, ResultRow,
+    SampleStats,
+};
+
+const LAN: IfId = IfId(1);
+const WAN: IfId = IfId(2);
+const WAN_MAC: MacAddress = MacAddress([0x02, 0, 0, 0, 0, 2]);
+const GATEWAY_MAC: MacAddress = MacAddress([0x02, 0, 0, 0, 0, 3]);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Suite {
+    Smoke,
+    Datapath,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RunConfig {
+    pub suite: Suite,
+    pub seed: u64,
+    pub samples: usize,
+    pub sample_time: Duration,
+    pub warmup_time: Duration,
+    pub batches: Vec<usize>,
+}
+
+impl RunConfig {
+    #[must_use]
+    pub fn smoke() -> Self {
+        Self {
+            suite: Suite::Smoke,
+            seed: 0x5eed_0200_0000_0001,
+            samples: 5,
+            sample_time: Duration::from_millis(5),
+            warmup_time: Duration::from_millis(20),
+            batches: vec![1, 32],
+        }
+    }
+
+    #[must_use]
+    pub fn datapath() -> Self {
+        Self {
+            suite: Suite::Datapath,
+            seed: 0x5eed_0200_0000_0001,
+            samples: 31,
+            sample_time: Duration::from_millis(100),
+            warmup_time: Duration::from_millis(250),
+            batches: vec![1, 8, 32, 64, 256],
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RunError {
+    NoSamples,
+    ZeroSampleTime,
+    ZeroBatch,
+    RepetitionOverflow,
+    TimedAllocations { case: &'static str, count: u64 },
+    UnexpectedBatchReport,
+    ForwardingOracle,
+    InvalidStatistics,
+}
+
+impl fmt::Display for RunError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoSamples => formatter.write_str("sample count must be nonzero"),
+            Self::ZeroSampleTime => formatter.write_str("sample time must be nonzero"),
+            Self::ZeroBatch => formatter.write_str("batch sizes must be nonzero"),
+            Self::RepetitionOverflow => formatter.write_str("adaptive repetition count overflowed"),
+            Self::TimedAllocations { case, count } => {
+                write!(formatter, "{case} allocated {count} times in timed regions")
+            }
+            Self::UnexpectedBatchReport => {
+                formatter.write_str("plain forwarding returned an unexpected batch report")
+            }
+            Self::ForwardingOracle => {
+                formatter.write_str("plain forwarding output failed its untimed oracle")
+            }
+            Self::InvalidStatistics => formatter.write_str("sample statistics were invalid"),
+        }
+    }
+}
+
+impl std::error::Error for RunError {}
+
+#[derive(Clone, Copy)]
+struct Measurement {
+    elapsed: Duration,
+    allocations: u64,
+    digest: u16,
+}
+
+/// Executes the selected NIC-free cases and returns structured result rows.
+///
+/// Formatting and artifact I/O are deliberately outside this function.
+pub fn run(config: &RunConfig) -> Result<Vec<ResultRow>, RunError> {
+    validate_config(config)?;
+    let mut rows =
+        Vec::with_capacity(FrameSize::ALL.len() * (config.batches.len() + usize::from(2_u8)));
+    for size in FrameSize::ALL {
+        for &batch in &config.batches {
+            rows.push(run_plain_case(config, size, batch)?);
+        }
+        rows.push(run_checksum_case(config, size, 1)?);
+        rows.push(run_checksum_case(config, size, 2)?);
+    }
+    Ok(rows)
+}
+
+fn validate_config(config: &RunConfig) -> Result<(), RunError> {
+    if config.samples == 0 {
+        return Err(RunError::NoSamples);
+    }
+    if config.sample_time.is_zero() {
+        return Err(RunError::ZeroSampleTime);
+    }
+    if config.batches.contains(&0) {
+        return Err(RunError::ZeroBatch);
+    }
+    Ok(())
+}
+
+fn run_plain_case(
+    config: &RunConfig,
+    size: FrameSize,
+    batch_size: usize,
+) -> Result<ResultRow, RunError> {
+    let template = plain_ipv4_fixture(size, config.seed);
+    let mut backend = BenchBackend::new(batch_size, LAN, &template);
+    let routes = [Route::new(
+        Ipv4Address::from_octets([0, 0, 0, 0]),
+        0,
+        WAN,
+        Some(Ipv4Address::from_octets([203, 0, 113, 1])),
+    )
+    .expect("benchmark route is valid")];
+    let interfaces = [
+        Interface {
+            id: LAN,
+            mac: MacAddress([0x02, 0, 0, 0, 0, 1]),
+        },
+        Interface {
+            id: WAN,
+            mac: WAN_MAC,
+        },
+    ];
+    let neighbors = [Neighbor {
+        interface: WAN,
+        target: Ipv4Address::from_octets([203, 0, 113, 1]),
+        mac: GATEWAY_MAC,
+    }];
+    let bindings = [LocalIpv4Binding {
+        interface: LAN,
+        address: Ipv4Address::from_octets([192, 0, 2, 1]),
+    }];
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &bindings)
+        .expect("benchmark snapshot is valid");
+
+    warm_plain(
+        &mut backend,
+        &template,
+        &snapshot,
+        batch_size,
+        config.warmup_time,
+    )?;
+    let repetitions = calibrate_plain(
+        &mut backend,
+        &template,
+        &snapshot,
+        batch_size,
+        config.sample_time,
+    )?;
+    let mut normalized = Vec::with_capacity(config.samples);
+    let mut allocations = 0;
+    let mut digest = 0;
+    for _ in 0..config.samples {
+        let measurement =
+            measure_plain(&mut backend, &template, &snapshot, batch_size, repetitions)?;
+        allocations += measurement.allocations;
+        digest = measurement.digest;
+        let packets = repetitions
+            .checked_mul(batch_size)
+            .ok_or(RunError::RepetitionOverflow)?;
+        normalized.push(measurement.elapsed.as_nanos() as f64 / packets as f64);
+    }
+    if allocations != 0 {
+        return Err(RunError::TimedAllocations {
+            case: "plain-ipv4",
+            count: allocations,
+        });
+    }
+    verify_forwarded(&backend, &template, batch_size)?;
+    Ok(ResultRow {
+        case: "plain-ipv4",
+        size,
+        batch: batch_size,
+        checksum_passes: 0,
+        seed: config.seed,
+        repetitions_per_sample: repetitions,
+        timed_allocations: allocations,
+        stats: SampleStats::from_samples(&normalized).ok_or(RunError::InvalidStatistics)?,
+        digest,
+    })
+}
+
+fn warm_plain(
+    backend: &mut BenchBackend,
+    template: &[u8],
+    snapshot: &ForwardingSnapshot<'_>,
+    batch_size: usize,
+    warmup_time: Duration,
+) -> Result<(), RunError> {
+    let started = Instant::now();
+    while started.elapsed() < warmup_time {
+        let measurement = measure_plain(backend, template, snapshot, batch_size, 1)?;
+        ensure_no_allocations("plain-ipv4", measurement.allocations)?;
+        black_box(measurement);
+    }
+    Ok(())
+}
+
+fn calibrate_plain(
+    backend: &mut BenchBackend,
+    template: &[u8],
+    snapshot: &ForwardingSnapshot<'_>,
+    batch_size: usize,
+    target: Duration,
+) -> Result<usize, RunError> {
+    let mut repetitions = 1_usize;
+    loop {
+        let measurement = measure_plain(backend, template, snapshot, batch_size, repetitions)?;
+        ensure_no_allocations("plain-ipv4", measurement.allocations)?;
+        if measurement.elapsed >= target {
+            return Ok(repetitions);
+        }
+        repetitions = repetitions
+            .checked_mul(2)
+            .ok_or(RunError::RepetitionOverflow)?;
+    }
+}
+
+fn measure_plain(
+    backend: &mut BenchBackend,
+    template: &[u8],
+    snapshot: &ForwardingSnapshot<'_>,
+    batch_size: usize,
+    repetitions: usize,
+) -> Result<Measurement, RunError> {
+    let mut elapsed = Duration::ZERO;
+    let mut allocations = 0_u64;
+    let mut digest = 0_u16;
+    let mut trace = NoTrace;
+    for _ in 0..repetitions {
+        backend.reset(template);
+        let batch = backend.receive(batch_size).expect("infallible backend");
+        let before_allocations = allocation_count();
+        let started = Instant::now();
+        let report = forward_batch(batch, snapshot, &mut trace);
+        elapsed += started.elapsed();
+        allocations += allocation_count() - before_allocations;
+        if report.received != batch_size
+            || report.tx_requested != batch_size
+            || report.dropped != 0
+            || report.consumed != 0
+            || report.completion.tx_requested != batch_size
+            || report.completion.tx_accepted != batch_size
+            || report.completion.tx_rejected != 0
+            || report.completion.recycled != 0
+            || report.completion.error.is_some()
+        {
+            return Err(RunError::UnexpectedBatchReport);
+        }
+        digest = u16::try_from(black_box(report.tx_requested)).unwrap_or(u16::MAX);
+    }
+    Ok(Measurement {
+        elapsed,
+        allocations,
+        digest,
+    })
+}
+
+fn verify_forwarded(
+    backend: &BenchBackend,
+    template: &[u8],
+    batch_size: usize,
+) -> Result<(), RunError> {
+    for index in 0..batch_size {
+        if backend.completion(index) != Some(BenchCompletion::Transmitted(WAN)) {
+            return Err(RunError::ForwardingOracle);
+        }
+        let bytes = backend.bytes(index).ok_or(RunError::ForwardingOracle)?;
+        let ipv4 = validate_ipv4_frame(bytes).map_err(|_| RunError::ForwardingOracle)?;
+        if bytes[0..6] != GATEWAY_MAC.0
+            || bytes[6..12] != WAN_MAC.0
+            || ipv4.ttl != 63
+            || ipv4.source != Ipv4Address::from_octets([192, 0, 2, 10])
+            || ipv4.destination != Ipv4Address::from_octets([198, 51, 100, 10])
+            || bytes[34..] != template[34..]
+        {
+            return Err(RunError::ForwardingOracle);
+        }
+    }
+    Ok(())
+}
+
+fn run_checksum_case(
+    config: &RunConfig,
+    size: FrameSize,
+    passes: u8,
+) -> Result<ResultRow, RunError> {
+    let bytes = plain_ipv4_fixture(size, config.seed);
+    warm_checksum(&bytes, passes, config.warmup_time)?;
+    let repetitions = calibrate_checksum(&bytes, passes, config.sample_time)?;
+    let mut normalized = Vec::with_capacity(config.samples);
+    let mut allocations = 0;
+    let mut digest = 0;
+    for _ in 0..config.samples {
+        let measurement = measure_checksum(&bytes, passes, repetitions);
+        allocations += measurement.allocations;
+        digest = measurement.digest;
+        normalized.push(measurement.elapsed.as_nanos() as f64 / repetitions as f64);
+    }
+    let case = if passes == 1 {
+        "checksum-once"
+    } else {
+        "checksum-twice"
+    };
+    if allocations != 0 {
+        return Err(RunError::TimedAllocations {
+            case,
+            count: allocations,
+        });
+    }
+    Ok(ResultRow {
+        case,
+        size,
+        batch: 1,
+        checksum_passes: passes,
+        seed: config.seed,
+        repetitions_per_sample: repetitions,
+        timed_allocations: allocations,
+        stats: SampleStats::from_samples(&normalized).ok_or(RunError::InvalidStatistics)?,
+        digest,
+    })
+}
+
+fn warm_checksum(bytes: &[u8], passes: u8, warmup_time: Duration) -> Result<(), RunError> {
+    let started = Instant::now();
+    while started.elapsed() < warmup_time {
+        let measurement = measure_checksum(bytes, passes, 1);
+        ensure_no_allocations("checksum-control", measurement.allocations)?;
+        black_box(measurement);
+    }
+    Ok(())
+}
+
+fn calibrate_checksum(bytes: &[u8], passes: u8, target: Duration) -> Result<usize, RunError> {
+    let mut repetitions = 1_usize;
+    loop {
+        let measurement = measure_checksum(bytes, passes, repetitions);
+        ensure_no_allocations("checksum-control", measurement.allocations)?;
+        if measurement.elapsed >= target {
+            return Ok(repetitions);
+        }
+        repetitions = repetitions
+            .checked_mul(2)
+            .ok_or(RunError::RepetitionOverflow)?;
+    }
+}
+
+fn ensure_no_allocations(case: &'static str, count: u64) -> Result<(), RunError> {
+    if count == 0 {
+        Ok(())
+    } else {
+        Err(RunError::TimedAllocations { case, count })
+    }
+}
+
+fn measure_checksum(bytes: &[u8], passes: u8, repetitions: usize) -> Measurement {
+    let before_allocations = allocation_count();
+    let started = Instant::now();
+    let mut digest = 0_u16;
+    for _ in 0..repetitions {
+        for _ in 0..passes {
+            digest = black_box(internet_checksum(black_box(bytes)));
+        }
+    }
+    let elapsed = started.elapsed();
+    let allocations = allocation_count() - before_allocations;
+    Measurement {
+        elapsed,
+        allocations,
+        digest: black_box(digest),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_configs_are_rejected_before_setup() {
+        let mut config = RunConfig::smoke();
+        config.samples = 0;
+        assert_eq!(run(&config), Err(RunError::NoSamples));
+        config.samples = 1;
+        config.sample_time = Duration::ZERO;
+        assert_eq!(run(&config), Err(RunError::ZeroSampleTime));
+        config.sample_time = Duration::from_nanos(1);
+        config.batches = vec![0];
+        assert_eq!(run(&config), Err(RunError::ZeroBatch));
+    }
+
+    #[test]
+    fn one_plain_iteration_passes_the_untimed_wire_oracle() {
+        let mut config = RunConfig::smoke();
+        config.samples = 1;
+        config.sample_time = Duration::from_nanos(1);
+        config.warmup_time = Duration::ZERO;
+        config.batches = vec![1];
+        let rows = run(&config).unwrap();
+        assert_eq!(rows.len(), 6);
+        assert!(rows.iter().all(|row| row.timed_allocations == 0));
+        assert!(rows.iter().any(|row| {
+            row.case == "plain-ipv4" && row.size == FrameSize::Wire64 && row.stats.samples == 1
+        }));
+    }
+}

--- a/crates/bench/src/runner.rs
+++ b/crates/bench/src/runner.rs
@@ -16,6 +16,7 @@ const LAN: IfId = IfId(1);
 const WAN: IfId = IfId(2);
 const WAN_MAC: MacAddress = MacAddress([0x02, 0, 0, 0, 0, 2]);
 const GATEWAY_MAC: MacAddress = MacAddress([0x02, 0, 0, 0, 0, 3]);
+const MIN_AGGREGATE_REPETITIONS: usize = 64;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Suite {
@@ -65,6 +66,7 @@ pub enum RunError {
     ZeroSampleTime,
     ZeroBatch,
     RepetitionOverflow,
+    SetupControlExceededMeasured { setup: Duration, measured: Duration },
     TimedAllocations { case: &'static str, count: u64 },
     UnexpectedBatchReport,
     ForwardingOracle,
@@ -78,6 +80,10 @@ impl fmt::Display for RunError {
             Self::ZeroSampleTime => formatter.write_str("sample time must be nonzero"),
             Self::ZeroBatch => formatter.write_str("batch sizes must be nonzero"),
             Self::RepetitionOverflow => formatter.write_str("adaptive repetition count overflowed"),
+            Self::SetupControlExceededMeasured { setup, measured } => write!(
+                formatter,
+                "setup control ({setup:?}) exceeded measured interval ({measured:?})"
+            ),
             Self::TimedAllocations { case, count } => {
                 write!(formatter, "{case} allocated {count} times in timed regions")
             }
@@ -223,9 +229,24 @@ fn warm_plain(
 ) -> Result<(), RunError> {
     let started = Instant::now();
     while started.elapsed() < warmup_time {
-        let measurement = measure_plain(backend, template, snapshot, batch_size, 1)?;
-        ensure_no_allocations("plain-ipv4", measurement.allocations)?;
-        black_box(measurement);
+        match measure_plain(
+            backend,
+            template,
+            snapshot,
+            batch_size,
+            MIN_AGGREGATE_REPETITIONS,
+        ) {
+            Ok(measurement) => {
+                ensure_no_allocations("plain-ipv4", measurement.allocations)?;
+                black_box(measurement);
+            }
+            Err(RunError::SetupControlExceededMeasured { .. }) => {
+                // A discarded warmup probe can be shorter than scheduler and
+                // cache noise. Formal samples still propagate this typed
+                // error rather than substituting zero.
+            }
+            Err(error) => return Err(error),
+        }
     }
     Ok(())
 }
@@ -237,9 +258,19 @@ fn calibrate_plain(
     batch_size: usize,
     target: Duration,
 ) -> Result<usize, RunError> {
-    let mut repetitions = 1_usize;
+    let mut repetitions = MIN_AGGREGATE_REPETITIONS;
     loop {
-        let measurement = measure_plain(backend, template, snapshot, batch_size, repetitions)?;
+        let measurement = match measure_plain(backend, template, snapshot, batch_size, repetitions)
+        {
+            Ok(measurement) => measurement,
+            Err(RunError::SetupControlExceededMeasured { .. }) => {
+                repetitions = repetitions
+                    .checked_mul(2)
+                    .ok_or(RunError::RepetitionOverflow)?;
+                continue;
+            }
+            Err(error) => return Err(error),
+        };
         ensure_no_allocations("plain-ipv4", measurement.allocations)?;
         if measurement.elapsed >= target {
             return Ok(repetitions);
@@ -290,10 +321,16 @@ fn measure_plain(
         return Err(RunError::UnexpectedBatchReport);
     }
     Ok(Measurement {
-        elapsed: measured_elapsed.saturating_sub(setup_elapsed),
+        elapsed: subtract_setup_control(setup_elapsed, measured_elapsed)?,
         allocations,
         digest: u16::try_from(report.tx_requested).unwrap_or(u16::MAX),
     })
+}
+
+fn subtract_setup_control(setup: Duration, measured: Duration) -> Result<Duration, RunError> {
+    measured
+        .checked_sub(setup)
+        .ok_or(RunError::SetupControlExceededMeasured { setup, measured })
 }
 
 fn verify_forwarded(
@@ -432,7 +469,7 @@ mod tests {
     fn one_plain_iteration_passes_the_untimed_wire_oracle() {
         let mut config = RunConfig::smoke();
         config.samples = 1;
-        config.sample_time = Duration::from_nanos(1);
+        config.sample_time = Duration::from_micros(100);
         config.warmup_time = Duration::ZERO;
         config.batches = vec![1];
         let rows = run(&config).unwrap();
@@ -453,5 +490,20 @@ mod tests {
         assert_eq!(once.digest, 0x220d);
         assert_eq!(twice.digest, once.digest);
         assert_eq!(internet_checksum(&bytes), 0x220d);
+    }
+
+    #[test]
+    fn setup_control_subtraction_never_silently_saturates() {
+        assert_eq!(
+            subtract_setup_control(Duration::from_nanos(3), Duration::from_nanos(8)),
+            Ok(Duration::from_nanos(5))
+        );
+        assert_eq!(
+            subtract_setup_control(Duration::from_nanos(8), Duration::from_nanos(3)),
+            Err(RunError::SetupControlExceededMeasured {
+                setup: Duration::from_nanos(8),
+                measured: Duration::from_nanos(3),
+            })
+        );
     }
 }

--- a/crates/bench/src/runner.rs
+++ b/crates/bench/src/runner.rs
@@ -257,36 +257,42 @@ fn measure_plain(
     batch_size: usize,
     repetitions: usize,
 ) -> Result<Measurement, RunError> {
-    let mut elapsed = Duration::ZERO;
-    let mut allocations = 0_u64;
-    let mut digest = 0_u16;
-    let mut trace = NoTrace;
+    let setup_started = Instant::now();
     for _ in 0..repetitions {
         backend.reset(template);
         let batch = backend.receive(batch_size).expect("infallible backend");
-        let before_allocations = allocation_count();
-        let started = Instant::now();
-        let report = forward_batch(batch, snapshot, &mut trace);
-        elapsed += started.elapsed();
-        allocations += allocation_count() - before_allocations;
-        if report.received != batch_size
-            || report.tx_requested != batch_size
-            || report.dropped != 0
-            || report.consumed != 0
-            || report.completion.tx_requested != batch_size
-            || report.completion.tx_accepted != batch_size
-            || report.completion.tx_rejected != 0
-            || report.completion.recycled != 0
-            || report.completion.error.is_some()
-        {
-            return Err(RunError::UnexpectedBatchReport);
-        }
-        digest = u16::try_from(black_box(report.tx_requested)).unwrap_or(u16::MAX);
+        let _ = black_box(batch);
+    }
+    let setup_elapsed = setup_started.elapsed();
+
+    let mut trace = NoTrace;
+    let before_allocations = allocation_count();
+    let measured_started = Instant::now();
+    let mut last_report = None;
+    for _ in 0..repetitions {
+        backend.reset(template);
+        let batch = backend.receive(batch_size).expect("infallible backend");
+        last_report = Some(black_box(forward_batch(batch, snapshot, &mut trace)));
+    }
+    let measured_elapsed = measured_started.elapsed();
+    let allocations = allocation_count() - before_allocations;
+    let report = black_box(last_report).expect("repetitions are nonzero");
+    if report.received != batch_size
+        || report.tx_requested != batch_size
+        || report.dropped != 0
+        || report.consumed != 0
+        || report.completion.tx_requested != batch_size
+        || report.completion.tx_accepted != batch_size
+        || report.completion.tx_rejected != 0
+        || report.completion.recycled != 0
+        || report.completion.error.is_some()
+    {
+        return Err(RunError::UnexpectedBatchReport);
     }
     Ok(Measurement {
-        elapsed,
+        elapsed: measured_elapsed.saturating_sub(setup_elapsed),
         allocations,
-        digest,
+        digest: u16::try_from(report.tx_requested).unwrap_or(u16::MAX),
     })
 }
 
@@ -435,5 +441,17 @@ mod tests {
         assert!(rows.iter().any(|row| {
             row.case == "plain-ipv4" && row.size == FrameSize::Wire64 && row.stats.samples == 1
         }));
+    }
+
+    #[test]
+    fn checksum_control_matches_an_independent_known_answer() {
+        // RFC 1071-style four-word example:
+        // 0001 + f203 + f4f5 + f6f7 = ddf2 after carry folding.
+        let bytes = [0x00, 0x01, 0xf2, 0x03, 0xf4, 0xf5, 0xf6, 0xf7];
+        let once = measure_checksum(&bytes, 1, 3);
+        let twice = measure_checksum(&bytes, 2, 3);
+        assert_eq!(once.digest, 0x220d);
+        assert_eq!(twice.digest, once.digest);
+        assert_eq!(internet_checksum(&bytes), 0x220d);
     }
 }

--- a/crates/bench/src/stats.rs
+++ b/crates/bench/src/stats.rs
@@ -1,0 +1,86 @@
+/// Distribution summary for normalized nanoseconds per packet or operation.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SampleStats {
+    pub samples: usize,
+    pub min_ns: f64,
+    pub p50_ns: f64,
+    pub p95_ns: f64,
+    pub mad_ns: f64,
+}
+
+impl SampleStats {
+    #[must_use]
+    pub fn from_samples(samples: &[f64]) -> Option<Self> {
+        if samples.is_empty()
+            || samples
+                .iter()
+                .any(|sample| !sample.is_finite() || *sample <= 0.0)
+        {
+            return None;
+        }
+        let mut ordered = samples.to_vec();
+        ordered.sort_by(f64::total_cmp);
+        let p50_ns = median(&ordered);
+        let p95_index = (ordered.len() * 95).div_ceil(100).saturating_sub(1);
+        let p95_ns = ordered[p95_index];
+        let mut deviations = ordered
+            .iter()
+            .map(|sample| (sample - p50_ns).abs())
+            .collect::<Vec<_>>();
+        deviations.sort_by(f64::total_cmp);
+        Some(Self {
+            samples: ordered.len(),
+            min_ns: ordered[0],
+            p50_ns,
+            p95_ns,
+            mad_ns: median(&deviations),
+        })
+    }
+
+    #[must_use]
+    pub fn million_per_second(self) -> f64 {
+        if self.p50_ns == 0.0 {
+            f64::INFINITY
+        } else {
+            1_000.0 / self.p50_ns
+        }
+    }
+}
+
+fn median(ordered: &[f64]) -> f64 {
+    let middle = ordered.len() / 2;
+    if ordered.len().is_multiple_of(2) {
+        (ordered[middle - 1] + ordered[middle]) / 2.0
+    } else {
+        ordered[middle]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn summary_uses_median_nearest_rank_p95_and_mad() {
+        let stats = SampleStats::from_samples(&[9.0, 1.0, 5.0, 3.0, 7.0]).unwrap();
+        assert_eq!(
+            stats,
+            SampleStats {
+                samples: 5,
+                min_ns: 1.0,
+                p50_ns: 5.0,
+                p95_ns: 9.0,
+                mad_ns: 2.0,
+            }
+        );
+        assert_eq!(stats.million_per_second(), 200.0);
+    }
+
+    #[test]
+    fn invalid_or_empty_samples_are_rejected() {
+        assert!(SampleStats::from_samples(&[]).is_none());
+        assert!(SampleStats::from_samples(&[f64::NAN]).is_none());
+        assert!(SampleStats::from_samples(&[0.0]).is_none());
+        assert!(SampleStats::from_samples(&[-1.0]).is_none());
+    }
+}


### PR DESCRIPTION
## Summary
- add a std-only non-published benchmark crate depending only on ruster-core
- measure preallocated backend lease datapath and checksum controls without io-sim or NIC cost
- define exact wire-size metadata, deterministic fixtures/oracles, allocation-zero checks, human/JSONL output, and aggregate timing intervals
- reject setup-control timing inversion with typed errors

## Validation
- release smoke passed with positive samples and zero timed allocations
- full repository gates passed on the final implementation SHA
- independent performance review approved after three correction rounds

## Claims
These are hot-cache core microbenchmarks, not AF_XDP, DMA, end-to-end, or 10GbE evidence.