### PR TITLE
Add musl compile check to required CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,19 @@ jobs:
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
       - run: cargo check --workspace --all-targets --all-features --locked
 
+  musl:
+    name: Musl
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        with:
+          toolchain: 1.97.1
+          targets: x86_64-unknown-linux-musl
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
+      - run: cargo check --workspace --all-targets --all-features --locked --target x86_64-unknown-linux-musl
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -174,6 +174,16 @@ scripts/check-requirements.sh
 scripts/test-check-requirements.sh
 ```
 
+CIの`Musl` jobは、固定したRust 1.97.1へtargetを追加して次のcheckも実行します。
+
+```bash
+rustup target add --toolchain 1.97.1 x86_64-unknown-linux-musl
+cargo +1.97.1 check --workspace --all-targets --all-features --locked --target x86_64-unknown-linux-musl
+```
+
+これはmusl targetでworkspace全体が型検査を通ることだけを確認するcompile-only portability
+checkです。musl向けartifactのlink、test実行、実NICでのruntime compatibilityは保証しません。
+
 設計契約と非対象は[architecture v0.2](docs/architecture-v0.2.md)、要件とRFC根拠は
 [requirements](docs/requirements-v0.2.md)、production backendから自宅ラボ運用までの
 優先順位とmilestoneは[development plan](docs/development-plan-v0.2.md)を参照してください。


### PR DESCRIPTION
## Summary

- add an independent `Musl` CI job using pinned Rust 1.97.1
- check every workspace target and feature with the locked dependency graph for `x86_64-unknown-linux-musl`
- document that the gate is compile-only and does not claim link, test, or runtime compatibility

No requirements ledger row is needed because this changes CI portability evidence, not packet behavior or RFC conformance.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-targets --all-features --locked`
- `cargo test --doc --workspace --all-features --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `cargo check --workspace --all-targets --all-features --locked`
- `scripts/check-requirements.sh`
- `scripts/test-check-requirements.sh`
- `cargo +1.97.1 check --workspace --all-targets --all-features --locked --target x86_64-unknown-linux-musl`
- workflow YAML parsed successfully; all `uses` entries remain pinned to full SHAs

After merge, repository rules should add `Musl` as a required status context.