### PR TITLE
test(io): add reusable backend conformance kit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,8 +14,16 @@ name = "ruster-core"
 version = "0.2.0"
 
 [[package]]
+name = "ruster-io-conformance"
+version = "0.2.0"
+dependencies = [
+ "ruster-core",
+]
+
+[[package]]
 name = "ruster-io-sim"
 version = "0.2.0"
 dependencies = [
  "ruster-core",
+ "ruster-io-conformance",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,10 @@
 [workspace]
-members = ["crates/bench", "crates/core", "crates/io-sim"]
+members = [
+    "crates/bench",
+    "crates/core",
+    "crates/io-conformance",
+    "crates/io-sim",
+]
 resolver = "2"
 
 [workspace.package]

--- a/crates/io-conformance/Cargo.toml
+++ b/crates/io-conformance/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ruster-io-sim"
+name = "ruster-io-conformance"
 edition.workspace = true
 version.workspace = true
 license.workspace = true
@@ -7,6 +7,3 @@ publish.workspace = true
 
 [dependencies]
 ruster-core = { path = "../core" }
-
-[dev-dependencies]
-ruster-io-conformance = { path = "../io-conformance" }

--- a/crates/io-conformance/src/finite_fake_tests.rs
+++ b/crates/io-conformance/src/finite_fake_tests.rs
@@ -27,6 +27,8 @@ const STALE_GENERATION: u8 = 3;
 const WRONG_LENGTH: u8 = 4;
 const WRONG_RING: u8 = 5;
 const TOKEN_INVENTION: u8 = 6;
+const RX_BATCH_DROP_LEAK: u8 = 7;
+const GENERATED_STALE_CARRYOVER: u8 = 8;
 const FRAME_CAPACITY: usize = 128;
 const FRAME_COUNT: usize = 4;
 
@@ -80,7 +82,7 @@ struct State<const FAULT: u8> {
     rx: VecDeque<Frame>,
     rx_events: Vec<RxEvent>,
     generated_events: Vec<GeneratedEvent>,
-    generated_pending: Vec<Frame>,
+    generated_carryover: Vec<Frame>,
     submitted_rx: Vec<Submitted>,
     submitted_generated: Vec<Submitted>,
     physical_by_address: BTreeMap<usize, u64>,
@@ -107,7 +109,7 @@ impl<const FAULT: u8> State<FAULT> {
             rx: VecDeque::new(),
             rx_events: Vec::new(),
             generated_events: Vec::new(),
-            generated_pending: Vec::new(),
+            generated_carryover: Vec::new(),
             submitted_rx: Vec::new(),
             submitted_generated: Vec::new(),
             physical_by_address,
@@ -300,6 +302,19 @@ impl<const FAULT: u8> PacketBatch for FakeRxBatch<FAULT> {
     }
 }
 
+impl<const FAULT: u8> Drop for FakeRxBatch<FAULT> {
+    fn drop(&mut self) {
+        if FAULT == RX_BATCH_DROP_LEAK {
+            self.leased.clear();
+            return;
+        }
+        let mut state = self.state.borrow_mut();
+        while let Some(frame) = self.leased.pop_back() {
+            state.rx.push_front(frame);
+        }
+    }
+}
+
 impl<const FAULT: u8> PacketSlot for FakeRxSlot<FAULT> {
     fn ingress(&self) -> IfId {
         self.frame.as_ref().expect("live RX frame").ingress
@@ -403,12 +418,14 @@ struct FakeGeneratedBatch<const FAULT: u8> {
     egress: IfId,
     remaining_allocations: usize,
     max_frame: usize,
+    pending: Rc<RefCell<Vec<Frame>>>,
     counters: Rc<RefCell<GeneratedCounters>>,
 }
 
 struct FakeGeneratedSlot<const FAULT: u8> {
     state: Rc<RefCell<State<FAULT>>>,
     frame: Option<Frame>,
+    pending: Rc<RefCell<Vec<Frame>>>,
     counters: Rc<RefCell<GeneratedCounters>>,
     egress: IfId,
 }
@@ -418,15 +435,21 @@ impl<const FAULT: u8> GeneratedPacketIo for FakeIo<FAULT> {
     type Batch<'a> = FakeGeneratedBatch<FAULT>;
 
     fn begin_generated(&mut self, egress: IfId) -> Self::Batch<'_> {
-        let state = self.0.borrow();
+        let mut state = self.0.borrow_mut();
         let remaining_allocations = state.generated_allocation_budget;
         let max_frame = state.generated_max_frame;
+        let pending = if FAULT == GENERATED_STALE_CARRYOVER {
+            std::mem::take(&mut state.generated_carryover)
+        } else {
+            Vec::new()
+        };
         drop(state);
         FakeGeneratedBatch {
             state: Rc::clone(&self.0),
             egress,
             remaining_allocations,
             max_frame,
+            pending: Rc::new(RefCell::new(pending)),
             counters: Rc::new(RefCell::new(GeneratedCounters::default())),
         }
     }
@@ -470,6 +493,7 @@ impl<const FAULT: u8> GeneratedPacketBatch for FakeGeneratedBatch<FAULT> {
         Ok(GeneratedPacketLease::new(FakeGeneratedSlot {
             state: Rc::clone(&self.state),
             frame: Some(frame),
+            pending: Rc::clone(&self.pending),
             counters: Rc::clone(&self.counters),
             egress: self.egress,
         }))
@@ -478,7 +502,7 @@ impl<const FAULT: u8> GeneratedPacketBatch for FakeGeneratedBatch<FAULT> {
     fn finish(self) -> GeneratedBatchCompletion<Self::Error> {
         let mut state = self.state.borrow_mut();
         let endpoint = State::<FAULT>::publication_endpoint(self.egress);
-        let pending = std::mem::take(&mut state.generated_pending);
+        let pending: Vec<_> = self.pending.borrow_mut().drain(..).collect();
         let mut accepted = 0;
         let mut rejected = 0;
         for frame in pending {
@@ -532,6 +556,35 @@ impl<const FAULT: u8> GeneratedPacketBatch for FakeGeneratedBatch<FAULT> {
     }
 }
 
+impl<const FAULT: u8> Drop for FakeGeneratedBatch<FAULT> {
+    fn drop(&mut self) {
+        let pending: Vec<_> = self.pending.borrow_mut().drain(..).collect();
+        if pending.is_empty() {
+            return;
+        }
+        let mut state = self.state.borrow_mut();
+        if FAULT == GENERATED_STALE_CARRYOVER {
+            state.generated_carryover.extend(pending);
+            return;
+        }
+        let endpoint = State::<FAULT>::publication_endpoint(self.egress);
+        for frame in pending {
+            let binding = state.retire(frame.bytes());
+            let bytes = frame.bytes().to_vec();
+            state.generated_events.push(GeneratedEvent {
+                frame: State::<FAULT>::event_frame(binding),
+                egress: self.egress,
+                bytes,
+                kind: GeneratedEventKind::TxRejected {
+                    attempted_egress: self.egress,
+                    endpoint,
+                },
+            });
+            state.return_to_pool(frame);
+        }
+    }
+}
+
 impl<const FAULT: u8> GeneratedPacketSlot for FakeGeneratedSlot<FAULT> {
     fn bytes_mut(&mut self) -> &mut [u8] {
         self.frame
@@ -545,7 +598,7 @@ impl<const FAULT: u8> GeneratedPacketSlot for FakeGeneratedSlot<FAULT> {
         match completion {
             GeneratedSlotCompletion::Transmit => {
                 self.counters.borrow_mut().requested += 1;
-                self.state.borrow_mut().generated_pending.push(frame);
+                self.pending.borrow_mut().push(frame);
             }
             GeneratedSlotCompletion::Cancelled | GeneratedSlotCompletion::Abandoned => {
                 let mut state = self.state.borrow_mut();
@@ -737,6 +790,7 @@ fn finite_fake_positive_rx_cases_include_unknown_egress_and_cq_reuse() {
     rx::repeated_rejects_restore_physical_pool::<FakeHarness<GOOD>>();
     rx::unknown_egress_is_rejected_without_submission::<FakeHarness<GOOD>>();
     rx::cq_return_releases_same_rx_frame_with_new_generation::<FakeHarness<GOOD>>();
+    rx::dropped_batch_preserves_unleased_rx_and_cq_ownership::<FakeHarness<GOOD>>();
 }
 
 #[test]
@@ -745,6 +799,8 @@ fn finite_fake_positive_generated_cases_include_unknown_egress_and_cq_reuse() {
     generated::repeated_rejects_restore_physical_pool_and_advance_generation::<FakeHarness<GOOD>>();
     generated::unknown_egress_is_rejected_without_submission::<FakeHarness<GOOD>>();
     generated::cq_return_releases_same_generated_frame_with_new_generation::<FakeHarness<GOOD>>();
+    generated::dropped_batch_accounts_generated_and_cannot_carry_to_next_egress::<FakeHarness<GOOD>>(
+    );
 }
 
 fn assert_detected(case: impl FnOnce()) {
@@ -789,5 +845,21 @@ fn conformance_detects_publication_on_the_wrong_ring() {
 fn conformance_detects_terminal_token_invention() {
     assert_detected(
         rx::commit_is_submitted_in_place_with_exact_descriptor::<FakeHarness<TOKEN_INVENTION>>,
+    );
+}
+
+#[test]
+fn conformance_detects_rx_whole_batch_drop_leak() {
+    assert_detected(
+        rx::dropped_batch_preserves_unleased_rx_and_cq_ownership::<FakeHarness<RX_BATCH_DROP_LEAK>>,
+    );
+}
+
+#[test]
+fn conformance_detects_generated_whole_batch_stale_carryover() {
+    assert_detected(
+        generated::dropped_batch_accounts_generated_and_cannot_carry_to_next_egress::<
+            FakeHarness<GENERATED_STALE_CARRYOVER>,
+        >,
     );
 }

--- a/crates/io-conformance/src/finite_fake_tests.rs
+++ b/crates/io-conformance/src/finite_fake_tests.rs
@@ -1,0 +1,793 @@
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, VecDeque},
+    convert::Infallible,
+    panic::{catch_unwind, AssertUnwindSafe},
+    rc::Rc,
+};
+
+use ruster_core::{
+    BatchCompletion, GeneratedAllocationError, GeneratedBatchCompletion, GeneratedPacketBatch,
+    GeneratedPacketIo, GeneratedPacketLease, GeneratedPacketSlot, GeneratedSlotCompletion, IfId,
+    PacketBatch, PacketIo, PacketLease, PacketSlot, SlotCompletion,
+};
+
+use super::{
+    generated, rx, BufferToken, GeneratedCompletionHarness, GeneratedCqPoolHarness, GeneratedEvent,
+    GeneratedEventKind, GeneratedFinitePoolHarness, GeneratedHarness, GeneratedReclaim,
+    GeneratedUnknownEgressHarness, LeaseObserver, LiveFrame, RxCompletionHarness, RxCqPoolHarness,
+    RxEvent, RxEventKind, RxFinitePoolHarness, RxHarness, RxReclaim, RxUnknownEgressHarness,
+    TxCompletion, TxEndpoint, CONFORMANCE_LAN_ENDPOINT, CONFORMANCE_WAN_ENDPOINT,
+};
+
+const GOOD: u8 = 0;
+const LEAK: u8 = 1;
+const ALIAS: u8 = 2;
+const STALE_GENERATION: u8 = 3;
+const WRONG_LENGTH: u8 = 4;
+const WRONG_RING: u8 = 5;
+const TOKEN_INVENTION: u8 = 6;
+const FRAME_CAPACITY: usize = 128;
+const FRAME_COUNT: usize = 4;
+
+struct Frame {
+    id: u64,
+    storage: Box<[u8; FRAME_CAPACITY]>,
+    len: usize,
+    ingress: IfId,
+}
+
+impl Frame {
+    fn new(id: u64) -> Self {
+        Self {
+            id,
+            storage: Box::new([0; FRAME_CAPACITY]),
+            len: 0,
+            ingress: IfId(0),
+        }
+    }
+
+    fn bytes(&self) -> &[u8] {
+        &self.storage[..self.len]
+    }
+
+    fn bytes_mut(&mut self) -> &mut [u8] {
+        &mut self.storage[..self.len]
+    }
+
+    fn load(&mut self, ingress: IfId, bytes: &[u8]) {
+        assert!(bytes.len() <= FRAME_CAPACITY);
+        self.ingress = ingress;
+        self.len = bytes.len();
+        self.storage[..self.len].copy_from_slice(bytes);
+    }
+
+    fn allocate(&mut self, len: usize) {
+        self.ingress = IfId(0);
+        self.len = len;
+        self.storage[..len].fill(0xa5);
+    }
+}
+
+struct Submitted {
+    frame: Frame,
+    binding: LiveFrame,
+    endpoint: TxEndpoint,
+}
+
+struct State<const FAULT: u8> {
+    free: Vec<Frame>,
+    rx: VecDeque<Frame>,
+    rx_events: Vec<RxEvent>,
+    generated_events: Vec<GeneratedEvent>,
+    generated_pending: Vec<Frame>,
+    submitted_rx: Vec<Submitted>,
+    submitted_generated: Vec<Submitted>,
+    physical_by_address: BTreeMap<usize, u64>,
+    generations: BTreeMap<u64, u64>,
+    live: BTreeMap<usize, LiveFrame>,
+    rx_accept_budget: usize,
+    generated_allocation_budget: usize,
+    generated_max_frame: usize,
+    generated_accept_budget: usize,
+    preferred_generated_frame: Option<u64>,
+}
+
+impl<const FAULT: u8> State<FAULT> {
+    fn new() -> Self {
+        let free: Vec<_> = (0..FRAME_COUNT)
+            .map(|index| Frame::new(100 + index as u64))
+            .collect();
+        let physical_by_address = free
+            .iter()
+            .map(|frame| (frame.storage.as_ptr() as usize, frame.id))
+            .collect();
+        Self {
+            free,
+            rx: VecDeque::new(),
+            rx_events: Vec::new(),
+            generated_events: Vec::new(),
+            generated_pending: Vec::new(),
+            submitted_rx: Vec::new(),
+            submitted_generated: Vec::new(),
+            physical_by_address,
+            generations: BTreeMap::new(),
+            live: BTreeMap::new(),
+            rx_accept_budget: usize::MAX,
+            generated_allocation_budget: usize::MAX,
+            generated_max_frame: FRAME_CAPACITY,
+            generated_accept_budget: usize::MAX,
+            preferred_generated_frame: None,
+        }
+    }
+
+    fn bind(&mut self, bytes: &[u8], requested_len: usize) -> LiveFrame {
+        assert_eq!(bytes.len(), requested_len);
+        let visible_address = bytes.as_ptr() as usize;
+        assert!(
+            !self.live.contains_key(&visible_address),
+            "address already has a live ownership cycle"
+        );
+        let physical_id = *self
+            .physical_by_address
+            .get(&visible_address)
+            .expect("binding points at a fake physical frame");
+        let frame_id = if FAULT == ALIAS { 1 } else { physical_id };
+        let generation = if FAULT == STALE_GENERATION {
+            1
+        } else {
+            let generation = self.generations.entry(frame_id).or_default();
+            *generation = generation.checked_add(1).expect("generation overflow");
+            *generation
+        };
+        let frame = LiveFrame {
+            token: BufferToken::new(frame_id, generation),
+            visible_address,
+            requested_len,
+        };
+        self.live.insert(visible_address, frame);
+        frame
+    }
+
+    fn observe(&self, bytes: &[u8]) -> LiveFrame {
+        let address = bytes.as_ptr() as usize;
+        let frame = *self.live.get(&address).expect("frame has no live binding");
+        assert_eq!(bytes.len(), frame.requested_len);
+        frame
+    }
+
+    fn retire(&mut self, bytes: &[u8]) -> LiveFrame {
+        let frame = self.observe(bytes);
+        assert_eq!(self.live.remove(&frame.visible_address), Some(frame));
+        frame
+    }
+
+    fn event_frame(frame: LiveFrame) -> LiveFrame {
+        if FAULT == TOKEN_INVENTION {
+            LiveFrame {
+                token: BufferToken::new(frame.token.frame_id + 10_000, frame.token.generation),
+                ..frame
+            }
+        } else {
+            frame
+        }
+    }
+
+    fn publication_endpoint(egress: IfId) -> Option<TxEndpoint> {
+        let endpoint = match egress {
+            interface if interface == CONFORMANCE_LAN_ENDPOINT.interface => {
+                CONFORMANCE_LAN_ENDPOINT
+            }
+            interface if interface == CONFORMANCE_WAN_ENDPOINT.interface => {
+                CONFORMANCE_WAN_ENDPOINT
+            }
+            _ => return None,
+        };
+        Some(if FAULT == WRONG_RING {
+            TxEndpoint {
+                queue: endpoint.queue + 1,
+                ..endpoint
+            }
+        } else {
+            endpoint
+        })
+    }
+
+    fn descriptor_len(frame: LiveFrame) -> usize {
+        if FAULT == WRONG_LENGTH {
+            frame.requested_len + 1
+        } else {
+            frame.requested_len
+        }
+    }
+
+    fn return_to_pool(&mut self, frame: Frame) {
+        if FAULT != LEAK {
+            self.free.push(frame);
+        }
+    }
+
+    fn take_free(&mut self, preferred: Option<u64>) -> Option<Frame> {
+        let index = preferred
+            .and_then(|id| self.free.iter().position(|frame| frame.id == id))
+            .unwrap_or_else(|| self.free.len().saturating_sub(1));
+        if self.free.is_empty() {
+            None
+        } else {
+            Some(self.free.swap_remove(index))
+        }
+    }
+}
+
+struct FakeObserver<const FAULT: u8>(Rc<RefCell<State<FAULT>>>);
+
+impl<const FAULT: u8> LeaseObserver for FakeObserver<FAULT> {
+    fn bind(&mut self, bytes: &[u8], requested_len: usize) -> LiveFrame {
+        self.0.borrow_mut().bind(bytes, requested_len)
+    }
+
+    fn observe(&self, bytes: &[u8]) -> LiveFrame {
+        self.0.borrow().observe(bytes)
+    }
+}
+
+struct FakeIo<const FAULT: u8>(Rc<RefCell<State<FAULT>>>);
+
+#[derive(Default)]
+struct RxCounters {
+    tx_requested: usize,
+    tx_accepted: usize,
+    tx_rejected: usize,
+    recycled: usize,
+}
+
+struct FakeRxBatch<const FAULT: u8> {
+    state: Rc<RefCell<State<FAULT>>>,
+    leased: VecDeque<Frame>,
+    counters: Rc<RefCell<RxCounters>>,
+}
+
+struct FakeRxSlot<const FAULT: u8> {
+    state: Rc<RefCell<State<FAULT>>>,
+    frame: Option<Frame>,
+    counters: Rc<RefCell<RxCounters>>,
+}
+
+impl<const FAULT: u8> PacketIo for FakeIo<FAULT> {
+    type Error = Infallible;
+    type Batch<'a> = FakeRxBatch<FAULT>;
+
+    fn receive(&mut self, budget: usize) -> Result<Self::Batch<'_>, Self::Error> {
+        let mut state = self.0.borrow_mut();
+        let count = budget.min(state.rx.len());
+        let leased = state.rx.drain(..count).collect();
+        drop(state);
+        Ok(FakeRxBatch {
+            state: Rc::clone(&self.0),
+            leased,
+            counters: Rc::new(RefCell::new(RxCounters::default())),
+        })
+    }
+}
+
+impl<const FAULT: u8> PacketBatch for FakeRxBatch<FAULT> {
+    type Error = Infallible;
+    type Slot<'a>
+        = FakeRxSlot<FAULT>
+    where
+        Self: 'a;
+
+    fn next_packet(&mut self) -> Option<PacketLease<Self::Slot<'_>>> {
+        self.leased.pop_front().map(|frame| {
+            PacketLease::new(FakeRxSlot {
+                state: Rc::clone(&self.state),
+                frame: Some(frame),
+                counters: Rc::clone(&self.counters),
+            })
+        })
+    }
+
+    fn finish(self) -> BatchCompletion<Self::Error> {
+        assert!(self.leased.is_empty(), "fake batch left unleased frames");
+        let counters = self.counters.borrow();
+        BatchCompletion {
+            tx_requested: counters.tx_requested,
+            tx_accepted: counters.tx_accepted,
+            tx_rejected: counters.tx_rejected,
+            recycled: counters.recycled,
+            error: None,
+        }
+    }
+}
+
+impl<const FAULT: u8> PacketSlot for FakeRxSlot<FAULT> {
+    fn ingress(&self) -> IfId {
+        self.frame.as_ref().expect("live RX frame").ingress
+    }
+
+    fn bytes_mut(&mut self) -> &mut [u8] {
+        self.frame.as_mut().expect("live RX frame").bytes_mut()
+    }
+
+    fn complete(mut self, completion: SlotCompletion) {
+        let frame = self.frame.take().expect("RX slot completed once");
+        let ingress = frame.ingress;
+        let bytes = frame.bytes().to_vec();
+        let mut state = self.state.borrow_mut();
+        let binding = state.observe(frame.bytes());
+        match completion {
+            SlotCompletion::Transmit(egress) => {
+                self.counters.borrow_mut().tx_requested += 1;
+                let endpoint = State::<FAULT>::publication_endpoint(egress);
+                if let Some(published_endpoint) = endpoint.filter(|_| state.rx_accept_budget != 0) {
+                    state.rx_accept_budget -= 1;
+                    self.counters.borrow_mut().tx_accepted += 1;
+                    state.rx_events.push(RxEvent {
+                        frame: State::<FAULT>::event_frame(binding),
+                        ingress,
+                        bytes,
+                        kind: RxEventKind::TxSubmitted {
+                            endpoint: published_endpoint,
+                            descriptor_len: State::<FAULT>::descriptor_len(binding),
+                        },
+                    });
+                    state.submitted_rx.push(Submitted {
+                        frame,
+                        binding,
+                        endpoint: published_endpoint,
+                    });
+                } else {
+                    self.counters.borrow_mut().tx_rejected += 1;
+                    state.retire(frame.bytes());
+                    state.rx_events.push(RxEvent {
+                        frame: State::<FAULT>::event_frame(binding),
+                        ingress,
+                        bytes,
+                        kind: RxEventKind::TxRejected {
+                            attempted_egress: egress,
+                            endpoint,
+                        },
+                    });
+                    state.return_to_pool(frame);
+                }
+            }
+            SlotCompletion::Recycle(reason) => {
+                self.counters.borrow_mut().recycled += 1;
+                state.retire(frame.bytes());
+                state.rx_events.push(RxEvent {
+                    frame: State::<FAULT>::event_frame(binding),
+                    ingress,
+                    bytes,
+                    kind: RxEventKind::Reclaimed(RxReclaim::Recycled(reason)),
+                });
+                state.return_to_pool(frame);
+            }
+            SlotCompletion::Consume(reason) => {
+                self.counters.borrow_mut().recycled += 1;
+                state.retire(frame.bytes());
+                state.rx_events.push(RxEvent {
+                    frame: State::<FAULT>::event_frame(binding),
+                    ingress,
+                    bytes,
+                    kind: RxEventKind::Reclaimed(RxReclaim::Consumed(reason)),
+                });
+                state.return_to_pool(frame);
+            }
+            SlotCompletion::LeaseAbandoned => {
+                self.counters.borrow_mut().recycled += 1;
+                state.retire(frame.bytes());
+                state.rx_events.push(RxEvent {
+                    frame: State::<FAULT>::event_frame(binding),
+                    ingress,
+                    bytes,
+                    kind: RxEventKind::Reclaimed(RxReclaim::Abandoned),
+                });
+                state.return_to_pool(frame);
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct GeneratedCounters {
+    attempts: usize,
+    allocated: usize,
+    failed: usize,
+    requested: usize,
+    cancelled: usize,
+    abandoned: usize,
+}
+
+struct FakeGeneratedBatch<const FAULT: u8> {
+    state: Rc<RefCell<State<FAULT>>>,
+    egress: IfId,
+    remaining_allocations: usize,
+    max_frame: usize,
+    counters: Rc<RefCell<GeneratedCounters>>,
+}
+
+struct FakeGeneratedSlot<const FAULT: u8> {
+    state: Rc<RefCell<State<FAULT>>>,
+    frame: Option<Frame>,
+    counters: Rc<RefCell<GeneratedCounters>>,
+    egress: IfId,
+}
+
+impl<const FAULT: u8> GeneratedPacketIo for FakeIo<FAULT> {
+    type Error = Infallible;
+    type Batch<'a> = FakeGeneratedBatch<FAULT>;
+
+    fn begin_generated(&mut self, egress: IfId) -> Self::Batch<'_> {
+        let state = self.0.borrow();
+        let remaining_allocations = state.generated_allocation_budget;
+        let max_frame = state.generated_max_frame;
+        drop(state);
+        FakeGeneratedBatch {
+            state: Rc::clone(&self.0),
+            egress,
+            remaining_allocations,
+            max_frame,
+            counters: Rc::new(RefCell::new(GeneratedCounters::default())),
+        }
+    }
+}
+
+impl<const FAULT: u8> GeneratedPacketBatch for FakeGeneratedBatch<FAULT> {
+    type Error = Infallible;
+    type Slot<'a>
+        = FakeGeneratedSlot<FAULT>
+    where
+        Self: 'a;
+
+    fn allocate(
+        &mut self,
+        frame_len: usize,
+    ) -> Result<GeneratedPacketLease<Self::Slot<'_>>, GeneratedAllocationError> {
+        self.counters.borrow_mut().attempts += 1;
+        let error = if frame_len == 0 {
+            Some(GeneratedAllocationError::ZeroLength)
+        } else if frame_len > self.max_frame {
+            Some(GeneratedAllocationError::FrameTooLarge)
+        } else if self.remaining_allocations == 0 {
+            Some(GeneratedAllocationError::Unavailable)
+        } else {
+            None
+        };
+        if let Some(error) = error {
+            self.counters.borrow_mut().failed += 1;
+            return Err(error);
+        }
+        let mut state = self.state.borrow_mut();
+        let preferred = state.preferred_generated_frame.take();
+        let Some(mut frame) = state.take_free(preferred) else {
+            self.counters.borrow_mut().failed += 1;
+            return Err(GeneratedAllocationError::Unavailable);
+        };
+        frame.allocate(frame_len);
+        drop(state);
+        self.remaining_allocations -= 1;
+        self.counters.borrow_mut().allocated += 1;
+        Ok(GeneratedPacketLease::new(FakeGeneratedSlot {
+            state: Rc::clone(&self.state),
+            frame: Some(frame),
+            counters: Rc::clone(&self.counters),
+            egress: self.egress,
+        }))
+    }
+
+    fn finish(self) -> GeneratedBatchCompletion<Self::Error> {
+        let mut state = self.state.borrow_mut();
+        let endpoint = State::<FAULT>::publication_endpoint(self.egress);
+        let pending = std::mem::take(&mut state.generated_pending);
+        let mut accepted = 0;
+        let mut rejected = 0;
+        for frame in pending {
+            let binding = state.observe(frame.bytes());
+            let bytes = frame.bytes().to_vec();
+            if let Some(published_endpoint) =
+                endpoint.filter(|_| accepted < state.generated_accept_budget)
+            {
+                accepted += 1;
+                state.generated_events.push(GeneratedEvent {
+                    frame: State::<FAULT>::event_frame(binding),
+                    egress: self.egress,
+                    bytes,
+                    kind: GeneratedEventKind::TxSubmitted {
+                        endpoint: published_endpoint,
+                        descriptor_len: State::<FAULT>::descriptor_len(binding),
+                    },
+                });
+                state.submitted_generated.push(Submitted {
+                    frame,
+                    binding,
+                    endpoint: published_endpoint,
+                });
+            } else {
+                rejected += 1;
+                state.retire(frame.bytes());
+                state.generated_events.push(GeneratedEvent {
+                    frame: State::<FAULT>::event_frame(binding),
+                    egress: self.egress,
+                    bytes,
+                    kind: GeneratedEventKind::TxRejected {
+                        attempted_egress: self.egress,
+                        endpoint,
+                    },
+                });
+                state.return_to_pool(frame);
+            }
+        }
+        let counters = self.counters.borrow();
+        GeneratedBatchCompletion {
+            attempts: counters.attempts,
+            allocated: counters.allocated,
+            failed: counters.failed,
+            requested: counters.requested,
+            cancelled: counters.cancelled,
+            abandoned: counters.abandoned,
+            accepted,
+            rejected,
+            error: None,
+        }
+    }
+}
+
+impl<const FAULT: u8> GeneratedPacketSlot for FakeGeneratedSlot<FAULT> {
+    fn bytes_mut(&mut self) -> &mut [u8] {
+        self.frame
+            .as_mut()
+            .expect("live generated frame")
+            .bytes_mut()
+    }
+
+    fn complete(mut self, completion: GeneratedSlotCompletion) {
+        let frame = self.frame.take().expect("generated slot completed once");
+        match completion {
+            GeneratedSlotCompletion::Transmit => {
+                self.counters.borrow_mut().requested += 1;
+                self.state.borrow_mut().generated_pending.push(frame);
+            }
+            GeneratedSlotCompletion::Cancelled | GeneratedSlotCompletion::Abandoned => {
+                let mut state = self.state.borrow_mut();
+                let binding = state.retire(frame.bytes());
+                let bytes = frame.bytes().to_vec();
+                let kind = if completion == GeneratedSlotCompletion::Cancelled {
+                    self.counters.borrow_mut().cancelled += 1;
+                    GeneratedEventKind::Reclaimed(GeneratedReclaim::Cancelled)
+                } else {
+                    self.counters.borrow_mut().abandoned += 1;
+                    GeneratedEventKind::Reclaimed(GeneratedReclaim::Abandoned)
+                };
+                state.generated_events.push(GeneratedEvent {
+                    frame: State::<FAULT>::event_frame(binding),
+                    egress: self.egress,
+                    bytes,
+                    kind,
+                });
+                state.return_to_pool(frame);
+            }
+        }
+    }
+}
+
+struct FakeHarness<const FAULT: u8> {
+    io: FakeIo<FAULT>,
+    observer: FakeObserver<FAULT>,
+}
+
+impl<const FAULT: u8> FakeHarness<FAULT> {
+    fn shared() -> Self {
+        let state = Rc::new(RefCell::new(State::new()));
+        Self {
+            io: FakeIo(Rc::clone(&state)),
+            observer: FakeObserver(state),
+        }
+    }
+
+    fn inject_selected(
+        &mut self,
+        frame_id: Option<u64>,
+        ingress: IfId,
+        bytes: Vec<u8>,
+    ) -> LiveFrame {
+        let mut state = self.io.0.borrow_mut();
+        let mut frame = state
+            .take_free(frame_id)
+            .expect("finite fake RX pool exhausted");
+        frame.load(ingress, &bytes);
+        drop(state);
+        let binding = self.observer.bind(frame.bytes(), bytes.len());
+        self.io.0.borrow_mut().rx.push_back(frame);
+        binding
+    }
+}
+
+impl<const FAULT: u8> RxHarness for FakeHarness<FAULT> {
+    type Io = FakeIo<FAULT>;
+    type Observer = FakeObserver<FAULT>;
+
+    fn new() -> Self {
+        Self::shared()
+    }
+
+    fn io_and_observer(&mut self) -> (&mut Self::Io, &mut Self::Observer) {
+        (&mut self.io, &mut self.observer)
+    }
+
+    fn inject_rx(&mut self, ingress: IfId, bytes: Vec<u8>) -> LiveFrame {
+        self.inject_selected(None, ingress, bytes)
+    }
+
+    fn set_rx_accept_budget(&mut self, budget: usize) {
+        self.io.0.borrow_mut().rx_accept_budget = budget;
+    }
+
+    fn pending_rx(&self) -> usize {
+        self.io.0.borrow().rx.len()
+    }
+
+    fn drain_rx_events(&mut self) -> Vec<RxEvent> {
+        std::mem::take(&mut self.io.0.borrow_mut().rx_events)
+    }
+}
+
+impl<const FAULT: u8> RxFinitePoolHarness for FakeHarness<FAULT> {
+    fn free_rx_frames(&self) -> usize {
+        self.io.0.borrow().free.len()
+    }
+}
+
+impl<const FAULT: u8> RxCompletionHarness for FakeHarness<FAULT> {
+    fn complete_rx_submissions(&mut self) -> Vec<TxCompletion> {
+        let mut state = self.io.0.borrow_mut();
+        let submitted = std::mem::take(&mut state.submitted_rx);
+        submitted
+            .into_iter()
+            .map(|submission| {
+                state.retire(submission.frame.bytes());
+                let completion = TxCompletion {
+                    frame: submission.binding,
+                    endpoint: submission.endpoint,
+                };
+                state.return_to_pool(submission.frame);
+                completion
+            })
+            .collect()
+    }
+}
+
+impl<const FAULT: u8> RxCqPoolHarness for FakeHarness<FAULT> {
+    fn inject_rx_from_free_frame(
+        &mut self,
+        frame_id: u64,
+        ingress: IfId,
+        bytes: Vec<u8>,
+    ) -> LiveFrame {
+        self.inject_selected(Some(frame_id), ingress, bytes)
+    }
+}
+
+impl<const FAULT: u8> RxUnknownEgressHarness for FakeHarness<FAULT> {}
+
+impl<const FAULT: u8> GeneratedHarness for FakeHarness<FAULT> {
+    type Io = FakeIo<FAULT>;
+    type Observer = FakeObserver<FAULT>;
+
+    fn new() -> Self {
+        Self::shared()
+    }
+
+    fn io_and_observer(&mut self) -> (&mut Self::Io, &mut Self::Observer) {
+        (&mut self.io, &mut self.observer)
+    }
+
+    fn set_generated_allocation_budget(&mut self, budget: usize) {
+        self.io.0.borrow_mut().generated_allocation_budget = budget;
+    }
+
+    fn set_generated_max_frame(&mut self, max_frame: usize) {
+        self.io.0.borrow_mut().generated_max_frame = max_frame;
+    }
+
+    fn set_generated_accept_budget(&mut self, budget: usize) {
+        self.io.0.borrow_mut().generated_accept_budget = budget;
+    }
+
+    fn drain_generated_events(&mut self) -> Vec<GeneratedEvent> {
+        std::mem::take(&mut self.io.0.borrow_mut().generated_events)
+    }
+}
+
+impl<const FAULT: u8> GeneratedFinitePoolHarness for FakeHarness<FAULT> {
+    fn free_generated_frames(&self) -> usize {
+        self.io.0.borrow().free.len()
+    }
+}
+
+impl<const FAULT: u8> GeneratedCompletionHarness for FakeHarness<FAULT> {
+    fn complete_generated_submissions(&mut self) -> Vec<TxCompletion> {
+        let mut state = self.io.0.borrow_mut();
+        let submitted = std::mem::take(&mut state.submitted_generated);
+        submitted
+            .into_iter()
+            .map(|submission| {
+                state.retire(submission.frame.bytes());
+                let completion = TxCompletion {
+                    frame: submission.binding,
+                    endpoint: submission.endpoint,
+                };
+                state.return_to_pool(submission.frame);
+                completion
+            })
+            .collect()
+    }
+}
+
+impl<const FAULT: u8> GeneratedCqPoolHarness for FakeHarness<FAULT> {
+    fn prefer_generated_frame(&mut self, frame_id: u64) {
+        self.io.0.borrow_mut().preferred_generated_frame = Some(frame_id);
+    }
+}
+
+impl<const FAULT: u8> GeneratedUnknownEgressHarness for FakeHarness<FAULT> {}
+
+#[test]
+fn finite_fake_positive_rx_cases_include_unknown_egress_and_cq_reuse() {
+    rx::partial_reject_reclaims_exact_tokens::<FakeHarness<GOOD>>();
+    rx::repeated_rejects_restore_physical_pool::<FakeHarness<GOOD>>();
+    rx::unknown_egress_is_rejected_without_submission::<FakeHarness<GOOD>>();
+    rx::cq_return_releases_same_rx_frame_with_new_generation::<FakeHarness<GOOD>>();
+}
+
+#[test]
+fn finite_fake_positive_generated_cases_include_unknown_egress_and_cq_reuse() {
+    generated::partial_reject_reclaims_exact_tokens::<FakeHarness<GOOD>>();
+    generated::repeated_rejects_restore_physical_pool_and_advance_generation::<FakeHarness<GOOD>>();
+    generated::unknown_egress_is_rejected_without_submission::<FakeHarness<GOOD>>();
+    generated::cq_return_releases_same_generated_frame_with_new_generation::<FakeHarness<GOOD>>();
+}
+
+fn assert_detected(case: impl FnOnce()) {
+    assert!(
+        catch_unwind(AssertUnwindSafe(case)).is_err(),
+        "deliberate fake-backend fault escaped conformance"
+    );
+}
+
+#[test]
+fn conformance_detects_a_physical_pool_leak() {
+    assert_detected(rx::repeated_rejects_restore_physical_pool::<FakeHarness<LEAK>>);
+}
+
+#[test]
+fn conformance_detects_live_frame_aliasing() {
+    assert_detected(rx::budget_and_unleased_slots_are_exact::<FakeHarness<ALIAS>>);
+}
+
+#[test]
+fn conformance_detects_stale_generation_after_cq_return() {
+    assert_detected(
+        rx::cq_return_releases_same_rx_frame_with_new_generation::<FakeHarness<STALE_GENERATION>>,
+    );
+}
+
+#[test]
+fn conformance_detects_wrong_descriptor_length() {
+    assert_detected(
+        rx::commit_is_submitted_in_place_with_exact_descriptor::<FakeHarness<WRONG_LENGTH>>,
+    );
+}
+
+#[test]
+fn conformance_detects_publication_on_the_wrong_ring() {
+    assert_detected(
+        rx::commit_is_submitted_in_place_with_exact_descriptor::<FakeHarness<WRONG_RING>>,
+    );
+}
+
+#[test]
+fn conformance_detects_terminal_token_invention() {
+    assert_detected(
+        rx::commit_is_submitted_in_place_with_exact_descriptor::<FakeHarness<TOKEN_INVENTION>>,
+    );
+}

--- a/crates/io-conformance/src/lib.rs
+++ b/crates/io-conformance/src/lib.rs
@@ -9,6 +9,23 @@
 
 use ruster_core::{ConsumeReason, DropReason, GeneratedPacketIo, IfId, PacketIo};
 
+/// Known ingress/egress used by reusable conformance cases.
+pub const CONFORMANCE_LAN: IfId = IfId(11);
+/// Second known ingress/egress used by reusable conformance cases.
+pub const CONFORMANCE_WAN: IfId = IfId(22);
+/// Interface deliberately absent from the backend's publication map.
+pub const CONFORMANCE_UNKNOWN: IfId = IfId(99);
+/// Required publication ring for [`CONFORMANCE_LAN`].
+pub const CONFORMANCE_LAN_ENDPOINT: TxEndpoint = TxEndpoint {
+    interface: CONFORMANCE_LAN,
+    queue: 3,
+};
+/// Required publication ring for [`CONFORMANCE_WAN`].
+pub const CONFORMANCE_WAN_ENDPOINT: TxEndpoint = TxEndpoint {
+    interface: CONFORMANCE_WAN,
+    queue: 7,
+};
+
 /// Backend frame identity plus an ownership-cycle generation.
 ///
 /// `frame_id` identifies physical storage, such as an AF_XDP UMEM frame.
@@ -47,7 +64,8 @@ pub struct TxEndpoint {
 
 /// Independent observer used while the I/O object is mutably borrowed.
 ///
-/// `bind` is called exactly when ownership of a generated allocation begins.
+/// `bind` is called exactly when ownership of an injected RX frame or a
+/// generated allocation begins.
 /// `observe` must return that existing binding and must never invent a new
 /// token for a terminal event.
 pub trait LeaseObserver {
@@ -133,9 +151,12 @@ pub trait RxHarness: Sized {
     fn inject_rx(&mut self, ingress: IfId, bytes: Vec<u8>) -> LiveFrame;
     fn set_rx_accept_budget(&mut self, budget: usize);
     fn pending_rx(&self) -> usize;
-    fn endpoint(&self, egress: IfId) -> Option<TxEndpoint>;
+    /// Drains observations from actual publication and reclamation rings.
+    ///
     /// Rejected/reclaimed events are already reusable; submitted events remain
-    /// in flight until a completion capability advances them.
+    /// in flight until a completion capability advances them. The endpoint of
+    /// a submitted event must identify the ring that received the descriptor,
+    /// not a value inferred from the requested egress afterward.
     fn drain_rx_events(&mut self) -> Vec<RxEvent>;
 }
 
@@ -148,7 +169,7 @@ pub trait RxFinishErrorHarness: RxHarness {
 }
 
 pub trait RxCompletionHarness: RxHarness {
-    /// Advances backend-observed completions for previously submitted tokens.
+    /// Advances CQ-observed completions for previously submitted tokens.
     fn complete_rx_submissions(&mut self) -> Vec<TxCompletion>;
 }
 
@@ -159,9 +180,16 @@ pub trait RxFinitePoolHarness: RxHarness {
     fn free_rx_frames(&self) -> usize;
 }
 
-pub trait RxUnknownEgressHarness: RxHarness {
-    /// Returns an interface that has no backend TX endpoint or ring.
-    fn unknown_rx_egress(&self) -> IfId;
+pub trait RxUnknownEgressHarness: RxHarness {}
+
+pub trait RxCqPoolHarness: RxCompletionHarness + RxFinitePoolHarness {
+    /// Reserves the named physical frame from the real free pool for RX.
+    fn inject_rx_from_free_frame(
+        &mut self,
+        frame_id: u64,
+        ingress: IfId,
+        bytes: Vec<u8>,
+    ) -> LiveFrame;
 }
 
 pub trait GeneratedHarness: Sized {
@@ -173,9 +201,12 @@ pub trait GeneratedHarness: Sized {
     fn set_generated_allocation_budget(&mut self, budget: usize);
     fn set_generated_max_frame(&mut self, max_frame: usize);
     fn set_generated_accept_budget(&mut self, budget: usize);
-    fn endpoint(&self, egress: IfId) -> Option<TxEndpoint>;
+    /// Drains observations from actual publication and reclamation rings.
+    ///
     /// Rejected/reclaimed events are already reusable; submitted events remain
-    /// in flight until a completion capability advances them.
+    /// in flight until a completion capability advances them. The endpoint of
+    /// a submitted event must identify the ring that received the descriptor,
+    /// not a value inferred from the requested egress afterward.
     fn drain_generated_events(&mut self) -> Vec<GeneratedEvent>;
 }
 
@@ -184,7 +215,7 @@ pub trait GeneratedFinishErrorHarness: GeneratedHarness {
 }
 
 pub trait GeneratedCompletionHarness: GeneratedHarness {
-    /// Advances backend-observed completions for previously submitted tokens.
+    /// Advances CQ-observed completions for previously submitted tokens.
     fn complete_generated_submissions(&mut self) -> Vec<TxCompletion>;
 }
 
@@ -194,9 +225,11 @@ pub trait GeneratedFinitePoolHarness: GeneratedHarness {
     fn free_generated_frames(&self) -> usize;
 }
 
-pub trait GeneratedUnknownEgressHarness: GeneratedHarness {
-    /// Returns an interface that has no backend TX endpoint or ring.
-    fn unknown_generated_egress(&self) -> IfId;
+pub trait GeneratedUnknownEgressHarness: GeneratedHarness {}
+
+pub trait GeneratedCqPoolHarness: GeneratedCompletionHarness + GeneratedFinitePoolHarness {
+    /// Makes the next allocation select the named physical free frame.
+    fn prefer_generated_frame(&mut self, frame_id: u64);
 }
 
 pub mod rx {
@@ -205,18 +238,21 @@ pub mod rx {
     use ruster_core::{ConsumeReason, DropReason, IfId, PacketBatch, PacketIo};
 
     use super::{
-        BufferToken, LeaseObserver, LiveFrame, RxCompletionHarness, RxEvent, RxEventKind,
-        RxFinishErrorHarness, RxFinitePoolHarness, RxHarness, RxReceiveErrorHarness, RxReclaim,
-        RxUnknownEgressHarness, TxEndpoint,
+        BufferToken, LeaseObserver, LiveFrame, RxCompletionHarness, RxCqPoolHarness, RxEvent,
+        RxEventKind, RxFinishErrorHarness, RxFinitePoolHarness, RxHarness, RxReceiveErrorHarness,
+        RxReclaim, RxUnknownEgressHarness, TxEndpoint, CONFORMANCE_LAN, CONFORMANCE_LAN_ENDPOINT,
+        CONFORMANCE_UNKNOWN, CONFORMANCE_WAN, CONFORMANCE_WAN_ENDPOINT,
     };
 
-    const LAN: IfId = IfId(11);
-    const WAN: IfId = IfId(22);
+    const LAN: IfId = CONFORMANCE_LAN;
+    const WAN: IfId = CONFORMANCE_WAN;
 
-    fn expected_endpoint<H: RxHarness>(harness: &H, egress: IfId) -> TxEndpoint {
-        harness
-            .endpoint(egress)
-            .expect("known conformance endpoint")
+    fn expected_endpoint(egress: IfId) -> TxEndpoint {
+        match egress {
+            LAN => CONFORMANCE_LAN_ENDPOINT,
+            WAN => CONFORMANCE_WAN_ENDPOINT,
+            _ => panic!("unknown conformance endpoint"),
+        }
     }
 
     fn assert_distinct_live(frames: &[LiveFrame]) {
@@ -325,7 +361,7 @@ pub mod rx {
 
     pub fn commit_is_submitted_in_place_with_exact_descriptor<H: RxHarness>() {
         let mut harness = H::new();
-        let endpoint = expected_endpoint(&harness, WAN);
+        let endpoint = expected_endpoint(WAN);
         let injected = harness.inject_rx(LAN, vec![0x10, 0x20, 0x30]);
         let completion = {
             let (io, observer) = harness.io_and_observer();
@@ -405,7 +441,7 @@ pub mod rx {
     pub fn partial_reject_reclaims_exact_tokens<H: RxHarness>() {
         let mut harness = H::new();
         harness.set_rx_accept_budget(1);
-        let endpoint = expected_endpoint(&harness, WAN);
+        let endpoint = expected_endpoint(WAN);
         let injected = [
             harness.inject_rx(LAN, vec![1, 0x41]),
             harness.inject_rx(LAN, vec![2, 0x42]),
@@ -518,7 +554,7 @@ pub mod rx {
 
     pub fn completion_advances_the_exact_submitted_token<H: RxCompletionHarness>() {
         let mut harness = H::new();
-        let endpoint = expected_endpoint(&harness, WAN);
+        let endpoint = expected_endpoint(WAN);
         let injected = harness.inject_rx(LAN, vec![0x71, 0x72]);
         {
             let (io, observer) = harness.io_and_observer();
@@ -547,11 +583,22 @@ pub mod rx {
         let mut harness = H::new();
         harness.set_rx_accept_budget(0);
         let baseline = harness.free_rx_frames();
+        let mut last_generation = BTreeMap::<u64, u64>::new();
         for cycle in 0_u8..4 {
             let injected = [
                 harness.inject_rx(LAN, vec![cycle, 1]),
                 harness.inject_rx(LAN, vec![cycle, 2]),
             ];
+            for frame in injected {
+                if let Some(previous) =
+                    last_generation.insert(frame.token.frame_id, frame.token.generation)
+                {
+                    assert!(
+                        frame.token.generation > previous,
+                        "reused RX frame did not advance ownership generation"
+                    );
+                }
+            }
             assert_eq!(harness.free_rx_frames() + injected.len(), baseline);
             {
                 let (io, observer) = harness.io_and_observer();
@@ -577,8 +624,7 @@ pub mod rx {
 
     pub fn unknown_egress_is_rejected_without_submission<H: RxUnknownEgressHarness>() {
         let mut harness = H::new();
-        let unknown = harness.unknown_rx_egress();
-        assert!(harness.endpoint(unknown).is_none());
+        let unknown = CONFORMANCE_UNKNOWN;
         let injected = harness.inject_rx(LAN, vec![0x81]);
         let completion = {
             let (io, observer) = harness.io_and_observer();
@@ -602,6 +648,78 @@ pub mod rx {
             }
         );
     }
+
+    pub fn cq_return_releases_same_rx_frame_with_new_generation<H: RxCqPoolHarness>() {
+        let mut harness = H::new();
+        harness.set_rx_accept_budget(1);
+        let baseline = harness.free_rx_frames();
+        assert!(baseline >= 1);
+        let first = harness.inject_rx(LAN, vec![0x91, 0x92]);
+        assert_eq!(harness.free_rx_frames() + 1, baseline);
+        {
+            let (io, observer) = harness.io_and_observer();
+            let mut batch = match io.receive(1) {
+                Ok(batch) => batch,
+                Err(_) => panic!("RX receive failed"),
+            };
+            let mut packet = batch.next_packet().expect("RX lease");
+            assert_eq!(observer.observe(packet.bytes_mut()), first);
+            packet.commit(WAN);
+            assert_eq!(batch.finish().tx_accepted, 1);
+        }
+        let events = harness.drain_rx_events();
+        assert_event_bindings(&[first], &events);
+        assert_eq!(
+            events[0].kind,
+            RxEventKind::TxSubmitted {
+                endpoint: expected_endpoint(WAN),
+                descriptor_len: first.requested_len,
+            }
+        );
+        assert_eq!(
+            harness.free_rx_frames() + 1,
+            baseline,
+            "submitted RX frame returned before CQ observation"
+        );
+        assert_eq!(
+            harness.complete_rx_submissions(),
+            [super::TxCompletion {
+                frame: first,
+                endpoint: expected_endpoint(WAN),
+            }]
+        );
+        assert_eq!(
+            harness.free_rx_frames(),
+            baseline,
+            "CQ-observed RX frame was not returned to the free pool"
+        );
+
+        let second = harness.inject_rx_from_free_frame(first.token.frame_id, LAN, vec![0x93, 0x94]);
+        assert_eq!(second.token.frame_id, first.token.frame_id);
+        assert!(
+            second.token.generation > first.token.generation,
+            "CQ-returned RX frame reused a stale generation"
+        );
+        assert_eq!(harness.free_rx_frames() + 1, baseline);
+        {
+            let (io, observer) = harness.io_and_observer();
+            let mut batch = match io.receive(1) {
+                Ok(batch) => batch,
+                Err(_) => panic!("RX receive failed"),
+            };
+            let mut packet = batch.next_packet().expect("re-leased RX frame");
+            assert_eq!(observer.observe(packet.bytes_mut()), second);
+            packet.recycle(DropReason::RouteMiss);
+            assert_eq!(batch.finish().recycled, 1);
+        }
+        assert_eq!(harness.free_rx_frames(), baseline);
+        let events = harness.drain_rx_events();
+        assert_event_bindings(&[second], &events);
+        assert_eq!(
+            events[0].kind,
+            RxEventKind::Reclaimed(RxReclaim::Recycled(DropReason::RouteMiss))
+        );
+    }
 }
 
 pub mod generated {
@@ -610,18 +728,22 @@ pub mod generated {
     use ruster_core::{GeneratedAllocationError, GeneratedPacketBatch, GeneratedPacketIo, IfId};
 
     use super::{
-        BufferToken, GeneratedCompletionHarness, GeneratedEvent, GeneratedEventKind,
-        GeneratedFinishErrorHarness, GeneratedFinitePoolHarness, GeneratedHarness,
-        GeneratedReclaim, GeneratedUnknownEgressHarness, LeaseObserver, LiveFrame, TxEndpoint,
+        BufferToken, GeneratedCompletionHarness, GeneratedCqPoolHarness, GeneratedEvent,
+        GeneratedEventKind, GeneratedFinishErrorHarness, GeneratedFinitePoolHarness,
+        GeneratedHarness, GeneratedReclaim, GeneratedUnknownEgressHarness, LeaseObserver,
+        LiveFrame, TxEndpoint, CONFORMANCE_LAN, CONFORMANCE_LAN_ENDPOINT, CONFORMANCE_UNKNOWN,
+        CONFORMANCE_WAN, CONFORMANCE_WAN_ENDPOINT,
     };
 
-    const LAN: IfId = IfId(11);
-    const WAN: IfId = IfId(22);
+    const LAN: IfId = CONFORMANCE_LAN;
+    const WAN: IfId = CONFORMANCE_WAN;
 
-    fn expected_endpoint<H: GeneratedHarness>(harness: &H, egress: IfId) -> TxEndpoint {
-        harness
-            .endpoint(egress)
-            .expect("known conformance endpoint")
+    fn expected_endpoint(egress: IfId) -> TxEndpoint {
+        match egress {
+            LAN => CONFORMANCE_LAN_ENDPOINT,
+            WAN => CONFORMANCE_WAN_ENDPOINT,
+            _ => panic!("unknown conformance endpoint"),
+        }
     }
 
     fn assert_distinct_live(frames: &[LiveFrame]) {
@@ -741,7 +863,7 @@ pub mod generated {
         let mut harness = H::new();
         harness.set_generated_max_frame(64);
         harness.set_generated_allocation_budget(3);
-        let endpoint = expected_endpoint(&harness, WAN);
+        let endpoint = expected_endpoint(WAN);
         let mut live = Vec::new();
         let completion = {
             let (io, observer) = harness.io_and_observer();
@@ -806,7 +928,7 @@ pub mod generated {
         let mut harness = H::new();
         harness.set_generated_allocation_budget(3);
         harness.set_generated_accept_budget(1);
-        let endpoint = expected_endpoint(&harness, WAN);
+        let endpoint = expected_endpoint(WAN);
         let mut live = Vec::new();
         let completion = {
             let (io, observer) = harness.io_and_observer();
@@ -855,8 +977,8 @@ pub mod generated {
         let mut harness = H::new();
         harness.set_generated_allocation_budget(1);
         let expected = [
-            (LAN, expected_endpoint(&harness, LAN), 1_u8),
-            (WAN, expected_endpoint(&harness, WAN), 2_u8),
+            (LAN, expected_endpoint(LAN), 1_u8),
+            (WAN, expected_endpoint(WAN), 2_u8),
         ];
         let mut live = Vec::new();
         for (egress, _, marker) in expected {
@@ -916,7 +1038,7 @@ pub mod generated {
     pub fn completion_advances_the_exact_submitted_token<H: GeneratedCompletionHarness>() {
         let mut harness = H::new();
         harness.set_generated_allocation_budget(1);
-        let endpoint = expected_endpoint(&harness, WAN);
+        let endpoint = expected_endpoint(WAN);
         let frame = {
             let (io, observer) = harness.io_and_observer();
             let mut batch = io.begin_generated(WAN);
@@ -980,8 +1102,7 @@ pub mod generated {
     pub fn unknown_egress_is_rejected_without_submission<H: GeneratedUnknownEgressHarness>() {
         let mut harness = H::new();
         harness.set_generated_allocation_budget(1);
-        let unknown = harness.unknown_generated_egress();
-        assert!(harness.endpoint(unknown).is_none());
+        let unknown = CONFORMANCE_UNKNOWN;
         let frame = {
             let (io, observer) = harness.io_and_observer();
             let mut batch = io.begin_generated(unknown);
@@ -1003,4 +1124,78 @@ pub mod generated {
             }
         );
     }
+
+    pub fn cq_return_releases_same_generated_frame_with_new_generation<
+        H: GeneratedCqPoolHarness,
+    >() {
+        let mut harness = H::new();
+        harness.set_generated_allocation_budget(1);
+        harness.set_generated_accept_budget(1);
+        let baseline = harness.free_generated_frames();
+        assert!(baseline >= 1);
+        let first = {
+            let (io, observer) = harness.io_and_observer();
+            let mut batch = io.begin_generated(WAN);
+            let mut packet = batch.allocate(60).expect("generated allocation");
+            packet.bytes_mut().fill(0xb1);
+            let frame = observer.bind(packet.bytes_mut(), 60);
+            packet.commit();
+            assert_eq!(batch.finish().accepted, 1);
+            frame
+        };
+        let events = harness.drain_generated_events();
+        assert_event_bindings(&[first], &events);
+        assert_eq!(
+            events[0].kind,
+            GeneratedEventKind::TxSubmitted {
+                endpoint: expected_endpoint(WAN),
+                descriptor_len: first.requested_len,
+            }
+        );
+        assert_eq!(
+            harness.free_generated_frames() + 1,
+            baseline,
+            "submitted generated frame returned before CQ observation"
+        );
+        assert_eq!(
+            harness.complete_generated_submissions(),
+            [super::TxCompletion {
+                frame: first,
+                endpoint: expected_endpoint(WAN),
+            }]
+        );
+        assert_eq!(
+            harness.free_generated_frames(),
+            baseline,
+            "CQ-observed generated frame was not returned to the free pool"
+        );
+
+        harness.prefer_generated_frame(first.token.frame_id);
+        harness.set_generated_allocation_budget(1);
+        let second = {
+            let (io, observer) = harness.io_and_observer();
+            let mut batch = io.begin_generated(WAN);
+            let mut packet = batch.allocate(60).expect("re-leased generated frame");
+            packet.bytes_mut().fill(0xb2);
+            let frame = observer.bind(packet.bytes_mut(), 60);
+            packet.cancel();
+            assert_eq!(batch.finish().cancelled, 1);
+            frame
+        };
+        assert_eq!(second.token.frame_id, first.token.frame_id);
+        assert!(
+            second.token.generation > first.token.generation,
+            "CQ-returned generated frame reused a stale generation"
+        );
+        assert_eq!(harness.free_generated_frames(), baseline);
+        let events = harness.drain_generated_events();
+        assert_event_bindings(&[second], &events);
+        assert_eq!(
+            events[0].kind,
+            GeneratedEventKind::Reclaimed(GeneratedReclaim::Cancelled)
+        );
+    }
 }
+
+#[cfg(test)]
+mod finite_fake_tests;

--- a/crates/io-conformance/src/lib.rs
+++ b/crates/io-conformance/src/lib.rs
@@ -1,0 +1,744 @@
+#![forbid(unsafe_code)]
+#![doc = "Reusable, deterministic conformance cases for ruster packet I/O backends."]
+
+use ruster_core::{ConsumeReason, DropReason, GeneratedPacketIo, IfId, PacketIo};
+
+/// Stable identity for one backend-owned buffer during an ownership cycle.
+///
+/// A backend may reuse the value only after the corresponding frame has been
+/// reclaimed. AF_XDP harnesses should derive it from the UMEM frame index or
+/// address, rather than packet contents.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct BufferToken(u64);
+
+impl BufferToken {
+    #[must_use]
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Identity returned when a test frame enters an RX backend-owned buffer.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct InjectedFrame {
+    pub token: BufferToken,
+    pub allocation_address: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RxDisposition {
+    Accepted { egress: IfId },
+    Recycled { reason: DropReason },
+    Consumed { reason: ConsumeReason },
+    Abandoned,
+    Rejected,
+}
+
+/// One terminal RX-buffer observation, moved out of the backend test adapter.
+#[derive(Debug, Eq, PartialEq)]
+pub struct RxOutcome {
+    pub token: BufferToken,
+    pub allocation_address: usize,
+    pub ingress: IfId,
+    pub bytes: Vec<u8>,
+    pub disposition: RxDisposition,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GeneratedDisposition {
+    Accepted,
+    Cancelled,
+    Abandoned,
+    Rejected,
+}
+
+/// One terminal generated-buffer observation.
+#[derive(Debug, Eq, PartialEq)]
+pub struct GeneratedOutcome {
+    pub token: BufferToken,
+    pub allocation_address: usize,
+    pub egress: IfId,
+    pub bytes: Vec<u8>,
+    pub disposition: GeneratedDisposition,
+}
+
+/// Test-only control and observation boundary for mandatory RX behavior.
+///
+/// The associated I/O object remains concrete, so conformance cases use
+/// static dispatch and never place a trait object in the packet path.
+pub trait RxHarness: Sized {
+    type Io: PacketIo;
+
+    fn new() -> Self;
+    fn io(&mut self) -> &mut Self::Io;
+    fn inject_rx(&mut self, ingress: IfId, bytes: Vec<u8>) -> InjectedFrame;
+    fn set_rx_accept_budget(&mut self, budget: usize);
+    fn pending_rx(&self) -> usize;
+    fn drain_rx_outcomes(&mut self) -> Vec<RxOutcome>;
+}
+
+/// Optional RX receive-error fault injection.
+pub trait RxReceiveErrorHarness: RxHarness {
+    fn fail_next_receive(&mut self);
+}
+
+/// Optional RX finish-error fault injection.
+pub trait RxFinishErrorHarness: RxHarness {
+    fn fail_next_rx_finish(&mut self);
+}
+
+/// Test-only control and observation boundary for generated TX behavior.
+pub trait GeneratedHarness: Sized {
+    type Io: GeneratedPacketIo;
+
+    fn new() -> Self;
+    fn io(&mut self) -> &mut Self::Io;
+    fn set_generated_allocation_budget(&mut self, budget: usize);
+    fn set_generated_max_frame(&mut self, max_frame: usize);
+    fn set_generated_accept_budget(&mut self, budget: usize);
+    fn drain_generated_outcomes(&mut self) -> Vec<GeneratedOutcome>;
+}
+
+/// Optional generated finish-error fault injection.
+pub trait GeneratedFinishErrorHarness: GeneratedHarness {
+    fn fail_next_generated_finish(&mut self);
+}
+
+pub mod rx {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    use ruster_core::{ConsumeReason, DropReason, IfId, PacketBatch, PacketIo};
+
+    use super::{
+        BufferToken, InjectedFrame, RxDisposition, RxFinishErrorHarness, RxHarness, RxOutcome,
+        RxReceiveErrorHarness,
+    };
+
+    const LAN: IfId = IfId(11);
+    const WAN: IfId = IfId(22);
+
+    fn receive<H: RxHarness>(harness: &mut H, budget: usize) -> <H::Io as PacketIo>::Batch<'_> {
+        match harness.io().receive(budget) {
+            Ok(batch) => batch,
+            Err(_) => panic!("RX conformance setup unexpectedly failed receive"),
+        }
+    }
+
+    fn injected_map(frames: &[InjectedFrame]) -> BTreeMap<BufferToken, usize> {
+        frames
+            .iter()
+            .map(|frame| (frame.token, frame.allocation_address))
+            .collect()
+    }
+
+    fn assert_exact_rx_ownership(expected: &[InjectedFrame], outcomes: &[RxOutcome]) {
+        let expected = injected_map(expected);
+        assert_eq!(outcomes.len(), expected.len());
+        let mut observed = BTreeSet::new();
+        for outcome in outcomes {
+            assert!(
+                observed.insert(outcome.token),
+                "duplicate RX terminal token"
+            );
+            assert_eq!(
+                expected.get(&outcome.token),
+                Some(&outcome.allocation_address),
+                "RX allocation identity changed or an unknown token appeared"
+            );
+        }
+        assert_eq!(
+            observed,
+            expected.keys().copied().collect(),
+            "RX token was lost"
+        );
+    }
+
+    pub fn budget_and_unleased_slots_are_exact<H: RxHarness>() {
+        let mut harness = H::new();
+        let injected = [
+            harness.inject_rx(LAN, vec![1, 0xa1]),
+            harness.inject_rx(LAN, vec![2, 0xa2]),
+            harness.inject_rx(LAN, vec![3, 0xa3]),
+        ];
+
+        let completion = {
+            let mut batch = receive(&mut harness, 0);
+            assert!(batch.next_packet().is_none());
+            batch.finish()
+        };
+        assert!(completion.invariants_hold());
+        assert_eq!(
+            (
+                completion.tx_requested,
+                completion.tx_accepted,
+                completion.tx_rejected,
+                completion.recycled,
+            ),
+            (0, 0, 0, 0)
+        );
+        assert_eq!(harness.pending_rx(), 3);
+
+        let completion = {
+            let mut batch = receive(&mut harness, 2);
+            let mut leased = 0;
+            while let Some(packet) = batch.next_packet() {
+                packet.recycle(DropReason::RouteMiss);
+                leased += 1;
+            }
+            assert_eq!(leased, 2);
+            batch.finish()
+        };
+        assert_eq!(completion.recycled, 2);
+        assert_eq!(harness.pending_rx(), 1);
+
+        let completion = {
+            let mut batch = receive(&mut harness, usize::MAX);
+            let packet = batch.next_packet().expect("unleased RX slot");
+            packet.recycle(DropReason::RouteMiss);
+            assert!(batch.next_packet().is_none());
+            batch.finish()
+        };
+        assert_eq!(completion.recycled, 1);
+        assert_eq!(harness.pending_rx(), 0);
+
+        let outcomes = harness.drain_rx_outcomes();
+        assert_exact_rx_ownership(&injected, &outcomes);
+        assert!(outcomes.iter().all(|outcome| {
+            outcome.disposition
+                == RxDisposition::Recycled {
+                    reason: DropReason::RouteMiss,
+                }
+        }));
+    }
+
+    pub fn commit_is_in_place_and_egress_typed<H: RxHarness>() {
+        let mut harness = H::new();
+        let injected = harness.inject_rx(LAN, vec![0x10, 0x20, 0x30]);
+        let completion = {
+            let mut batch = receive(&mut harness, 1);
+            let mut packet = batch.next_packet().expect("one RX lease");
+            assert_eq!(packet.ingress(), LAN);
+            let bytes = packet.bytes_mut();
+            assert_eq!(bytes.as_ptr() as usize, injected.allocation_address);
+            bytes[1] = 0x99;
+            packet.commit(WAN);
+            batch.finish()
+        };
+        assert!(completion.invariants_hold());
+        assert_eq!(
+            (
+                completion.tx_requested,
+                completion.tx_accepted,
+                completion.tx_rejected,
+                completion.recycled,
+            ),
+            (1, 1, 0, 0)
+        );
+        let outcomes = harness.drain_rx_outcomes();
+        assert_exact_rx_ownership(&[injected], &outcomes);
+        assert_eq!(outcomes[0].bytes, [0x10, 0x99, 0x30]);
+        assert_eq!(
+            outcomes[0].disposition,
+            RxDisposition::Accepted { egress: WAN }
+        );
+    }
+
+    pub fn recycle_consume_and_abandon_are_distinct<H: RxHarness>() {
+        let mut harness = H::new();
+        let injected = [
+            harness.inject_rx(LAN, vec![1, 0x11]),
+            harness.inject_rx(LAN, vec![2, 0x22]),
+            harness.inject_rx(LAN, vec![3, 0x33]),
+        ];
+        let completion = {
+            let mut batch = receive(&mut harness, 3);
+            while let Some(mut packet) = batch.next_packet() {
+                match packet.bytes_mut()[0] {
+                    1 => packet.recycle(DropReason::NeighborUnresolved),
+                    2 => packet.consume(ConsumeReason::ArpControl),
+                    3 => drop(packet),
+                    _ => panic!("unexpected RX marker"),
+                }
+            }
+            batch.finish()
+        };
+        assert!(completion.invariants_hold());
+        assert_eq!(
+            (
+                completion.tx_requested,
+                completion.tx_accepted,
+                completion.tx_rejected,
+                completion.recycled,
+            ),
+            (0, 0, 0, 3)
+        );
+
+        let outcomes = harness.drain_rx_outcomes();
+        assert_exact_rx_ownership(&injected, &outcomes);
+        for outcome in outcomes {
+            let expected = match outcome.bytes[0] {
+                1 => RxDisposition::Recycled {
+                    reason: DropReason::NeighborUnresolved,
+                },
+                2 => RxDisposition::Consumed {
+                    reason: ConsumeReason::ArpControl,
+                },
+                3 => RxDisposition::Abandoned,
+                _ => panic!("unexpected RX marker"),
+            };
+            assert_eq!(outcome.disposition, expected);
+        }
+    }
+
+    pub fn partial_reject_reclaims_exactly_before_finish_returns<H: RxHarness>() {
+        let mut harness = H::new();
+        harness.set_rx_accept_budget(1);
+        let injected = [
+            harness.inject_rx(LAN, vec![1, 0x41]),
+            harness.inject_rx(LAN, vec![2, 0x42]),
+            harness.inject_rx(LAN, vec![3, 0x43]),
+        ];
+        let completion = {
+            let mut batch = receive(&mut harness, 3);
+            while let Some(packet) = batch.next_packet() {
+                packet.commit(WAN);
+            }
+            batch.finish()
+        };
+        assert!(completion.invariants_hold());
+        assert_eq!(
+            (
+                completion.tx_requested,
+                completion.tx_accepted,
+                completion.tx_rejected,
+                completion.recycled,
+            ),
+            (3, 1, 2, 0)
+        );
+
+        let outcomes = harness.drain_rx_outcomes();
+        assert_exact_rx_ownership(&injected, &outcomes);
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|outcome| matches!(outcome.disposition, RxDisposition::Accepted { .. }))
+                .count(),
+            1
+        );
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|outcome| outcome.disposition == RxDisposition::Rejected)
+                .count(),
+            2
+        );
+    }
+
+    pub fn repeated_reject_cycles_conserve_rx_ownership<H: RxHarness>() {
+        let mut harness = H::new();
+        harness.set_rx_accept_budget(0);
+        for cycle in 0_u8..4 {
+            let injected = [
+                harness.inject_rx(LAN, vec![cycle, 1]),
+                harness.inject_rx(LAN, vec![cycle, 2]),
+            ];
+            let completion = {
+                let mut batch = receive(&mut harness, 2);
+                while let Some(packet) = batch.next_packet() {
+                    packet.commit(WAN);
+                }
+                batch.finish()
+            };
+            assert!(completion.invariants_hold());
+            assert_eq!(
+                (
+                    completion.tx_requested,
+                    completion.tx_accepted,
+                    completion.tx_rejected,
+                    completion.recycled,
+                ),
+                (2, 0, 2, 0)
+            );
+            let outcomes = harness.drain_rx_outcomes();
+            assert_exact_rx_ownership(&injected, &outcomes);
+            assert!(outcomes
+                .iter()
+                .all(|outcome| outcome.disposition == RxDisposition::Rejected));
+        }
+    }
+
+    pub fn receive_error_preserves_queued_ownership<H: RxReceiveErrorHarness>() {
+        let mut harness = H::new();
+        let injected = harness.inject_rx(LAN, vec![0x51, 0x52]);
+        harness.fail_next_receive();
+        assert!(harness.io().receive(1).is_err());
+        assert_eq!(harness.pending_rx(), 1);
+
+        let completion = {
+            let mut batch = receive(&mut harness, 1);
+            batch
+                .next_packet()
+                .expect("RX slot survives receive error")
+                .recycle(DropReason::RouteMiss);
+            batch.finish()
+        };
+        assert_eq!(completion.recycled, 1);
+        let outcomes = harness.drain_rx_outcomes();
+        assert_exact_rx_ownership(&[injected], &outcomes);
+    }
+
+    pub fn partial_reject_with_finish_error_is_exact<H: RxFinishErrorHarness>() {
+        let mut harness = H::new();
+        harness.set_rx_accept_budget(1);
+        harness.fail_next_rx_finish();
+        let injected = [
+            harness.inject_rx(LAN, vec![0x61]),
+            harness.inject_rx(LAN, vec![0x62]),
+            harness.inject_rx(LAN, vec![0x63]),
+        ];
+        let completion = {
+            let mut batch = receive(&mut harness, 3);
+            while let Some(packet) = batch.next_packet() {
+                packet.commit(WAN);
+            }
+            batch.finish()
+        };
+        assert!(completion.invariants_hold());
+        assert_eq!(
+            (
+                completion.tx_requested,
+                completion.tx_accepted,
+                completion.tx_rejected,
+                completion.recycled,
+            ),
+            (3, 1, 2, 0)
+        );
+        assert!(completion.error.is_some());
+        let outcomes = harness.drain_rx_outcomes();
+        assert_exact_rx_ownership(&injected, &outcomes);
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|outcome| outcome.disposition == RxDisposition::Rejected)
+                .count(),
+            2
+        );
+    }
+}
+
+pub mod generated {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    use ruster_core::{GeneratedAllocationError, GeneratedPacketBatch, GeneratedPacketIo, IfId};
+
+    use super::{
+        GeneratedDisposition, GeneratedFinishErrorHarness, GeneratedHarness, GeneratedOutcome,
+    };
+
+    const LAN: IfId = IfId(11);
+    const WAN: IfId = IfId(22);
+
+    fn assert_exact_generated_ownership(
+        expected_addresses: &BTreeMap<u8, usize>,
+        outcomes: &[GeneratedOutcome],
+    ) {
+        assert_eq!(outcomes.len(), expected_addresses.len());
+        let mut tokens = BTreeSet::new();
+        for outcome in outcomes {
+            assert!(
+                tokens.insert(outcome.token),
+                "duplicate generated terminal token"
+            );
+            let marker = outcome.bytes[0];
+            assert_eq!(
+                expected_addresses.get(&marker),
+                Some(&outcome.allocation_address),
+                "generated allocation identity changed"
+            );
+        }
+    }
+
+    pub fn empty_session_has_zero_accounting<H: GeneratedHarness>() {
+        let mut harness = H::new();
+        let completion = harness.io().begin_generated(WAN).finish();
+        assert!(completion.invariants_hold());
+        assert_eq!(
+            (
+                completion.attempts,
+                completion.allocated,
+                completion.failed,
+                completion.requested,
+                completion.cancelled,
+                completion.abandoned,
+                completion.accepted,
+                completion.rejected,
+            ),
+            (0, 0, 0, 0, 0, 0, 0, 0)
+        );
+        assert!(completion.error.is_none());
+        assert!(harness.drain_generated_outcomes().is_empty());
+    }
+
+    pub fn allocation_failures_are_typed_and_transfer_no_ownership<H: GeneratedHarness>() {
+        let mut harness = H::new();
+        harness.set_generated_max_frame(64);
+        harness.set_generated_allocation_budget(1);
+        let mut addresses = BTreeMap::new();
+        let completion = {
+            let mut batch = harness.io().begin_generated(WAN);
+            assert!(matches!(
+                batch.allocate(0),
+                Err(GeneratedAllocationError::ZeroLength)
+            ));
+            assert!(matches!(
+                batch.allocate(65),
+                Err(GeneratedAllocationError::FrameTooLarge)
+            ));
+            let mut valid = batch
+                .allocate(64)
+                .expect("invalid requests must not consume allocation budget");
+            valid.bytes_mut().fill(7);
+            addresses.insert(7, valid.bytes_mut().as_ptr() as usize);
+            valid.cancel();
+            assert!(matches!(
+                batch.allocate(64),
+                Err(GeneratedAllocationError::Unavailable)
+            ));
+            batch.finish()
+        };
+        assert!(completion.invariants_hold());
+        assert_eq!(
+            (
+                completion.attempts,
+                completion.allocated,
+                completion.failed,
+                completion.requested,
+                completion.cancelled,
+                completion.abandoned,
+                completion.accepted,
+                completion.rejected,
+            ),
+            (4, 1, 3, 0, 1, 0, 0, 0)
+        );
+        let outcomes = harness.drain_generated_outcomes();
+        assert_exact_generated_ownership(&addresses, &outcomes);
+        assert_eq!(outcomes[0].disposition, GeneratedDisposition::Cancelled);
+    }
+
+    pub fn commit_cancel_and_abandon_are_exact_length_and_distinct<H: GeneratedHarness>() {
+        let mut harness = H::new();
+        harness.set_generated_max_frame(64);
+        harness.set_generated_allocation_budget(3);
+        let mut addresses = BTreeMap::new();
+        let completion = {
+            let mut batch = harness.io().begin_generated(WAN);
+
+            let mut committed = batch.allocate(60).expect("generated commit allocation");
+            assert_eq!(committed.bytes_mut().len(), 60);
+            committed.bytes_mut().fill(0);
+            committed.bytes_mut()[0] = 1;
+            addresses.insert(1, committed.bytes_mut().as_ptr() as usize);
+            committed.commit();
+
+            let mut cancelled = batch.allocate(61).expect("generated cancel allocation");
+            assert_eq!(cancelled.bytes_mut().len(), 61);
+            cancelled.bytes_mut().fill(0);
+            cancelled.bytes_mut()[0] = 2;
+            addresses.insert(2, cancelled.bytes_mut().as_ptr() as usize);
+            cancelled.cancel();
+
+            let mut abandoned = batch.allocate(62).expect("generated abandon allocation");
+            assert_eq!(abandoned.bytes_mut().len(), 62);
+            abandoned.bytes_mut().fill(0);
+            abandoned.bytes_mut()[0] = 3;
+            addresses.insert(3, abandoned.bytes_mut().as_ptr() as usize);
+            drop(abandoned);
+
+            batch.finish()
+        };
+        assert!(completion.invariants_hold());
+        assert_eq!(
+            (
+                completion.attempts,
+                completion.allocated,
+                completion.failed,
+                completion.requested,
+                completion.cancelled,
+                completion.abandoned,
+                completion.accepted,
+                completion.rejected,
+            ),
+            (3, 3, 0, 1, 1, 1, 1, 0)
+        );
+
+        let outcomes = harness.drain_generated_outcomes();
+        assert_exact_generated_ownership(&addresses, &outcomes);
+        for outcome in outcomes {
+            let expected = match outcome.bytes[0] {
+                1 => GeneratedDisposition::Accepted,
+                2 => GeneratedDisposition::Cancelled,
+                3 => GeneratedDisposition::Abandoned,
+                _ => panic!("unexpected generated marker"),
+            };
+            assert_eq!(outcome.disposition, expected);
+            assert_eq!(outcome.egress, WAN);
+        }
+    }
+
+    pub fn partial_reject_reclaims_exactly_before_finish_returns<H: GeneratedHarness>() {
+        let mut harness = H::new();
+        harness.set_generated_allocation_budget(3);
+        harness.set_generated_accept_budget(1);
+        let mut addresses = BTreeMap::new();
+        let completion = {
+            let mut batch = harness.io().begin_generated(WAN);
+            for marker in 1_u8..=3 {
+                let mut packet = batch.allocate(60).expect("generated allocation");
+                packet.bytes_mut().fill(marker);
+                addresses.insert(marker, packet.bytes_mut().as_ptr() as usize);
+                packet.commit();
+            }
+            batch.finish()
+        };
+        assert!(completion.invariants_hold());
+        assert_eq!(
+            (
+                completion.attempts,
+                completion.allocated,
+                completion.failed,
+                completion.requested,
+                completion.cancelled,
+                completion.abandoned,
+                completion.accepted,
+                completion.rejected,
+            ),
+            (3, 3, 0, 3, 0, 0, 1, 2)
+        );
+        let outcomes = harness.drain_generated_outcomes();
+        assert_exact_generated_ownership(&addresses, &outcomes);
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|outcome| outcome.disposition == GeneratedDisposition::Accepted)
+                .count(),
+            1
+        );
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|outcome| outcome.disposition == GeneratedDisposition::Rejected)
+                .count(),
+            2
+        );
+    }
+
+    pub fn sessions_pin_egress_without_cross_talk<H: GeneratedHarness>() {
+        let mut harness = H::new();
+        harness.set_generated_allocation_budget(1);
+        for (egress, marker) in [(LAN, 1_u8), (WAN, 2_u8)] {
+            let completion = {
+                let mut batch = harness.io().begin_generated(egress);
+                let mut packet = batch.allocate(60).expect("generated allocation");
+                packet.bytes_mut().fill(marker);
+                packet.commit();
+                batch.finish()
+            };
+            assert_eq!(completion.accepted, 1);
+        }
+        let outcomes = harness.drain_generated_outcomes();
+        assert_eq!(outcomes.len(), 2);
+        for outcome in outcomes {
+            let expected = match outcome.bytes[0] {
+                1 => LAN,
+                2 => WAN,
+                _ => panic!("unexpected generated marker"),
+            };
+            assert_eq!(outcome.egress, expected);
+            assert_eq!(outcome.disposition, GeneratedDisposition::Accepted);
+        }
+    }
+
+    pub fn repeated_reject_cycles_conserve_generated_pool<H: GeneratedHarness>() {
+        let mut harness = H::new();
+        harness.set_generated_allocation_budget(2);
+        harness.set_generated_accept_budget(0);
+        for cycle in 0_u8..4 {
+            let mut addresses = BTreeMap::new();
+            let completion = {
+                let mut batch = harness.io().begin_generated(WAN);
+                for slot in 1_u8..=2 {
+                    let marker = cycle * 2 + slot;
+                    let mut packet = batch.allocate(60).expect("pool capacity leaked");
+                    packet.bytes_mut().fill(marker);
+                    addresses.insert(marker, packet.bytes_mut().as_ptr() as usize);
+                    packet.commit();
+                }
+                batch.finish()
+            };
+            assert!(completion.invariants_hold());
+            assert_eq!(
+                (
+                    completion.attempts,
+                    completion.allocated,
+                    completion.failed,
+                    completion.requested,
+                    completion.accepted,
+                    completion.rejected,
+                ),
+                (2, 2, 0, 2, 0, 2)
+            );
+            let outcomes = harness.drain_generated_outcomes();
+            assert_exact_generated_ownership(&addresses, &outcomes);
+            assert!(outcomes
+                .iter()
+                .all(|outcome| outcome.disposition == GeneratedDisposition::Rejected));
+        }
+    }
+
+    pub fn partial_reject_with_finish_error_is_exact<H: GeneratedFinishErrorHarness>() {
+        let mut harness = H::new();
+        harness.set_generated_allocation_budget(3);
+        harness.set_generated_accept_budget(1);
+        harness.fail_next_generated_finish();
+        let mut addresses = BTreeMap::new();
+        let completion = {
+            let mut batch = harness.io().begin_generated(WAN);
+            for marker in 1_u8..=3 {
+                let mut packet = batch.allocate(60).expect("generated allocation");
+                packet.bytes_mut().fill(marker);
+                addresses.insert(marker, packet.bytes_mut().as_ptr() as usize);
+                packet.commit();
+            }
+            batch.finish()
+        };
+        assert!(completion.invariants_hold());
+        assert_eq!(
+            (
+                completion.attempts,
+                completion.allocated,
+                completion.failed,
+                completion.requested,
+                completion.cancelled,
+                completion.abandoned,
+                completion.accepted,
+                completion.rejected,
+            ),
+            (3, 3, 0, 3, 0, 0, 1, 2)
+        );
+        assert!(completion.error.is_some());
+        let outcomes = harness.drain_generated_outcomes();
+        assert_exact_generated_ownership(&addresses, &outcomes);
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|outcome| outcome.disposition == GeneratedDisposition::Rejected)
+                .count(),
+            2
+        );
+    }
+}

--- a/crates/io-conformance/src/lib.rs
+++ b/crates/io-conformance/src/lib.rs
@@ -720,6 +720,113 @@ pub mod rx {
             RxEventKind::Reclaimed(RxReclaim::Recycled(DropReason::RouteMiss))
         );
     }
+
+    pub fn dropped_batch_preserves_unleased_rx_and_cq_ownership<H: RxCqPoolHarness>() {
+        let mut harness = H::new();
+        harness.set_rx_accept_budget(1);
+        let baseline = harness.free_rx_frames();
+        assert!(baseline >= 3);
+        let injected = [
+            harness.inject_rx(LAN, vec![0xc1]),
+            harness.inject_rx(LAN, vec![0xc2]),
+            harness.inject_rx(LAN, vec![0xc3]),
+        ];
+        assert_distinct_live(&injected);
+        assert_eq!(harness.free_rx_frames() + injected.len(), baseline);
+
+        {
+            let (io, observer) = harness.io_and_observer();
+            let mut batch = match io.receive(3) {
+                Ok(batch) => batch,
+                Err(_) => panic!("RX receive failed"),
+            };
+            let mut packet = batch.next_packet().expect("committed RX lease");
+            assert_eq!(observer.observe(packet.bytes_mut()), injected[0]);
+            packet.commit(WAN);
+            drop(batch);
+        }
+
+        let terminal = harness.drain_rx_events();
+        assert_event_bindings(&injected[..1], &terminal);
+        let submitted = match terminal[0].kind {
+            RxEventKind::TxSubmitted {
+                endpoint,
+                descriptor_len,
+            } => {
+                assert_eq!(endpoint, expected_endpoint(WAN));
+                assert_eq!(descriptor_len, injected[0].requested_len);
+                assert_eq!(
+                    harness.free_rx_frames() + injected.len(),
+                    baseline,
+                    "batch drop returned a published RX frame before CQ"
+                );
+                true
+            }
+            RxEventKind::TxRejected {
+                attempted_egress,
+                endpoint,
+            } => {
+                assert_eq!(attempted_egress, WAN);
+                assert_eq!(endpoint, Some(expected_endpoint(WAN)));
+                assert_eq!(harness.free_rx_frames() + 2, baseline);
+                false
+            }
+            RxEventKind::Reclaimed(_) => panic!("committed RX lease lost its TX disposition"),
+        };
+        assert_eq!(
+            harness.pending_rx(),
+            2,
+            "batch drop lost or exposed unleased RX ownership"
+        );
+
+        let mut reobserved = Vec::new();
+        {
+            let (io, observer) = harness.io_and_observer();
+            let mut batch = match io.receive(2) {
+                Ok(batch) => batch,
+                Err(_) => panic!("unleased RX retry failed"),
+            };
+            while let Some(mut packet) = batch.next_packet() {
+                reobserved.push(observer.observe(packet.bytes_mut()));
+                packet.recycle(DropReason::RouteMiss);
+            }
+            assert_eq!(batch.finish().recycled, 2);
+        }
+        assert_eq!(
+            reobserved
+                .iter()
+                .map(|frame| frame.token)
+                .collect::<BTreeSet<_>>(),
+            injected[1..]
+                .iter()
+                .map(|frame| frame.token)
+                .collect::<BTreeSet<_>>(),
+            "batch drop changed unleased RX ownership"
+        );
+        let reclaimed = harness.drain_rx_events();
+        assert_event_bindings(&injected[1..], &reclaimed);
+        assert!(reclaimed.iter().all(|event| {
+            event.kind == RxEventKind::Reclaimed(RxReclaim::Recycled(DropReason::RouteMiss))
+        }));
+
+        let completions = harness.complete_rx_submissions();
+        if submitted {
+            assert_eq!(
+                completions,
+                [super::TxCompletion {
+                    frame: injected[0],
+                    endpoint: expected_endpoint(WAN),
+                }]
+            );
+        } else {
+            assert!(completions.is_empty());
+        }
+        assert_eq!(
+            harness.free_rx_frames(),
+            baseline,
+            "batch-drop lifecycle did not restore the physical RX pool"
+        );
+    }
 }
 
 pub mod generated {
@@ -1193,6 +1300,114 @@ pub mod generated {
         assert_eq!(
             events[0].kind,
             GeneratedEventKind::Reclaimed(GeneratedReclaim::Cancelled)
+        );
+    }
+
+    pub fn dropped_batch_accounts_generated_and_cannot_carry_to_next_egress<
+        H: GeneratedCqPoolHarness,
+    >() {
+        let mut harness = H::new();
+        harness.set_generated_allocation_budget(3);
+        harness.set_generated_accept_budget(1);
+        let baseline = harness.free_generated_frames();
+        assert!(baseline >= 3);
+        let mut live = Vec::new();
+        {
+            let (io, observer) = harness.io_and_observer();
+            let mut batch = io.begin_generated(WAN);
+            for (marker, terminal) in [(0xd1_u8, 0_u8), (0xd2, 1), (0xd3, 2)] {
+                let mut packet = batch.allocate(60).expect("generated allocation");
+                packet.bytes_mut().fill(marker);
+                live.push(observer.bind(packet.bytes_mut(), 60));
+                match terminal {
+                    0 => packet.commit(),
+                    1 => packet.cancel(),
+                    2 => drop(packet),
+                    _ => unreachable!(),
+                }
+            }
+            drop(batch);
+        }
+        assert_distinct_cycles(&live);
+        let events = harness.drain_generated_events();
+        assert_event_bindings(&live, &events);
+        let mut submitted = false;
+        for event in events {
+            let expected = match event.bytes[0] {
+                0xd1 => match event.kind {
+                    GeneratedEventKind::TxSubmitted {
+                        endpoint,
+                        descriptor_len,
+                    } => {
+                        assert_eq!(endpoint, expected_endpoint(WAN));
+                        assert_eq!(descriptor_len, live[0].requested_len);
+                        submitted = true;
+                        continue;
+                    }
+                    GeneratedEventKind::TxRejected {
+                        attempted_egress,
+                        endpoint,
+                    } => {
+                        assert_eq!(attempted_egress, WAN);
+                        assert_eq!(endpoint, Some(expected_endpoint(WAN)));
+                        continue;
+                    }
+                    GeneratedEventKind::Reclaimed(_) => {
+                        panic!("committed generated lease lost its TX disposition")
+                    }
+                },
+                0xd2 => GeneratedEventKind::Reclaimed(GeneratedReclaim::Cancelled),
+                0xd3 => GeneratedEventKind::Reclaimed(GeneratedReclaim::Abandoned),
+                _ => panic!("unexpected generated marker"),
+            };
+            assert_eq!(event.kind, expected);
+        }
+        assert_eq!(
+            harness.free_generated_frames() + usize::from(submitted),
+            baseline,
+            "generated batch drop lost a frame or returned an in-flight frame"
+        );
+
+        harness.set_generated_allocation_budget(0);
+        let next = {
+            let (io, _) = harness.io_and_observer();
+            io.begin_generated(LAN).finish()
+        };
+        assert_eq!(
+            (
+                next.attempts,
+                next.allocated,
+                next.failed,
+                next.requested,
+                next.cancelled,
+                next.abandoned,
+                next.accepted,
+                next.rejected,
+            ),
+            (0, 0, 0, 0, 0, 0, 0, 0),
+            "later egress inherited a dropped generated batch"
+        );
+        assert!(
+            harness.drain_generated_events().is_empty(),
+            "later egress published or reclaimed stale generated ownership"
+        );
+
+        let completions = harness.complete_generated_submissions();
+        if submitted {
+            assert_eq!(
+                completions,
+                [super::TxCompletion {
+                    frame: live[0],
+                    endpoint: expected_endpoint(WAN),
+                }]
+            );
+        } else {
+            assert!(completions.is_empty());
+        }
+        assert_eq!(
+            harness.free_generated_frames(),
+            baseline,
+            "batch-drop lifecycle did not restore the generated physical pool"
         );
     }
 }

--- a/crates/io-conformance/src/lib.rs
+++ b/crates/io-conformance/src/lib.rs
@@ -1,112 +1,202 @@
 #![forbid(unsafe_code)]
 #![doc = "Reusable, deterministic conformance cases for ruster packet I/O backends."]
+//!
+//! Harnesses bind physical frame identity while a lease is live. Later
+//! observations must reuse that binding and cannot create identity after
+//! `finish`. Accepted TX is only submitted and remains in flight; optional
+//! completion capabilities advance the same token separately. Finite-pool
+//! capabilities must expose the real backend free pool or ring.
 
 use ruster_core::{ConsumeReason, DropReason, GeneratedPacketIo, IfId, PacketIo};
 
-/// Stable identity for one backend-owned buffer during an ownership cycle.
+/// Backend frame identity plus an ownership-cycle generation.
 ///
-/// A backend may reuse the value only after the corresponding frame has been
-/// reclaimed. AF_XDP harnesses should derive it from the UMEM frame index or
-/// address, rather than packet contents.
+/// `frame_id` identifies physical storage, such as an AF_XDP UMEM frame.
+/// Reallocation of the same storage must increment `generation`, preventing an
+/// old observation from being confused with a later ownership cycle.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct BufferToken(u64);
+pub struct BufferToken {
+    pub frame_id: u64,
+    pub generation: u64,
+}
 
 impl BufferToken {
     #[must_use]
-    pub const fn new(value: u64) -> Self {
-        Self(value)
-    }
-
-    #[must_use]
-    pub const fn get(self) -> u64 {
-        self.0
+    pub const fn new(frame_id: u64, generation: u64) -> Self {
+        Self {
+            frame_id,
+            generation,
+        }
     }
 }
 
-/// Identity returned when a test frame enters an RX backend-owned buffer.
+/// Identity bound while a lease is live.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct InjectedFrame {
+pub struct LiveFrame {
     pub token: BufferToken,
-    pub allocation_address: usize,
+    pub visible_address: usize,
+    pub requested_len: usize,
+}
+
+/// A concrete backend TX endpoint.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TxEndpoint {
+    pub interface: IfId,
+    pub queue: u32,
+}
+
+/// Independent observer used while the I/O object is mutably borrowed.
+///
+/// `bind` is called exactly when ownership of a generated allocation begins.
+/// `observe` must return that existing binding and must never invent a new
+/// token for a terminal event.
+pub trait LeaseObserver {
+    fn bind(&mut self, bytes: &[u8], requested_len: usize) -> LiveFrame;
+    fn observe(&self, bytes: &[u8]) -> LiveFrame;
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum RxDisposition {
-    Accepted { egress: IfId },
-    Recycled { reason: DropReason },
-    Consumed { reason: ConsumeReason },
+pub enum RxReclaim {
+    Recycled(DropReason),
+    Consumed(ConsumeReason),
     Abandoned,
-    Rejected,
-}
-
-/// One terminal RX-buffer observation, moved out of the backend test adapter.
-#[derive(Debug, Eq, PartialEq)]
-pub struct RxOutcome {
-    pub token: BufferToken,
-    pub allocation_address: usize,
-    pub ingress: IfId,
-    pub bytes: Vec<u8>,
-    pub disposition: RxDisposition,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum GeneratedDisposition {
-    Accepted,
+pub enum RxEventKind {
+    /// Descriptor publication succeeded; the frame remains in flight.
+    TxSubmitted {
+        endpoint: TxEndpoint,
+        descriptor_len: usize,
+    },
+    /// Descriptor publication failed and the frame is already reclaimed.
+    TxRejected {
+        attempted_egress: IfId,
+        endpoint: Option<TxEndpoint>,
+    },
+    /// A non-TX lifecycle returned the frame to the backend.
+    Reclaimed(RxReclaim),
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct RxEvent {
+    pub frame: LiveFrame,
+    pub ingress: IfId,
+    /// Cold test snapshot. Ownership identity comes from `frame`.
+    pub bytes: Vec<u8>,
+    pub kind: RxEventKind,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GeneratedReclaim {
     Cancelled,
     Abandoned,
-    Rejected,
 }
 
-/// One terminal generated-buffer observation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GeneratedEventKind {
+    /// Descriptor publication succeeded; the frame remains in flight.
+    TxSubmitted {
+        endpoint: TxEndpoint,
+        descriptor_len: usize,
+    },
+    /// Descriptor publication failed and the frame is already reclaimed.
+    TxRejected {
+        attempted_egress: IfId,
+        endpoint: Option<TxEndpoint>,
+    },
+    Reclaimed(GeneratedReclaim),
+}
+
 #[derive(Debug, Eq, PartialEq)]
-pub struct GeneratedOutcome {
-    pub token: BufferToken,
-    pub allocation_address: usize,
+pub struct GeneratedEvent {
+    pub frame: LiveFrame,
     pub egress: IfId,
+    /// Cold test snapshot. Ownership identity comes from `frame`.
     pub bytes: Vec<u8>,
-    pub disposition: GeneratedDisposition,
+    pub kind: GeneratedEventKind,
 }
 
-/// Test-only control and observation boundary for mandatory RX behavior.
-///
-/// The associated I/O object remains concrete, so conformance cases use
-/// static dispatch and never place a trait object in the packet path.
+/// CQ/completion observation for a previously submitted frame.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TxCompletion {
+    pub frame: LiveFrame,
+    pub endpoint: TxEndpoint,
+}
+
 pub trait RxHarness: Sized {
     type Io: PacketIo;
+    type Observer: LeaseObserver;
 
     fn new() -> Self;
-    fn io(&mut self) -> &mut Self::Io;
-    fn inject_rx(&mut self, ingress: IfId, bytes: Vec<u8>) -> InjectedFrame;
+    fn io_and_observer(&mut self) -> (&mut Self::Io, &mut Self::Observer);
+    fn inject_rx(&mut self, ingress: IfId, bytes: Vec<u8>) -> LiveFrame;
     fn set_rx_accept_budget(&mut self, budget: usize);
     fn pending_rx(&self) -> usize;
-    fn drain_rx_outcomes(&mut self) -> Vec<RxOutcome>;
+    fn endpoint(&self, egress: IfId) -> Option<TxEndpoint>;
+    /// Rejected/reclaimed events are already reusable; submitted events remain
+    /// in flight until a completion capability advances them.
+    fn drain_rx_events(&mut self) -> Vec<RxEvent>;
 }
 
-/// Optional RX receive-error fault injection.
 pub trait RxReceiveErrorHarness: RxHarness {
     fn fail_next_receive(&mut self);
 }
 
-/// Optional RX finish-error fault injection.
 pub trait RxFinishErrorHarness: RxHarness {
     fn fail_next_rx_finish(&mut self);
 }
 
-/// Test-only control and observation boundary for generated TX behavior.
+pub trait RxCompletionHarness: RxHarness {
+    /// Advances backend-observed completions for previously submitted tokens.
+    fn complete_rx_submissions(&mut self) -> Vec<TxCompletion>;
+}
+
+/// Physical finite-pool observation; implementations must read the backend
+/// free pool/ring, not derive the value from conformance event counters.
+/// `inject_rx` must reserve frames from this same reported pool.
+pub trait RxFinitePoolHarness: RxHarness {
+    fn free_rx_frames(&self) -> usize;
+}
+
+pub trait RxUnknownEgressHarness: RxHarness {
+    /// Returns an interface that has no backend TX endpoint or ring.
+    fn unknown_rx_egress(&self) -> IfId;
+}
+
 pub trait GeneratedHarness: Sized {
     type Io: GeneratedPacketIo;
+    type Observer: LeaseObserver;
 
     fn new() -> Self;
-    fn io(&mut self) -> &mut Self::Io;
+    fn io_and_observer(&mut self) -> (&mut Self::Io, &mut Self::Observer);
     fn set_generated_allocation_budget(&mut self, budget: usize);
     fn set_generated_max_frame(&mut self, max_frame: usize);
     fn set_generated_accept_budget(&mut self, budget: usize);
-    fn drain_generated_outcomes(&mut self) -> Vec<GeneratedOutcome>;
+    fn endpoint(&self, egress: IfId) -> Option<TxEndpoint>;
+    /// Rejected/reclaimed events are already reusable; submitted events remain
+    /// in flight until a completion capability advances them.
+    fn drain_generated_events(&mut self) -> Vec<GeneratedEvent>;
 }
 
-/// Optional generated finish-error fault injection.
 pub trait GeneratedFinishErrorHarness: GeneratedHarness {
     fn fail_next_generated_finish(&mut self);
+}
+
+pub trait GeneratedCompletionHarness: GeneratedHarness {
+    /// Advances backend-observed completions for previously submitted tokens.
+    fn complete_generated_submissions(&mut self) -> Vec<TxCompletion>;
+}
+
+/// Physical finite-pool observation; implementations must query the backend
+/// free pool/ring rather than maintain an accounting shadow.
+pub trait GeneratedFinitePoolHarness: GeneratedHarness {
+    fn free_generated_frames(&self) -> usize;
+}
+
+pub trait GeneratedUnknownEgressHarness: GeneratedHarness {
+    /// Returns an interface that has no backend TX endpoint or ring.
+    fn unknown_generated_egress(&self) -> IfId;
 }
 
 pub mod rx {
@@ -115,47 +205,54 @@ pub mod rx {
     use ruster_core::{ConsumeReason, DropReason, IfId, PacketBatch, PacketIo};
 
     use super::{
-        BufferToken, InjectedFrame, RxDisposition, RxFinishErrorHarness, RxHarness, RxOutcome,
-        RxReceiveErrorHarness,
+        BufferToken, LeaseObserver, LiveFrame, RxCompletionHarness, RxEvent, RxEventKind,
+        RxFinishErrorHarness, RxFinitePoolHarness, RxHarness, RxReceiveErrorHarness, RxReclaim,
+        RxUnknownEgressHarness, TxEndpoint,
     };
 
     const LAN: IfId = IfId(11);
     const WAN: IfId = IfId(22);
 
-    fn receive<H: RxHarness>(harness: &mut H, budget: usize) -> <H::Io as PacketIo>::Batch<'_> {
-        match harness.io().receive(budget) {
-            Ok(batch) => batch,
-            Err(_) => panic!("RX conformance setup unexpectedly failed receive"),
-        }
+    fn expected_endpoint<H: RxHarness>(harness: &H, egress: IfId) -> TxEndpoint {
+        harness
+            .endpoint(egress)
+            .expect("known conformance endpoint")
     }
 
-    fn injected_map(frames: &[InjectedFrame]) -> BTreeMap<BufferToken, usize> {
-        frames
-            .iter()
-            .map(|frame| (frame.token, frame.allocation_address))
-            .collect()
+    fn assert_distinct_live(frames: &[LiveFrame]) {
+        let frame_ids: BTreeSet<_> = frames.iter().map(|frame| frame.token.frame_id).collect();
+        let tokens: BTreeSet<_> = frames.iter().map(|frame| frame.token).collect();
+        assert_eq!(frame_ids.len(), frames.len(), "live RX frame alias");
+        assert_eq!(tokens.len(), frames.len(), "duplicate live RX token");
+        assert!(frames.iter().all(|frame| frame.token.generation != 0));
     }
 
-    fn assert_exact_rx_ownership(expected: &[InjectedFrame], outcomes: &[RxOutcome]) {
-        let expected = injected_map(expected);
-        assert_eq!(outcomes.len(), expected.len());
+    fn expected_map(frames: &[LiveFrame]) -> BTreeMap<BufferToken, LiveFrame> {
+        frames.iter().map(|frame| (frame.token, *frame)).collect()
+    }
+
+    fn assert_event_bindings(expected: &[LiveFrame], events: &[RxEvent]) {
+        let expected = expected_map(expected);
+        assert_eq!(events.len(), expected.len());
         let mut observed = BTreeSet::new();
-        for outcome in outcomes {
+        for event in events {
             assert!(
-                observed.insert(outcome.token),
-                "duplicate RX terminal token"
+                observed.insert(event.frame.token),
+                "duplicate RX event token"
             );
             assert_eq!(
-                expected.get(&outcome.token),
-                Some(&outcome.allocation_address),
-                "RX allocation identity changed or an unknown token appeared"
+                expected.get(&event.frame.token),
+                Some(&event.frame),
+                "RX terminal event changed or invented its lease-time binding"
             );
+            assert_eq!(event.bytes.len(), event.frame.requested_len);
+            if let RxEventKind::TxSubmitted { descriptor_len, .. } = event.kind {
+                assert_eq!(
+                    descriptor_len, event.frame.requested_len,
+                    "RX descriptor length differs from the lease-time length"
+                );
+            }
         }
-        assert_eq!(
-            observed,
-            expected.keys().copied().collect(),
-            "RX token was lost"
-        );
     }
 
     pub fn budget_and_unleased_slots_are_exact<H: RxHarness>() {
@@ -165,13 +262,17 @@ pub mod rx {
             harness.inject_rx(LAN, vec![2, 0xa2]),
             harness.inject_rx(LAN, vec![3, 0xa3]),
         ];
+        assert_distinct_live(&injected);
 
         let completion = {
-            let mut batch = receive(&mut harness, 0);
+            let (io, _) = harness.io_and_observer();
+            let mut batch = match io.receive(0) {
+                Ok(batch) => batch,
+                Err(_) => panic!("zero-budget receive failed"),
+            };
             assert!(batch.next_packet().is_none());
             batch.finish()
         };
-        assert!(completion.invariants_hold());
         assert_eq!(
             (
                 completion.tx_requested,
@@ -183,53 +284,63 @@ pub mod rx {
         );
         assert_eq!(harness.pending_rx(), 3);
 
+        let mut leased_tokens = BTreeSet::new();
         let completion = {
-            let mut batch = receive(&mut harness, 2);
-            let mut leased = 0;
-            while let Some(packet) = batch.next_packet() {
+            let (io, observer) = harness.io_and_observer();
+            let mut batch = match io.receive(2) {
+                Ok(batch) => batch,
+                Err(_) => panic!("budgeted receive failed"),
+            };
+            while let Some(mut packet) = batch.next_packet() {
+                let frame = observer.observe(packet.bytes_mut());
+                assert!(leased_tokens.insert(frame.token));
                 packet.recycle(DropReason::RouteMiss);
-                leased += 1;
             }
-            assert_eq!(leased, 2);
             batch.finish()
         };
         assert_eq!(completion.recycled, 2);
         assert_eq!(harness.pending_rx(), 1);
 
         let completion = {
-            let mut batch = receive(&mut harness, usize::MAX);
-            let packet = batch.next_packet().expect("unleased RX slot");
+            let (io, observer) = harness.io_and_observer();
+            let mut batch = match io.receive(usize::MAX) {
+                Ok(batch) => batch,
+                Err(_) => panic!("remaining receive failed"),
+            };
+            let mut packet = batch.next_packet().expect("unleased RX slot");
+            let frame = observer.observe(packet.bytes_mut());
+            assert!(leased_tokens.insert(frame.token));
             packet.recycle(DropReason::RouteMiss);
             assert!(batch.next_packet().is_none());
             batch.finish()
         };
         assert_eq!(completion.recycled, 1);
-        assert_eq!(harness.pending_rx(), 0);
-
-        let outcomes = harness.drain_rx_outcomes();
-        assert_exact_rx_ownership(&injected, &outcomes);
-        assert!(outcomes.iter().all(|outcome| {
-            outcome.disposition
-                == RxDisposition::Recycled {
-                    reason: DropReason::RouteMiss,
-                }
-        }));
+        assert_eq!(
+            leased_tokens,
+            injected.iter().map(|frame| frame.token).collect()
+        );
+        let events = harness.drain_rx_events();
+        assert_event_bindings(&injected, &events);
     }
 
-    pub fn commit_is_in_place_and_egress_typed<H: RxHarness>() {
+    pub fn commit_is_submitted_in_place_with_exact_descriptor<H: RxHarness>() {
         let mut harness = H::new();
+        let endpoint = expected_endpoint(&harness, WAN);
         let injected = harness.inject_rx(LAN, vec![0x10, 0x20, 0x30]);
         let completion = {
-            let mut batch = receive(&mut harness, 1);
+            let (io, observer) = harness.io_and_observer();
+            let mut batch = match io.receive(1) {
+                Ok(batch) => batch,
+                Err(_) => panic!("RX receive failed"),
+            };
             let mut packet = batch.next_packet().expect("one RX lease");
             assert_eq!(packet.ingress(), LAN);
-            let bytes = packet.bytes_mut();
-            assert_eq!(bytes.as_ptr() as usize, injected.allocation_address);
-            bytes[1] = 0x99;
+            let observed = observer.observe(packet.bytes_mut());
+            assert_eq!(observed, injected);
+            packet.bytes_mut()[1] = 0x99;
             packet.commit(WAN);
             batch.finish()
         };
-        assert!(completion.invariants_hold());
         assert_eq!(
             (
                 completion.tx_requested,
@@ -239,12 +350,15 @@ pub mod rx {
             ),
             (1, 1, 0, 0)
         );
-        let outcomes = harness.drain_rx_outcomes();
-        assert_exact_rx_ownership(&[injected], &outcomes);
-        assert_eq!(outcomes[0].bytes, [0x10, 0x99, 0x30]);
+        let events = harness.drain_rx_events();
+        assert_event_bindings(&[injected], &events);
+        assert_eq!(events[0].bytes, [0x10, 0x99, 0x30]);
         assert_eq!(
-            outcomes[0].disposition,
-            RxDisposition::Accepted { egress: WAN }
+            events[0].kind,
+            RxEventKind::TxSubmitted {
+                endpoint,
+                descriptor_len: injected.requested_len,
+            }
         );
     }
 
@@ -255,9 +369,16 @@ pub mod rx {
             harness.inject_rx(LAN, vec![2, 0x22]),
             harness.inject_rx(LAN, vec![3, 0x33]),
         ];
+        assert_distinct_live(&injected);
         let completion = {
-            let mut batch = receive(&mut harness, 3);
+            let (io, observer) = harness.io_and_observer();
+            let mut batch = match io.receive(3) {
+                Ok(batch) => batch,
+                Err(_) => panic!("RX receive failed"),
+            };
             while let Some(mut packet) = batch.next_packet() {
+                let observed = observer.observe(packet.bytes_mut());
+                assert_eq!(observed.requested_len, packet.bytes_mut().len());
                 match packet.bytes_mut()[0] {
                     1 => packet.recycle(DropReason::NeighborUnresolved),
                     2 => packet.consume(ConsumeReason::ArpControl),
@@ -267,50 +388,43 @@ pub mod rx {
             }
             batch.finish()
         };
-        assert!(completion.invariants_hold());
-        assert_eq!(
-            (
-                completion.tx_requested,
-                completion.tx_accepted,
-                completion.tx_rejected,
-                completion.recycled,
-            ),
-            (0, 0, 0, 3)
-        );
-
-        let outcomes = harness.drain_rx_outcomes();
-        assert_exact_rx_ownership(&injected, &outcomes);
-        for outcome in outcomes {
-            let expected = match outcome.bytes[0] {
-                1 => RxDisposition::Recycled {
-                    reason: DropReason::NeighborUnresolved,
-                },
-                2 => RxDisposition::Consumed {
-                    reason: ConsumeReason::ArpControl,
-                },
-                3 => RxDisposition::Abandoned,
+        assert_eq!(completion.recycled, 3);
+        let events = harness.drain_rx_events();
+        assert_event_bindings(&injected, &events);
+        for event in events {
+            let expected = match event.bytes[0] {
+                1 => RxEventKind::Reclaimed(RxReclaim::Recycled(DropReason::NeighborUnresolved)),
+                2 => RxEventKind::Reclaimed(RxReclaim::Consumed(ConsumeReason::ArpControl)),
+                3 => RxEventKind::Reclaimed(RxReclaim::Abandoned),
                 _ => panic!("unexpected RX marker"),
             };
-            assert_eq!(outcome.disposition, expected);
+            assert_eq!(event.kind, expected);
         }
     }
 
-    pub fn partial_reject_reclaims_exactly_before_finish_returns<H: RxHarness>() {
+    pub fn partial_reject_reclaims_exact_tokens<H: RxHarness>() {
         let mut harness = H::new();
         harness.set_rx_accept_budget(1);
+        let endpoint = expected_endpoint(&harness, WAN);
         let injected = [
             harness.inject_rx(LAN, vec![1, 0x41]),
             harness.inject_rx(LAN, vec![2, 0x42]),
             harness.inject_rx(LAN, vec![3, 0x43]),
         ];
+        assert_distinct_live(&injected);
         let completion = {
-            let mut batch = receive(&mut harness, 3);
-            while let Some(packet) = batch.next_packet() {
+            let (io, observer) = harness.io_and_observer();
+            let mut batch = match io.receive(3) {
+                Ok(batch) => batch,
+                Err(_) => panic!("RX receive failed"),
+            };
+            while let Some(mut packet) = batch.next_packet() {
+                let observed = observer.observe(packet.bytes_mut());
+                assert!(injected.contains(&observed));
                 packet.commit(WAN);
             }
             batch.finish()
         };
-        assert!(completion.invariants_hold());
         assert_eq!(
             (
                 completion.tx_requested,
@@ -320,76 +434,59 @@ pub mod rx {
             ),
             (3, 1, 2, 0)
         );
-
-        let outcomes = harness.drain_rx_outcomes();
-        assert_exact_rx_ownership(&injected, &outcomes);
+        let events = harness.drain_rx_events();
+        assert_event_bindings(&injected, &events);
         assert_eq!(
-            outcomes
+            events
                 .iter()
-                .filter(|outcome| matches!(outcome.disposition, RxDisposition::Accepted { .. }))
+                .filter(|event| {
+                    event.kind
+                        == RxEventKind::TxSubmitted {
+                            endpoint,
+                            descriptor_len: event.frame.requested_len,
+                        }
+                })
                 .count(),
             1
         );
         assert_eq!(
-            outcomes
+            events
                 .iter()
-                .filter(|outcome| outcome.disposition == RxDisposition::Rejected)
+                .filter(|event| {
+                    event.kind
+                        == RxEventKind::TxRejected {
+                            attempted_egress: WAN,
+                            endpoint: Some(endpoint),
+                        }
+                })
                 .count(),
             2
         );
-    }
-
-    pub fn repeated_reject_cycles_conserve_rx_ownership<H: RxHarness>() {
-        let mut harness = H::new();
-        harness.set_rx_accept_budget(0);
-        for cycle in 0_u8..4 {
-            let injected = [
-                harness.inject_rx(LAN, vec![cycle, 1]),
-                harness.inject_rx(LAN, vec![cycle, 2]),
-            ];
-            let completion = {
-                let mut batch = receive(&mut harness, 2);
-                while let Some(packet) = batch.next_packet() {
-                    packet.commit(WAN);
-                }
-                batch.finish()
-            };
-            assert!(completion.invariants_hold());
-            assert_eq!(
-                (
-                    completion.tx_requested,
-                    completion.tx_accepted,
-                    completion.tx_rejected,
-                    completion.recycled,
-                ),
-                (2, 0, 2, 0)
-            );
-            let outcomes = harness.drain_rx_outcomes();
-            assert_exact_rx_ownership(&injected, &outcomes);
-            assert!(outcomes
-                .iter()
-                .all(|outcome| outcome.disposition == RxDisposition::Rejected));
-        }
     }
 
     pub fn receive_error_preserves_queued_ownership<H: RxReceiveErrorHarness>() {
         let mut harness = H::new();
         let injected = harness.inject_rx(LAN, vec![0x51, 0x52]);
         harness.fail_next_receive();
-        assert!(harness.io().receive(1).is_err());
+        let receive_failed = {
+            let (io, _) = harness.io_and_observer();
+            io.receive(1).is_err()
+        };
+        assert!(receive_failed);
         assert_eq!(harness.pending_rx(), 1);
-
         let completion = {
-            let mut batch = receive(&mut harness, 1);
-            batch
-                .next_packet()
-                .expect("RX slot survives receive error")
-                .recycle(DropReason::RouteMiss);
+            let (io, observer) = harness.io_and_observer();
+            let mut batch = match io.receive(1) {
+                Ok(batch) => batch,
+                Err(_) => panic!("RX retry failed"),
+            };
+            let mut packet = batch.next_packet().expect("RX slot survives error");
+            assert_eq!(observer.observe(packet.bytes_mut()), injected);
+            packet.recycle(DropReason::RouteMiss);
             batch.finish()
         };
         assert_eq!(completion.recycled, 1);
-        let outcomes = harness.drain_rx_outcomes();
-        assert_exact_rx_ownership(&[injected], &outcomes);
+        assert_event_bindings(&[injected], &harness.drain_rx_events());
     }
 
     pub fn partial_reject_with_finish_error_is_exact<H: RxFinishErrorHarness>() {
@@ -402,31 +499,107 @@ pub mod rx {
             harness.inject_rx(LAN, vec![0x63]),
         ];
         let completion = {
-            let mut batch = receive(&mut harness, 3);
-            while let Some(packet) = batch.next_packet() {
+            let (io, observer) = harness.io_and_observer();
+            let mut batch = match io.receive(3) {
+                Ok(batch) => batch,
+                Err(_) => panic!("RX receive failed"),
+            };
+            while let Some(mut packet) = batch.next_packet() {
+                assert!(injected.contains(&observer.observe(packet.bytes_mut())));
                 packet.commit(WAN);
             }
             batch.finish()
         };
         assert!(completion.invariants_hold());
-        assert_eq!(
-            (
-                completion.tx_requested,
-                completion.tx_accepted,
-                completion.tx_rejected,
-                completion.recycled,
-            ),
-            (3, 1, 2, 0)
-        );
+        assert_eq!((completion.tx_accepted, completion.tx_rejected), (1, 2));
         assert!(completion.error.is_some());
-        let outcomes = harness.drain_rx_outcomes();
-        assert_exact_rx_ownership(&injected, &outcomes);
+        assert_event_bindings(&injected, &harness.drain_rx_events());
+    }
+
+    pub fn completion_advances_the_exact_submitted_token<H: RxCompletionHarness>() {
+        let mut harness = H::new();
+        let endpoint = expected_endpoint(&harness, WAN);
+        let injected = harness.inject_rx(LAN, vec![0x71, 0x72]);
+        {
+            let (io, observer) = harness.io_and_observer();
+            let mut batch = match io.receive(1) {
+                Ok(batch) => batch,
+                Err(_) => panic!("RX receive failed"),
+            };
+            let mut packet = batch.next_packet().expect("RX lease");
+            assert_eq!(observer.observe(packet.bytes_mut()), injected);
+            packet.commit(WAN);
+            assert_eq!(batch.finish().tx_accepted, 1);
+        }
+        let events = harness.drain_rx_events();
+        assert!(matches!(events[0].kind, RxEventKind::TxSubmitted { .. }));
+        let completions = harness.complete_rx_submissions();
         assert_eq!(
-            outcomes
-                .iter()
-                .filter(|outcome| outcome.disposition == RxDisposition::Rejected)
-                .count(),
-            2
+            completions,
+            [super::TxCompletion {
+                frame: injected,
+                endpoint,
+            }]
+        );
+    }
+
+    pub fn repeated_rejects_restore_physical_pool<H: RxFinitePoolHarness>() {
+        let mut harness = H::new();
+        harness.set_rx_accept_budget(0);
+        let baseline = harness.free_rx_frames();
+        for cycle in 0_u8..4 {
+            let injected = [
+                harness.inject_rx(LAN, vec![cycle, 1]),
+                harness.inject_rx(LAN, vec![cycle, 2]),
+            ];
+            assert_eq!(harness.free_rx_frames() + injected.len(), baseline);
+            {
+                let (io, observer) = harness.io_and_observer();
+                let mut batch = match io.receive(2) {
+                    Ok(batch) => batch,
+                    Err(_) => panic!("RX receive failed"),
+                };
+                while let Some(mut packet) = batch.next_packet() {
+                    assert!(injected.contains(&observer.observe(packet.bytes_mut())));
+                    packet.commit(WAN);
+                }
+                assert_eq!(batch.finish().tx_rejected, 2);
+            }
+            assert_eq!(
+                harness.free_rx_frames(),
+                baseline,
+                "rejected frame was not returned by finish"
+            );
+            let events = harness.drain_rx_events();
+            assert_event_bindings(&injected, &events);
+        }
+    }
+
+    pub fn unknown_egress_is_rejected_without_submission<H: RxUnknownEgressHarness>() {
+        let mut harness = H::new();
+        let unknown = harness.unknown_rx_egress();
+        assert!(harness.endpoint(unknown).is_none());
+        let injected = harness.inject_rx(LAN, vec![0x81]);
+        let completion = {
+            let (io, observer) = harness.io_and_observer();
+            let mut batch = match io.receive(1) {
+                Ok(batch) => batch,
+                Err(_) => panic!("RX receive failed"),
+            };
+            let mut packet = batch.next_packet().expect("RX lease");
+            assert_eq!(observer.observe(packet.bytes_mut()), injected);
+            packet.commit(unknown);
+            batch.finish()
+        };
+        assert_eq!((completion.tx_accepted, completion.tx_rejected), (0, 1));
+        let events = harness.drain_rx_events();
+        assert_event_bindings(&[injected], &events);
+        assert_eq!(
+            events[0].kind,
+            RxEventKind::TxRejected {
+                attempted_egress: unknown,
+                endpoint: None,
+            }
         );
     }
 }
@@ -437,35 +610,68 @@ pub mod generated {
     use ruster_core::{GeneratedAllocationError, GeneratedPacketBatch, GeneratedPacketIo, IfId};
 
     use super::{
-        GeneratedDisposition, GeneratedFinishErrorHarness, GeneratedHarness, GeneratedOutcome,
+        BufferToken, GeneratedCompletionHarness, GeneratedEvent, GeneratedEventKind,
+        GeneratedFinishErrorHarness, GeneratedFinitePoolHarness, GeneratedHarness,
+        GeneratedReclaim, GeneratedUnknownEgressHarness, LeaseObserver, LiveFrame, TxEndpoint,
     };
 
     const LAN: IfId = IfId(11);
     const WAN: IfId = IfId(22);
 
-    fn assert_exact_generated_ownership(
-        expected_addresses: &BTreeMap<u8, usize>,
-        outcomes: &[GeneratedOutcome],
-    ) {
-        assert_eq!(outcomes.len(), expected_addresses.len());
-        let mut tokens = BTreeSet::new();
-        for outcome in outcomes {
+    fn expected_endpoint<H: GeneratedHarness>(harness: &H, egress: IfId) -> TxEndpoint {
+        harness
+            .endpoint(egress)
+            .expect("known conformance endpoint")
+    }
+
+    fn assert_distinct_live(frames: &[LiveFrame]) {
+        let frame_ids: BTreeSet<_> = frames.iter().map(|frame| frame.token.frame_id).collect();
+        let tokens: BTreeSet<_> = frames.iter().map(|frame| frame.token).collect();
+        assert_eq!(frame_ids.len(), frames.len(), "live generated frame alias");
+        assert_eq!(tokens.len(), frames.len(), "duplicate generated token");
+        assert!(frames.iter().all(|frame| frame.token.generation != 0));
+    }
+
+    fn assert_distinct_cycles(frames: &[LiveFrame]) {
+        let tokens: BTreeSet<_> = frames.iter().map(|frame| frame.token).collect();
+        assert_eq!(tokens.len(), frames.len(), "duplicate ownership cycle");
+        assert!(frames.iter().all(|frame| frame.token.generation != 0));
+    }
+
+    fn expected_map(frames: &[LiveFrame]) -> BTreeMap<BufferToken, LiveFrame> {
+        frames.iter().map(|frame| (frame.token, *frame)).collect()
+    }
+
+    fn assert_event_bindings(expected: &[LiveFrame], events: &[GeneratedEvent]) {
+        let expected = expected_map(expected);
+        assert_eq!(events.len(), expected.len());
+        let mut observed = BTreeSet::new();
+        for event in events {
             assert!(
-                tokens.insert(outcome.token),
-                "duplicate generated terminal token"
+                observed.insert(event.frame.token),
+                "duplicate generated event token"
             );
-            let marker = outcome.bytes[0];
             assert_eq!(
-                expected_addresses.get(&marker),
-                Some(&outcome.allocation_address),
-                "generated allocation identity changed"
+                expected.get(&event.frame.token),
+                Some(&event.frame),
+                "generated terminal event changed or invented its lease-time binding"
             );
+            assert_eq!(event.bytes.len(), event.frame.requested_len);
+            if let GeneratedEventKind::TxSubmitted { descriptor_len, .. } = event.kind {
+                assert_eq!(
+                    descriptor_len, event.frame.requested_len,
+                    "generated descriptor length differs from requested length"
+                );
+            }
         }
     }
 
     pub fn empty_session_has_zero_accounting<H: GeneratedHarness>() {
         let mut harness = H::new();
-        let completion = harness.io().begin_generated(WAN).finish();
+        let completion = {
+            let (io, _) = harness.io_and_observer();
+            io.begin_generated(WAN).finish()
+        };
         assert!(completion.invariants_hold());
         assert_eq!(
             (
@@ -480,17 +686,17 @@ pub mod generated {
             ),
             (0, 0, 0, 0, 0, 0, 0, 0)
         );
-        assert!(completion.error.is_none());
-        assert!(harness.drain_generated_outcomes().is_empty());
+        assert!(harness.drain_generated_events().is_empty());
     }
 
-    pub fn allocation_failures_are_typed_and_transfer_no_ownership<H: GeneratedHarness>() {
+    pub fn allocation_failures_bind_only_successful_ownership<H: GeneratedHarness>() {
         let mut harness = H::new();
         harness.set_generated_max_frame(64);
         harness.set_generated_allocation_budget(1);
-        let mut addresses = BTreeMap::new();
+        let mut live = Vec::new();
         let completion = {
-            let mut batch = harness.io().begin_generated(WAN);
+            let (io, observer) = harness.io_and_observer();
+            let mut batch = io.begin_generated(WAN);
             assert!(matches!(
                 batch.allocate(0),
                 Err(GeneratedAllocationError::ZeroLength)
@@ -501,9 +707,10 @@ pub mod generated {
             ));
             let mut valid = batch
                 .allocate(64)
-                .expect("invalid requests must not consume allocation budget");
+                .expect("invalid attempts consumed allocation budget");
             valid.bytes_mut().fill(7);
-            addresses.insert(7, valid.bytes_mut().as_ptr() as usize);
+            let frame = observer.bind(valid.bytes_mut(), 64);
+            live.push(frame);
             valid.cancel();
             assert!(matches!(
                 batch.allocate(64),
@@ -511,7 +718,6 @@ pub mod generated {
             ));
             batch.finish()
         };
-        assert!(completion.invariants_hold());
         assert_eq!(
             (
                 completion.attempts,
@@ -520,183 +726,166 @@ pub mod generated {
                 completion.requested,
                 completion.cancelled,
                 completion.abandoned,
-                completion.accepted,
-                completion.rejected,
             ),
-            (4, 1, 3, 0, 1, 0, 0, 0)
+            (4, 1, 3, 0, 1, 0)
         );
-        let outcomes = harness.drain_generated_outcomes();
-        assert_exact_generated_ownership(&addresses, &outcomes);
-        assert_eq!(outcomes[0].disposition, GeneratedDisposition::Cancelled);
+        let events = harness.drain_generated_events();
+        assert_event_bindings(&live, &events);
+        assert_eq!(
+            events[0].kind,
+            GeneratedEventKind::Reclaimed(GeneratedReclaim::Cancelled)
+        );
     }
 
-    pub fn commit_cancel_and_abandon_are_exact_length_and_distinct<H: GeneratedHarness>() {
+    pub fn commit_cancel_and_abandon_bind_exact_lengths<H: GeneratedHarness>() {
         let mut harness = H::new();
         harness.set_generated_max_frame(64);
         harness.set_generated_allocation_budget(3);
-        let mut addresses = BTreeMap::new();
+        let endpoint = expected_endpoint(&harness, WAN);
+        let mut live = Vec::new();
         let completion = {
-            let mut batch = harness.io().begin_generated(WAN);
-
-            let mut committed = batch.allocate(60).expect("generated commit allocation");
-            assert_eq!(committed.bytes_mut().len(), 60);
-            committed.bytes_mut().fill(0);
-            committed.bytes_mut()[0] = 1;
-            addresses.insert(1, committed.bytes_mut().as_ptr() as usize);
-            committed.commit();
-
-            let mut cancelled = batch.allocate(61).expect("generated cancel allocation");
-            assert_eq!(cancelled.bytes_mut().len(), 61);
-            cancelled.bytes_mut().fill(0);
-            cancelled.bytes_mut()[0] = 2;
-            addresses.insert(2, cancelled.bytes_mut().as_ptr() as usize);
-            cancelled.cancel();
-
-            let mut abandoned = batch.allocate(62).expect("generated abandon allocation");
-            assert_eq!(abandoned.bytes_mut().len(), 62);
-            abandoned.bytes_mut().fill(0);
-            abandoned.bytes_mut()[0] = 3;
-            addresses.insert(3, abandoned.bytes_mut().as_ptr() as usize);
-            drop(abandoned);
-
-            batch.finish()
-        };
-        assert!(completion.invariants_hold());
-        assert_eq!(
-            (
-                completion.attempts,
-                completion.allocated,
-                completion.failed,
-                completion.requested,
-                completion.cancelled,
-                completion.abandoned,
-                completion.accepted,
-                completion.rejected,
-            ),
-            (3, 3, 0, 1, 1, 1, 1, 0)
-        );
-
-        let outcomes = harness.drain_generated_outcomes();
-        assert_exact_generated_ownership(&addresses, &outcomes);
-        for outcome in outcomes {
-            let expected = match outcome.bytes[0] {
-                1 => GeneratedDisposition::Accepted,
-                2 => GeneratedDisposition::Cancelled,
-                3 => GeneratedDisposition::Abandoned,
-                _ => panic!("unexpected generated marker"),
-            };
-            assert_eq!(outcome.disposition, expected);
-            assert_eq!(outcome.egress, WAN);
-        }
-    }
-
-    pub fn partial_reject_reclaims_exactly_before_finish_returns<H: GeneratedHarness>() {
-        let mut harness = H::new();
-        harness.set_generated_allocation_budget(3);
-        harness.set_generated_accept_budget(1);
-        let mut addresses = BTreeMap::new();
-        let completion = {
-            let mut batch = harness.io().begin_generated(WAN);
-            for marker in 1_u8..=3 {
-                let mut packet = batch.allocate(60).expect("generated allocation");
+            let (io, observer) = harness.io_and_observer();
+            let mut batch = io.begin_generated(WAN);
+            for (marker, len, terminal) in [(1_u8, 60, 0_u8), (2, 61, 1), (3, 62, 2)] {
+                let mut packet = batch.allocate(len).expect("generated allocation");
+                assert_eq!(packet.bytes_mut().len(), len);
                 packet.bytes_mut().fill(marker);
-                addresses.insert(marker, packet.bytes_mut().as_ptr() as usize);
-                packet.commit();
+                let frame = observer.bind(packet.bytes_mut(), len);
+                live.push(frame);
+                match terminal {
+                    0 => packet.commit(),
+                    1 => packet.cancel(),
+                    2 => drop(packet),
+                    _ => unreachable!(),
+                }
+            }
+            assert_distinct_cycles(&live);
+            assert_ne!(
+                live[0].token.frame_id, live[1].token.frame_id,
+                "committed frame aliased a later live allocation"
+            );
+            assert_ne!(
+                live[0].token.frame_id, live[2].token.frame_id,
+                "committed frame aliased a later live allocation"
+            );
+            if live[1].token.frame_id == live[2].token.frame_id {
+                assert!(
+                    live[2].token.generation > live[1].token.generation,
+                    "reused frame did not advance ownership generation"
+                );
             }
             batch.finish()
         };
-        assert!(completion.invariants_hold());
         assert_eq!(
             (
-                completion.attempts,
-                completion.allocated,
-                completion.failed,
                 completion.requested,
                 completion.cancelled,
                 completion.abandoned,
                 completion.accepted,
                 completion.rejected,
             ),
-            (3, 3, 0, 3, 0, 0, 1, 2)
+            (1, 1, 1, 1, 0)
         );
-        let outcomes = harness.drain_generated_outcomes();
-        assert_exact_generated_ownership(&addresses, &outcomes);
+        let events = harness.drain_generated_events();
+        assert_event_bindings(&live, &events);
+        for event in events {
+            let expected = match event.bytes[0] {
+                1 => GeneratedEventKind::TxSubmitted {
+                    endpoint,
+                    descriptor_len: 60,
+                },
+                2 => GeneratedEventKind::Reclaimed(GeneratedReclaim::Cancelled),
+                3 => GeneratedEventKind::Reclaimed(GeneratedReclaim::Abandoned),
+                _ => panic!("unexpected generated marker"),
+            };
+            assert_eq!(event.kind, expected);
+        }
+    }
+
+    pub fn partial_reject_reclaims_exact_tokens<H: GeneratedHarness>() {
+        let mut harness = H::new();
+        harness.set_generated_allocation_budget(3);
+        harness.set_generated_accept_budget(1);
+        let endpoint = expected_endpoint(&harness, WAN);
+        let mut live = Vec::new();
+        let completion = {
+            let (io, observer) = harness.io_and_observer();
+            let mut batch = io.begin_generated(WAN);
+            for marker in 1_u8..=3 {
+                let mut packet = batch.allocate(60).expect("generated allocation");
+                packet.bytes_mut().fill(marker);
+                live.push(observer.bind(packet.bytes_mut(), 60));
+                packet.commit();
+            }
+            assert_distinct_live(&live);
+            batch.finish()
+        };
+        assert_eq!((completion.accepted, completion.rejected), (1, 2));
+        let events = harness.drain_generated_events();
+        assert_event_bindings(&live, &events);
         assert_eq!(
-            outcomes
+            events
                 .iter()
-                .filter(|outcome| outcome.disposition == GeneratedDisposition::Accepted)
+                .filter(|event| {
+                    event.kind
+                        == GeneratedEventKind::TxSubmitted {
+                            endpoint,
+                            descriptor_len: event.frame.requested_len,
+                        }
+                })
                 .count(),
             1
         );
         assert_eq!(
-            outcomes
+            events
                 .iter()
-                .filter(|outcome| outcome.disposition == GeneratedDisposition::Rejected)
+                .filter(|event| {
+                    event.kind
+                        == GeneratedEventKind::TxRejected {
+                            attempted_egress: WAN,
+                            endpoint: Some(endpoint),
+                        }
+                })
                 .count(),
             2
         );
     }
 
-    pub fn sessions_pin_egress_without_cross_talk<H: GeneratedHarness>() {
+    pub fn sessions_bind_concrete_endpoints<H: GeneratedHarness>() {
         let mut harness = H::new();
         harness.set_generated_allocation_budget(1);
-        for (egress, marker) in [(LAN, 1_u8), (WAN, 2_u8)] {
+        let expected = [
+            (LAN, expected_endpoint(&harness, LAN), 1_u8),
+            (WAN, expected_endpoint(&harness, WAN), 2_u8),
+        ];
+        let mut live = Vec::new();
+        for (egress, _, marker) in expected {
             let completion = {
-                let mut batch = harness.io().begin_generated(egress);
+                let (io, observer) = harness.io_and_observer();
+                let mut batch = io.begin_generated(egress);
                 let mut packet = batch.allocate(60).expect("generated allocation");
                 packet.bytes_mut().fill(marker);
+                live.push(observer.bind(packet.bytes_mut(), 60));
                 packet.commit();
                 batch.finish()
             };
             assert_eq!(completion.accepted, 1);
         }
-        let outcomes = harness.drain_generated_outcomes();
-        assert_eq!(outcomes.len(), 2);
-        for outcome in outcomes {
-            let expected = match outcome.bytes[0] {
-                1 => LAN,
-                2 => WAN,
-                _ => panic!("unexpected generated marker"),
-            };
-            assert_eq!(outcome.egress, expected);
-            assert_eq!(outcome.disposition, GeneratedDisposition::Accepted);
-        }
-    }
-
-    pub fn repeated_reject_cycles_conserve_generated_pool<H: GeneratedHarness>() {
-        let mut harness = H::new();
-        harness.set_generated_allocation_budget(2);
-        harness.set_generated_accept_budget(0);
-        for cycle in 0_u8..4 {
-            let mut addresses = BTreeMap::new();
-            let completion = {
-                let mut batch = harness.io().begin_generated(WAN);
-                for slot in 1_u8..=2 {
-                    let marker = cycle * 2 + slot;
-                    let mut packet = batch.allocate(60).expect("pool capacity leaked");
-                    packet.bytes_mut().fill(marker);
-                    addresses.insert(marker, packet.bytes_mut().as_ptr() as usize);
-                    packet.commit();
-                }
-                batch.finish()
-            };
-            assert!(completion.invariants_hold());
-            assert_eq!(
-                (
-                    completion.attempts,
-                    completion.allocated,
-                    completion.failed,
-                    completion.requested,
-                    completion.accepted,
-                    completion.rejected,
-                ),
-                (2, 2, 0, 2, 0, 2)
-            );
-            let outcomes = harness.drain_generated_outcomes();
-            assert_exact_generated_ownership(&addresses, &outcomes);
-            assert!(outcomes
+        assert_distinct_live(&live);
+        let events = harness.drain_generated_events();
+        assert_event_bindings(&live, &events);
+        for event in events {
+            let (_, endpoint, _) = expected
                 .iter()
-                .all(|outcome| outcome.disposition == GeneratedDisposition::Rejected));
+                .find(|(_, _, marker)| *marker == event.bytes[0])
+                .expect("known marker");
+            assert_eq!(
+                event.kind,
+                GeneratedEventKind::TxSubmitted {
+                    endpoint: *endpoint,
+                    descriptor_len: 60,
+                }
+            );
         }
     }
 
@@ -705,40 +894,113 @@ pub mod generated {
         harness.set_generated_allocation_budget(3);
         harness.set_generated_accept_budget(1);
         harness.fail_next_generated_finish();
-        let mut addresses = BTreeMap::new();
+        let mut live = Vec::new();
         let completion = {
-            let mut batch = harness.io().begin_generated(WAN);
+            let (io, observer) = harness.io_and_observer();
+            let mut batch = io.begin_generated(WAN);
             for marker in 1_u8..=3 {
                 let mut packet = batch.allocate(60).expect("generated allocation");
                 packet.bytes_mut().fill(marker);
-                addresses.insert(marker, packet.bytes_mut().as_ptr() as usize);
+                live.push(observer.bind(packet.bytes_mut(), 60));
                 packet.commit();
             }
+            assert_distinct_live(&live);
             batch.finish()
         };
         assert!(completion.invariants_hold());
-        assert_eq!(
-            (
-                completion.attempts,
-                completion.allocated,
-                completion.failed,
-                completion.requested,
-                completion.cancelled,
-                completion.abandoned,
-                completion.accepted,
-                completion.rejected,
-            ),
-            (3, 3, 0, 3, 0, 0, 1, 2)
-        );
+        assert_eq!((completion.accepted, completion.rejected), (1, 2));
         assert!(completion.error.is_some());
-        let outcomes = harness.drain_generated_outcomes();
-        assert_exact_generated_ownership(&addresses, &outcomes);
+        assert_event_bindings(&live, &harness.drain_generated_events());
+    }
+
+    pub fn completion_advances_the_exact_submitted_token<H: GeneratedCompletionHarness>() {
+        let mut harness = H::new();
+        harness.set_generated_allocation_budget(1);
+        let endpoint = expected_endpoint(&harness, WAN);
+        let frame = {
+            let (io, observer) = harness.io_and_observer();
+            let mut batch = io.begin_generated(WAN);
+            let mut packet = batch.allocate(60).expect("generated allocation");
+            packet.bytes_mut().fill(9);
+            let frame = observer.bind(packet.bytes_mut(), 60);
+            packet.commit();
+            assert_eq!(batch.finish().accepted, 1);
+            frame
+        };
+        let events = harness.drain_generated_events();
+        assert!(matches!(
+            events[0].kind,
+            GeneratedEventKind::TxSubmitted { .. }
+        ));
         assert_eq!(
-            outcomes
-                .iter()
-                .filter(|outcome| outcome.disposition == GeneratedDisposition::Rejected)
-                .count(),
-            2
+            harness.complete_generated_submissions(),
+            [super::TxCompletion { frame, endpoint }]
+        );
+    }
+
+    pub fn repeated_rejects_restore_physical_pool_and_advance_generation<
+        H: GeneratedFinitePoolHarness,
+    >() {
+        let mut harness = H::new();
+        harness.set_generated_allocation_budget(2);
+        harness.set_generated_accept_budget(0);
+        let baseline = harness.free_generated_frames();
+        assert!(baseline >= 2);
+        let mut last_generation = BTreeMap::<u64, u64>::new();
+        for cycle in 0_u8..4 {
+            let mut live = Vec::new();
+            {
+                let (io, observer) = harness.io_and_observer();
+                let mut batch = io.begin_generated(WAN);
+                for slot in 1_u8..=2 {
+                    let mut packet = batch.allocate(60).expect("physical pool leaked");
+                    packet.bytes_mut().fill(cycle * 2 + slot);
+                    let frame = observer.bind(packet.bytes_mut(), 60);
+                    if let Some(previous) =
+                        last_generation.insert(frame.token.frame_id, frame.token.generation)
+                    {
+                        assert!(frame.token.generation > previous, "ABA generation reused");
+                    }
+                    live.push(frame);
+                    packet.commit();
+                }
+                assert_distinct_live(&live);
+                assert_eq!(batch.finish().rejected, 2);
+            }
+            assert_eq!(
+                harness.free_generated_frames(),
+                baseline,
+                "rejected frame was not returned to the physical pool"
+            );
+            let events = harness.drain_generated_events();
+            assert_event_bindings(&live, &events);
+        }
+    }
+
+    pub fn unknown_egress_is_rejected_without_submission<H: GeneratedUnknownEgressHarness>() {
+        let mut harness = H::new();
+        harness.set_generated_allocation_budget(1);
+        let unknown = harness.unknown_generated_egress();
+        assert!(harness.endpoint(unknown).is_none());
+        let frame = {
+            let (io, observer) = harness.io_and_observer();
+            let mut batch = io.begin_generated(unknown);
+            let mut packet = batch.allocate(60).expect("generated allocation");
+            packet.bytes_mut().fill(0xa1);
+            let frame = observer.bind(packet.bytes_mut(), 60);
+            packet.commit();
+            let completion = batch.finish();
+            assert_eq!((completion.accepted, completion.rejected), (0, 1));
+            frame
+        };
+        let events = harness.drain_generated_events();
+        assert_event_bindings(&[frame], &events);
+        assert_eq!(
+            events[0].kind,
+            GeneratedEventKind::TxRejected {
+                attempted_egress: unknown,
+                endpoint: None,
+            }
         );
     }
 }

--- a/crates/io-sim/src/lib.rs
+++ b/crates/io-sim/src/lib.rs
@@ -57,6 +57,13 @@ pub struct RecycledFrame {
     pub bytes: Vec<u8>,
 }
 
+/// Extended cold-path capture for backend conformance observation.
+#[derive(Debug, Eq, PartialEq)]
+pub struct RecycledFrameCapture {
+    pub frame: RecycledFrame,
+    pub rejected_egress: Option<IfId>,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum GeneratedRecycleCause {
     Cancelled,
@@ -82,7 +89,7 @@ pub struct SimIo {
     next_sequence: u64,
     rx: VecDeque<Slot>,
     tx: VecDeque<TxFrame>,
-    recycled: VecDeque<RecycledFrame>,
+    recycled: VecDeque<RecycledFrameCapture>,
     generated_recycled: VecDeque<GeneratedRecycledFrame>,
     generated_budget: usize,
     generated_max_frame: usize,
@@ -145,6 +152,10 @@ impl SimIo {
     }
 
     pub fn pop_recycled(&mut self) -> Option<RecycledFrame> {
+        self.recycled.pop_front().map(|capture| capture.frame)
+    }
+
+    pub fn pop_recycled_capture(&mut self) -> Option<RecycledFrameCapture> {
         self.recycled.pop_front()
     }
 
@@ -452,7 +463,7 @@ impl PacketIo for SimIo {
 pub struct SimBatch<'a> {
     rx: &'a mut VecDeque<Slot>,
     tx: &'a mut VecDeque<TxFrame>,
-    recycled: &'a mut VecDeque<RecycledFrame>,
+    recycled: &'a mut VecDeque<RecycledFrameCapture>,
     accept_budget: &'a mut usize,
     remaining: usize,
     counters: BatchCounters,
@@ -502,7 +513,7 @@ impl PacketBatch for SimBatch<'_> {
 pub struct SimSlot<'a> {
     slot: Option<Slot>,
     tx: &'a mut VecDeque<TxFrame>,
-    recycled: &'a mut VecDeque<RecycledFrame>,
+    recycled: &'a mut VecDeque<RecycledFrameCapture>,
     accept_budget: &'a mut usize,
     counters: &'a mut BatchCounters,
 }
@@ -523,11 +534,14 @@ impl PacketSlot for SimSlot<'_> {
                 self.counters.tx_requested += 1;
                 if *self.accept_budget == 0 {
                     self.counters.tx_rejected += 1;
-                    self.recycled.push_back(RecycledFrame {
-                        sequence: slot.sequence,
-                        ingress: slot.ingress,
-                        cause: RecycleCause::TxRejected,
-                        bytes: slot.bytes,
+                    self.recycled.push_back(RecycledFrameCapture {
+                        frame: RecycledFrame {
+                            sequence: slot.sequence,
+                            ingress: slot.ingress,
+                            cause: RecycleCause::TxRejected,
+                            bytes: slot.bytes,
+                        },
+                        rejected_egress: Some(egress),
                     });
                 } else {
                     *self.accept_budget -= 1;
@@ -731,11 +745,14 @@ impl SimGeneratedSlot<'_> {
 
 impl SimSlot<'_> {
     fn recycle(&mut self, slot: Slot, cause: RecycleCause) {
-        self.recycled.push_back(RecycledFrame {
-            sequence: slot.sequence,
-            ingress: slot.ingress,
-            cause,
-            bytes: slot.bytes,
+        self.recycled.push_back(RecycledFrameCapture {
+            frame: RecycledFrame {
+                sequence: slot.sequence,
+                ingress: slot.ingress,
+                cause,
+                bytes: slot.bytes,
+            },
+            rejected_egress: None,
         });
         self.counters.recycled += 1;
     }

--- a/crates/io-sim/tests/backend_conformance.rs
+++ b/crates/io-sim/tests/backend_conformance.rs
@@ -1,0 +1,189 @@
+use ruster_io_conformance::{
+    generated, rx, BufferToken, GeneratedDisposition, GeneratedFinishErrorHarness,
+    GeneratedHarness, GeneratedOutcome, InjectedFrame, RxDisposition, RxHarness, RxOutcome,
+};
+use ruster_io_sim::{FrameOrigin, GeneratedRecycleCause, RecycleCause, SimIo};
+
+struct SimHarness {
+    io: SimIo,
+}
+
+impl RxHarness for SimHarness {
+    type Io = SimIo;
+
+    fn new() -> Self {
+        Self { io: SimIo::new() }
+    }
+
+    fn io(&mut self) -> &mut Self::Io {
+        &mut self.io
+    }
+
+    fn inject_rx(&mut self, ingress: ruster_core::IfId, bytes: Vec<u8>) -> InjectedFrame {
+        let allocation_address = bytes.as_ptr() as usize;
+        let sequence = self.io.inject(ingress, bytes);
+        InjectedFrame {
+            token: BufferToken::new(sequence),
+            allocation_address,
+        }
+    }
+
+    fn set_rx_accept_budget(&mut self, budget: usize) {
+        self.io.set_received_accept_budget(budget);
+    }
+
+    fn pending_rx(&self) -> usize {
+        self.io.pending_rx()
+    }
+
+    fn drain_rx_outcomes(&mut self) -> Vec<RxOutcome> {
+        let mut outcomes = Vec::new();
+        while let Some(frame) = self.io.pop_tx() {
+            assert!(matches!(frame.origin, FrameOrigin::Received { .. }));
+            outcomes.push(RxOutcome {
+                token: BufferToken::new(frame.sequence),
+                allocation_address: frame.bytes.as_ptr() as usize,
+                ingress: frame.ingress,
+                bytes: frame.bytes,
+                disposition: RxDisposition::Accepted {
+                    egress: frame.egress,
+                },
+            });
+        }
+        while let Some(frame) = self.io.pop_recycled() {
+            let disposition = match frame.cause {
+                RecycleCause::Forwarding(reason) => RxDisposition::Recycled { reason },
+                RecycleCause::Consumed(reason) => RxDisposition::Consumed { reason },
+                RecycleCause::TxRejected => RxDisposition::Rejected,
+                RecycleCause::LeaseAbandoned => RxDisposition::Abandoned,
+            };
+            outcomes.push(RxOutcome {
+                token: BufferToken::new(frame.sequence),
+                allocation_address: frame.bytes.as_ptr() as usize,
+                ingress: frame.ingress,
+                bytes: frame.bytes,
+                disposition,
+            });
+        }
+        outcomes
+    }
+}
+
+impl GeneratedHarness for SimHarness {
+    type Io = SimIo;
+
+    fn new() -> Self {
+        Self { io: SimIo::new() }
+    }
+
+    fn io(&mut self) -> &mut Self::Io {
+        &mut self.io
+    }
+
+    fn set_generated_allocation_budget(&mut self, budget: usize) {
+        self.io.set_generated_budget(budget);
+    }
+
+    fn set_generated_max_frame(&mut self, max_frame: usize) {
+        self.io.set_generated_max_frame(max_frame);
+    }
+
+    fn set_generated_accept_budget(&mut self, budget: usize) {
+        self.io.set_generated_accept_budget(budget);
+    }
+
+    fn drain_generated_outcomes(&mut self) -> Vec<GeneratedOutcome> {
+        let mut outcomes = Vec::new();
+        while let Some(frame) = self.io.pop_tx() {
+            assert_eq!(frame.origin, FrameOrigin::Generated);
+            outcomes.push(GeneratedOutcome {
+                token: BufferToken::new(frame.sequence),
+                allocation_address: frame.bytes.as_ptr() as usize,
+                egress: frame.egress,
+                bytes: frame.bytes,
+                disposition: GeneratedDisposition::Accepted,
+            });
+        }
+        while let Some(frame) = self.io.pop_generated_recycled() {
+            let disposition = match frame.cause {
+                GeneratedRecycleCause::Cancelled => GeneratedDisposition::Cancelled,
+                GeneratedRecycleCause::Abandoned => GeneratedDisposition::Abandoned,
+                GeneratedRecycleCause::TxRejected => GeneratedDisposition::Rejected,
+            };
+            outcomes.push(GeneratedOutcome {
+                token: BufferToken::new(frame.sequence),
+                allocation_address: frame.bytes.as_ptr() as usize,
+                egress: frame.egress,
+                bytes: frame.bytes,
+                disposition,
+            });
+        }
+        outcomes
+    }
+}
+
+impl GeneratedFinishErrorHarness for SimHarness {
+    fn fail_next_generated_finish(&mut self) {
+        self.io.fail_next_generated_finish();
+    }
+}
+
+#[test]
+fn rx_budget_and_unleased_slots_are_exact() {
+    rx::budget_and_unleased_slots_are_exact::<SimHarness>();
+}
+
+#[test]
+fn rx_commit_is_in_place_and_egress_typed() {
+    rx::commit_is_in_place_and_egress_typed::<SimHarness>();
+}
+
+#[test]
+fn rx_recycle_consume_and_abandon_are_distinct() {
+    rx::recycle_consume_and_abandon_are_distinct::<SimHarness>();
+}
+
+#[test]
+fn rx_partial_reject_reclaims_exactly_before_finish_returns() {
+    rx::partial_reject_reclaims_exactly_before_finish_returns::<SimHarness>();
+}
+
+#[test]
+fn rx_repeated_reject_cycles_conserve_ownership() {
+    rx::repeated_reject_cycles_conserve_rx_ownership::<SimHarness>();
+}
+
+#[test]
+fn generated_empty_session_has_zero_accounting() {
+    generated::empty_session_has_zero_accounting::<SimHarness>();
+}
+
+#[test]
+fn generated_allocation_failures_are_typed_and_transfer_no_ownership() {
+    generated::allocation_failures_are_typed_and_transfer_no_ownership::<SimHarness>();
+}
+
+#[test]
+fn generated_commit_cancel_and_abandon_are_exact_length_and_distinct() {
+    generated::commit_cancel_and_abandon_are_exact_length_and_distinct::<SimHarness>();
+}
+
+#[test]
+fn generated_partial_reject_reclaims_exactly_before_finish_returns() {
+    generated::partial_reject_reclaims_exactly_before_finish_returns::<SimHarness>();
+}
+
+#[test]
+fn generated_sessions_pin_egress_without_cross_talk() {
+    generated::sessions_pin_egress_without_cross_talk::<SimHarness>();
+}
+
+#[test]
+fn generated_repeated_reject_cycles_conserve_pool() {
+    generated::repeated_reject_cycles_conserve_generated_pool::<SimHarness>();
+}
+
+#[test]
+fn generated_partial_reject_with_finish_error_is_exact() {
+    generated::partial_reject_with_finish_error_is_exact::<SimHarness>();
+}

--- a/crates/io-sim/tests/backend_conformance.rs
+++ b/crates/io-sim/tests/backend_conformance.rs
@@ -1,31 +1,99 @@
+use std::collections::BTreeMap;
+
 use ruster_io_conformance::{
-    generated, rx, BufferToken, GeneratedDisposition, GeneratedFinishErrorHarness,
-    GeneratedHarness, GeneratedOutcome, InjectedFrame, RxDisposition, RxHarness, RxOutcome,
+    generated, rx, BufferToken, GeneratedCompletionHarness, GeneratedEvent, GeneratedEventKind,
+    GeneratedFinishErrorHarness, GeneratedHarness, GeneratedReclaim, LeaseObserver, LiveFrame,
+    RxCompletionHarness, RxEvent, RxEventKind, RxHarness, RxReclaim, TxCompletion, TxEndpoint,
 };
 use ruster_io_sim::{FrameOrigin, GeneratedRecycleCause, RecycleCause, SimIo};
 
+#[derive(Default)]
+struct SimObserver {
+    generations: BTreeMap<u64, u64>,
+    live: BTreeMap<usize, LiveFrame>,
+}
+
+impl LeaseObserver for SimObserver {
+    fn bind(&mut self, bytes: &[u8], requested_len: usize) -> LiveFrame {
+        assert_eq!(bytes.len(), requested_len);
+        let visible_address = bytes.as_ptr() as usize;
+        let frame_id = visible_address as u64;
+        assert!(
+            !self.live.contains_key(&visible_address),
+            "sim allocation address is already live"
+        );
+        let generation = self.generations.entry(frame_id).or_default();
+        *generation = generation.checked_add(1).expect("sim generation overflow");
+        let frame = LiveFrame {
+            token: BufferToken::new(frame_id, *generation),
+            visible_address,
+            requested_len,
+        };
+        self.live.insert(visible_address, frame);
+        frame
+    }
+
+    fn observe(&self, bytes: &[u8]) -> LiveFrame {
+        let address = bytes.as_ptr() as usize;
+        let frame = *self
+            .live
+            .get(&address)
+            .expect("sim terminal event has no lease-time identity");
+        assert_eq!(bytes.len(), frame.requested_len);
+        frame
+    }
+}
+
+impl SimObserver {
+    fn reclaim(&mut self, bytes: &[u8]) -> LiveFrame {
+        let frame = self.observe(bytes);
+        assert_eq!(self.live.remove(&frame.visible_address), Some(frame));
+        frame
+    }
+
+    fn complete(&mut self, frame: LiveFrame) {
+        assert_eq!(self.live.remove(&frame.visible_address), Some(frame));
+    }
+}
+
 struct SimHarness {
     io: SimIo,
+    observer: SimObserver,
+    rx_completions: Vec<TxCompletion>,
+    generated_completions: Vec<TxCompletion>,
+}
+
+impl SimHarness {
+    fn endpoint(egress: ruster_core::IfId) -> TxEndpoint {
+        TxEndpoint {
+            interface: egress,
+            queue: 0,
+        }
+    }
 }
 
 impl RxHarness for SimHarness {
     type Io = SimIo;
+    type Observer = SimObserver;
 
     fn new() -> Self {
-        Self { io: SimIo::new() }
-    }
-
-    fn io(&mut self) -> &mut Self::Io {
-        &mut self.io
-    }
-
-    fn inject_rx(&mut self, ingress: ruster_core::IfId, bytes: Vec<u8>) -> InjectedFrame {
-        let allocation_address = bytes.as_ptr() as usize;
-        let sequence = self.io.inject(ingress, bytes);
-        InjectedFrame {
-            token: BufferToken::new(sequence),
-            allocation_address,
+        Self {
+            io: SimIo::new(),
+            observer: SimObserver::default(),
+            rx_completions: Vec::new(),
+            generated_completions: Vec::new(),
         }
+    }
+
+    fn io_and_observer(&mut self) -> (&mut Self::Io, &mut Self::Observer) {
+        (&mut self.io, &mut self.observer)
+    }
+
+    fn inject_rx(&mut self, ingress: ruster_core::IfId, mut bytes: Vec<u8>) -> LiveFrame {
+        let requested_len = bytes.len();
+        let frame = self.observer.bind(&bytes, requested_len);
+        self.io.inject(ingress, std::mem::take(&mut bytes));
+        frame
     }
 
     fn set_rx_accept_budget(&mut self, budget: usize) {
@@ -36,48 +104,85 @@ impl RxHarness for SimHarness {
         self.io.pending_rx()
     }
 
-    fn drain_rx_outcomes(&mut self) -> Vec<RxOutcome> {
-        let mut outcomes = Vec::new();
+    fn endpoint(&self, egress: ruster_core::IfId) -> Option<TxEndpoint> {
+        Some(Self::endpoint(egress))
+    }
+
+    fn drain_rx_events(&mut self) -> Vec<RxEvent> {
+        let mut events = Vec::new();
         while let Some(frame) = self.io.pop_tx() {
             assert!(matches!(frame.origin, FrameOrigin::Received { .. }));
-            outcomes.push(RxOutcome {
-                token: BufferToken::new(frame.sequence),
-                allocation_address: frame.bytes.as_ptr() as usize,
+            let identity = self.observer.observe(&frame.bytes);
+            let endpoint = Self::endpoint(frame.egress);
+            self.rx_completions.push(TxCompletion {
+                frame: identity,
+                endpoint,
+            });
+            events.push(RxEvent {
+                frame: identity,
                 ingress: frame.ingress,
-                bytes: frame.bytes,
-                disposition: RxDisposition::Accepted {
-                    egress: frame.egress,
+                kind: RxEventKind::TxSubmitted {
+                    endpoint,
+                    descriptor_len: frame.bytes.len(),
                 },
+                bytes: frame.bytes,
             });
         }
-        while let Some(frame) = self.io.pop_recycled() {
-            let disposition = match frame.cause {
-                RecycleCause::Forwarding(reason) => RxDisposition::Recycled { reason },
-                RecycleCause::Consumed(reason) => RxDisposition::Consumed { reason },
-                RecycleCause::TxRejected => RxDisposition::Rejected,
-                RecycleCause::LeaseAbandoned => RxDisposition::Abandoned,
+        while let Some(capture) = self.io.pop_recycled_capture() {
+            let frame = capture.frame;
+            let identity = self.observer.reclaim(&frame.bytes);
+            let kind = match frame.cause {
+                RecycleCause::Forwarding(reason) => {
+                    assert_eq!(capture.rejected_egress, None);
+                    RxEventKind::Reclaimed(RxReclaim::Recycled(reason))
+                }
+                RecycleCause::Consumed(reason) => {
+                    assert_eq!(capture.rejected_egress, None);
+                    RxEventKind::Reclaimed(RxReclaim::Consumed(reason))
+                }
+                RecycleCause::TxRejected => {
+                    let attempted_egress = capture.rejected_egress.expect("sim rejected TX egress");
+                    RxEventKind::TxRejected {
+                        attempted_egress,
+                        endpoint: Some(Self::endpoint(attempted_egress)),
+                    }
+                }
+                RecycleCause::LeaseAbandoned => {
+                    assert_eq!(capture.rejected_egress, None);
+                    RxEventKind::Reclaimed(RxReclaim::Abandoned)
+                }
             };
-            outcomes.push(RxOutcome {
-                token: BufferToken::new(frame.sequence),
-                allocation_address: frame.bytes.as_ptr() as usize,
+            events.push(RxEvent {
+                frame: identity,
                 ingress: frame.ingress,
                 bytes: frame.bytes,
-                disposition,
+                kind,
             });
         }
-        outcomes
+        events
+    }
+}
+
+impl RxCompletionHarness for SimHarness {
+    fn complete_rx_submissions(&mut self) -> Vec<TxCompletion> {
+        let completions = std::mem::take(&mut self.rx_completions);
+        for completion in &completions {
+            self.observer.complete(completion.frame);
+        }
+        completions
     }
 }
 
 impl GeneratedHarness for SimHarness {
     type Io = SimIo;
+    type Observer = SimObserver;
 
     fn new() -> Self {
-        Self { io: SimIo::new() }
+        <Self as RxHarness>::new()
     }
 
-    fn io(&mut self) -> &mut Self::Io {
-        &mut self.io
+    fn io_and_observer(&mut self) -> (&mut Self::Io, &mut Self::Observer) {
+        (&mut self.io, &mut self.observer)
     }
 
     fn set_generated_allocation_budget(&mut self, budget: usize) {
@@ -92,33 +197,52 @@ impl GeneratedHarness for SimHarness {
         self.io.set_generated_accept_budget(budget);
     }
 
-    fn drain_generated_outcomes(&mut self) -> Vec<GeneratedOutcome> {
-        let mut outcomes = Vec::new();
+    fn endpoint(&self, egress: ruster_core::IfId) -> Option<TxEndpoint> {
+        Some(Self::endpoint(egress))
+    }
+
+    fn drain_generated_events(&mut self) -> Vec<GeneratedEvent> {
+        let mut events = Vec::new();
         while let Some(frame) = self.io.pop_tx() {
             assert_eq!(frame.origin, FrameOrigin::Generated);
-            outcomes.push(GeneratedOutcome {
-                token: BufferToken::new(frame.sequence),
-                allocation_address: frame.bytes.as_ptr() as usize,
+            let identity = self.observer.observe(&frame.bytes);
+            let endpoint = Self::endpoint(frame.egress);
+            self.generated_completions.push(TxCompletion {
+                frame: identity,
+                endpoint,
+            });
+            events.push(GeneratedEvent {
+                frame: identity,
                 egress: frame.egress,
+                kind: GeneratedEventKind::TxSubmitted {
+                    endpoint,
+                    descriptor_len: frame.bytes.len(),
+                },
                 bytes: frame.bytes,
-                disposition: GeneratedDisposition::Accepted,
             });
         }
         while let Some(frame) = self.io.pop_generated_recycled() {
-            let disposition = match frame.cause {
-                GeneratedRecycleCause::Cancelled => GeneratedDisposition::Cancelled,
-                GeneratedRecycleCause::Abandoned => GeneratedDisposition::Abandoned,
-                GeneratedRecycleCause::TxRejected => GeneratedDisposition::Rejected,
+            let identity = self.observer.reclaim(&frame.bytes);
+            let kind = match frame.cause {
+                GeneratedRecycleCause::Cancelled => {
+                    GeneratedEventKind::Reclaimed(GeneratedReclaim::Cancelled)
+                }
+                GeneratedRecycleCause::Abandoned => {
+                    GeneratedEventKind::Reclaimed(GeneratedReclaim::Abandoned)
+                }
+                GeneratedRecycleCause::TxRejected => GeneratedEventKind::TxRejected {
+                    attempted_egress: frame.egress,
+                    endpoint: Some(Self::endpoint(frame.egress)),
+                },
             };
-            outcomes.push(GeneratedOutcome {
-                token: BufferToken::new(frame.sequence),
-                allocation_address: frame.bytes.as_ptr() as usize,
+            events.push(GeneratedEvent {
+                frame: identity,
                 egress: frame.egress,
                 bytes: frame.bytes,
-                disposition,
+                kind,
             });
         }
-        outcomes
+        events
     }
 }
 
@@ -128,14 +252,24 @@ impl GeneratedFinishErrorHarness for SimHarness {
     }
 }
 
+impl GeneratedCompletionHarness for SimHarness {
+    fn complete_generated_submissions(&mut self) -> Vec<TxCompletion> {
+        let completions = std::mem::take(&mut self.generated_completions);
+        for completion in &completions {
+            self.observer.complete(completion.frame);
+        }
+        completions
+    }
+}
+
 #[test]
 fn rx_budget_and_unleased_slots_are_exact() {
     rx::budget_and_unleased_slots_are_exact::<SimHarness>();
 }
 
 #[test]
-fn rx_commit_is_in_place_and_egress_typed() {
-    rx::commit_is_in_place_and_egress_typed::<SimHarness>();
+fn rx_commit_is_submitted_in_place_with_exact_descriptor() {
+    rx::commit_is_submitted_in_place_with_exact_descriptor::<SimHarness>();
 }
 
 #[test]
@@ -144,13 +278,13 @@ fn rx_recycle_consume_and_abandon_are_distinct() {
 }
 
 #[test]
-fn rx_partial_reject_reclaims_exactly_before_finish_returns() {
-    rx::partial_reject_reclaims_exactly_before_finish_returns::<SimHarness>();
+fn rx_partial_reject_reclaims_exact_tokens() {
+    rx::partial_reject_reclaims_exact_tokens::<SimHarness>();
 }
 
 #[test]
-fn rx_repeated_reject_cycles_conserve_ownership() {
-    rx::repeated_reject_cycles_conserve_rx_ownership::<SimHarness>();
+fn rx_completion_advances_the_exact_submitted_token() {
+    rx::completion_advances_the_exact_submitted_token::<SimHarness>();
 }
 
 #[test]
@@ -159,31 +293,31 @@ fn generated_empty_session_has_zero_accounting() {
 }
 
 #[test]
-fn generated_allocation_failures_are_typed_and_transfer_no_ownership() {
-    generated::allocation_failures_are_typed_and_transfer_no_ownership::<SimHarness>();
+fn generated_allocation_failures_bind_only_successful_ownership() {
+    generated::allocation_failures_bind_only_successful_ownership::<SimHarness>();
 }
 
 #[test]
-fn generated_commit_cancel_and_abandon_are_exact_length_and_distinct() {
-    generated::commit_cancel_and_abandon_are_exact_length_and_distinct::<SimHarness>();
+fn generated_commit_cancel_and_abandon_bind_exact_lengths() {
+    generated::commit_cancel_and_abandon_bind_exact_lengths::<SimHarness>();
 }
 
 #[test]
-fn generated_partial_reject_reclaims_exactly_before_finish_returns() {
-    generated::partial_reject_reclaims_exactly_before_finish_returns::<SimHarness>();
+fn generated_partial_reject_reclaims_exact_tokens() {
+    generated::partial_reject_reclaims_exact_tokens::<SimHarness>();
 }
 
 #[test]
-fn generated_sessions_pin_egress_without_cross_talk() {
-    generated::sessions_pin_egress_without_cross_talk::<SimHarness>();
-}
-
-#[test]
-fn generated_repeated_reject_cycles_conserve_pool() {
-    generated::repeated_reject_cycles_conserve_generated_pool::<SimHarness>();
+fn generated_sessions_bind_concrete_endpoints() {
+    generated::sessions_bind_concrete_endpoints::<SimHarness>();
 }
 
 #[test]
 fn generated_partial_reject_with_finish_error_is_exact() {
     generated::partial_reject_with_finish_error_is_exact::<SimHarness>();
+}
+
+#[test]
+fn generated_completion_advances_the_exact_submitted_token() {
+    generated::completion_advances_the_exact_submitted_token::<SimHarness>();
 }

--- a/crates/io-sim/tests/backend_conformance.rs
+++ b/crates/io-sim/tests/backend_conformance.rs
@@ -4,6 +4,7 @@ use ruster_io_conformance::{
     generated, rx, BufferToken, GeneratedCompletionHarness, GeneratedEvent, GeneratedEventKind,
     GeneratedFinishErrorHarness, GeneratedHarness, GeneratedReclaim, LeaseObserver, LiveFrame,
     RxCompletionHarness, RxEvent, RxEventKind, RxHarness, RxReclaim, TxCompletion, TxEndpoint,
+    CONFORMANCE_LAN, CONFORMANCE_LAN_ENDPOINT, CONFORMANCE_WAN, CONFORMANCE_WAN_ENDPOINT,
 };
 use ruster_io_sim::{FrameOrigin, GeneratedRecycleCause, RecycleCause, SimIo};
 
@@ -64,10 +65,14 @@ struct SimHarness {
 }
 
 impl SimHarness {
-    fn endpoint(egress: ruster_core::IfId) -> TxEndpoint {
-        TxEndpoint {
-            interface: egress,
-            queue: 0,
+    fn publication_endpoint(egress: ruster_core::IfId) -> TxEndpoint {
+        match egress {
+            CONFORMANCE_LAN => CONFORMANCE_LAN_ENDPOINT,
+            CONFORMANCE_WAN => CONFORMANCE_WAN_ENDPOINT,
+            _ => TxEndpoint {
+                interface: egress,
+                queue: u32::MAX,
+            },
         }
     }
 }
@@ -104,16 +109,12 @@ impl RxHarness for SimHarness {
         self.io.pending_rx()
     }
 
-    fn endpoint(&self, egress: ruster_core::IfId) -> Option<TxEndpoint> {
-        Some(Self::endpoint(egress))
-    }
-
     fn drain_rx_events(&mut self) -> Vec<RxEvent> {
         let mut events = Vec::new();
         while let Some(frame) = self.io.pop_tx() {
             assert!(matches!(frame.origin, FrameOrigin::Received { .. }));
             let identity = self.observer.observe(&frame.bytes);
-            let endpoint = Self::endpoint(frame.egress);
+            let endpoint = Self::publication_endpoint(frame.egress);
             self.rx_completions.push(TxCompletion {
                 frame: identity,
                 endpoint,
@@ -144,7 +145,7 @@ impl RxHarness for SimHarness {
                     let attempted_egress = capture.rejected_egress.expect("sim rejected TX egress");
                     RxEventKind::TxRejected {
                         attempted_egress,
-                        endpoint: Some(Self::endpoint(attempted_egress)),
+                        endpoint: Some(Self::publication_endpoint(attempted_egress)),
                     }
                 }
                 RecycleCause::LeaseAbandoned => {
@@ -164,6 +165,8 @@ impl RxHarness for SimHarness {
 }
 
 impl RxCompletionHarness for SimHarness {
+    // Sim has no hardware CQ. This capability models the same logical
+    // completion boundary while keeping submission and completion distinct.
     fn complete_rx_submissions(&mut self) -> Vec<TxCompletion> {
         let completions = std::mem::take(&mut self.rx_completions);
         for completion in &completions {
@@ -197,16 +200,12 @@ impl GeneratedHarness for SimHarness {
         self.io.set_generated_accept_budget(budget);
     }
 
-    fn endpoint(&self, egress: ruster_core::IfId) -> Option<TxEndpoint> {
-        Some(Self::endpoint(egress))
-    }
-
     fn drain_generated_events(&mut self) -> Vec<GeneratedEvent> {
         let mut events = Vec::new();
         while let Some(frame) = self.io.pop_tx() {
             assert_eq!(frame.origin, FrameOrigin::Generated);
             let identity = self.observer.observe(&frame.bytes);
-            let endpoint = Self::endpoint(frame.egress);
+            let endpoint = Self::publication_endpoint(frame.egress);
             self.generated_completions.push(TxCompletion {
                 frame: identity,
                 endpoint,
@@ -232,7 +231,7 @@ impl GeneratedHarness for SimHarness {
                 }
                 GeneratedRecycleCause::TxRejected => GeneratedEventKind::TxRejected {
                     attempted_egress: frame.egress,
-                    endpoint: Some(Self::endpoint(frame.egress)),
+                    endpoint: Some(Self::publication_endpoint(frame.egress)),
                 },
             };
             events.push(GeneratedEvent {
@@ -253,6 +252,8 @@ impl GeneratedFinishErrorHarness for SimHarness {
 }
 
 impl GeneratedCompletionHarness for SimHarness {
+    // Sim has no hardware CQ. This capability models the same logical
+    // completion boundary while keeping submission and completion distinct.
     fn complete_generated_submissions(&mut self) -> Vec<TxCompletion> {
         let completions = std::mem::take(&mut self.generated_completions);
         for completion in &completions {


### PR DESCRIPTION
## Summary
- add a reusable static-dispatch conformance crate for borrowed backend-owned RX/generated buffers
- verify terminal lease accounting, concrete physical endpoints, exact descriptor lengths, unknown egress, and logical completion boundaries
- add finite-pool/CQ capability tests proving publish→inflight→actual completion→same-frame higher-generation reuse
- add whole-batch Drop lifecycle coverage and fault fakes for leaks, aliasing, stale generations, wrong length/ring, token invention, and cross-session carryover
- adopt the applicable mandatory/logical cases in io-sim without claiming physical UMEM/CQ capabilities

## Validation
- implementer ran all README gates and requirements checks on latest-main rebased SHA d76cc24f9ac6b37f5be66377ff7ac1876c8db70a
- independent backend ownership review: APPROVE after three adversarial fix cycles
- conformance 10/10, negative fault meta-tests 8/8, sim adapter 12/12
- io-conformance remains an io-sim dev-dependency; production core dependency tree is unchanged

Prototype-v0.1 Rust was not copied or adapted.