### PR TITLE
test(security): add bounded deterministic smoke runner

### DIFF
--- a/crates/io-sim/tests/r16a_support/artifact.rs
+++ b/crates/io-sim/tests/r16a_support/artifact.rs
@@ -1,0 +1,408 @@
+use std::{
+    env,
+    fs::{self, File, OpenOptions},
+    io::{Read, Write},
+    path::{Component, Path, PathBuf},
+};
+
+use super::envelope::{CaseEnvelope, MAX_ENVELOPE_LEN};
+
+pub const ARTIFACT_DIR_ENV: &str = "RUSTER_R16A_ARTIFACT_DIR";
+pub const REPLAY_ENV: &str = "RUSTER_R16A_REPLAY";
+const MAX_DETAIL_BYTES: usize = 4_096;
+const MAX_JSONL_BYTES: usize = 65_536;
+
+pub struct ArtifactWriter {
+    directory: PathBuf,
+}
+
+pub struct ArtifactRecord {
+    pub case_path: PathBuf,
+    pub jsonl_path: PathBuf,
+    pub repro: String,
+}
+
+impl ArtifactWriter {
+    pub fn from_env() -> Result<Option<Self>, String> {
+        match env::var(ARTIFACT_DIR_ENV) {
+            Ok(value) => Self::new(PathBuf::from(value)).map(Some),
+            Err(env::VarError::NotPresent) => Ok(None),
+            Err(env::VarError::NotUnicode(_)) => {
+                Err(format!("{ARTIFACT_DIR_ENV} must be valid UTF-8"))
+            }
+        }
+    }
+
+    pub fn new(directory: PathBuf) -> Result<Self, String> {
+        validate_absolute_path(&directory, "artifact directory")?;
+        if directory == Path::new("/") {
+            return Err("artifact directory cannot be filesystem root".to_owned());
+        }
+        Ok(Self { directory })
+    }
+
+    pub fn write(
+        &self,
+        encoded: &[u8],
+        case: &CaseEnvelope<'_>,
+        detail: &str,
+    ) -> Result<ArtifactRecord, String> {
+        if encoded.len() > MAX_ENVELOPE_LEN {
+            return Err("refusing to write oversized replay envelope".to_owned());
+        }
+        validate_no_symlink_components(&self.directory, "artifact directory", true)?;
+        match create_private_dir(&self.directory) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(error) => return Err(format!("create private artifact directory: {error}")),
+        }
+        let metadata = fs::symlink_metadata(&self.directory)
+            .map_err(|error| format!("inspect artifact directory: {error}"))?;
+        if metadata.file_type().is_symlink() || !metadata.is_dir() {
+            return Err("artifact directory must be a real directory, not a symlink".to_owned());
+        }
+        validate_private_directory(&metadata)?;
+
+        let stem = format!(
+            "r16a-{}-{:016x}-{:016x}",
+            case.target.name(),
+            case.seed,
+            case.case_index
+        );
+        for suffix in 0_u8..16 {
+            let unique = if suffix == 0 {
+                stem.clone()
+            } else {
+                format!("{stem}-{suffix}")
+            };
+            let case_path = self.directory.join(format!("{unique}.case"));
+            let jsonl_path = self.directory.join(format!("{unique}.jsonl"));
+            let mut case_file = match create_new(&case_path) {
+                Ok(file) => file,
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(error) => return Err(format!("create replay envelope: {error}")),
+            };
+            if let Err(error) = secure_created_file(&case_file, &metadata) {
+                drop(case_file);
+                return Err(failed_artifact_transaction(&error, &[&case_path]));
+            }
+            if let Err(error) = case_file.write_all(encoded) {
+                drop(case_file);
+                return Err(failed_artifact_transaction(
+                    &format!("write replay envelope: {error}"),
+                    &[&case_path],
+                ));
+            }
+            let repro = match replay_repro(&case_path) {
+                Ok(repro) => repro,
+                Err(error) => {
+                    drop(case_file);
+                    return Err(failed_artifact_transaction(
+                        &format!("build replay command: {error}"),
+                        &[&case_path],
+                    ));
+                }
+            };
+            let mut metadata_file = match create_new(&jsonl_path) {
+                Ok(file) => file,
+                Err(error) => {
+                    drop(case_file);
+                    if let Err(cleanup_error) = fs::remove_file(&case_path) {
+                        return Err(format!(
+                            "create artifact metadata: {error}; cleanup replay envelope: \
+                             {cleanup_error}"
+                        ));
+                    }
+                    if error.kind() == std::io::ErrorKind::AlreadyExists {
+                        continue;
+                    }
+                    return Err(format!("create artifact metadata: {error}"));
+                }
+            };
+            if let Err(error) = secure_created_file(&metadata_file, &metadata) {
+                drop(case_file);
+                drop(metadata_file);
+                return Err(failed_artifact_transaction(
+                    &error,
+                    &[&case_path, &jsonl_path],
+                ));
+            }
+            let git_sha = validated_git_sha();
+            let detail = bounded_detail(detail);
+            let line = format!(
+                "{{\"schema\":1,\"git_sha\":\"{}\",\"target\":\"{}\",\
+                 \"seed\":\"0x{:016x}\",\"case\":{},\"case_path\":\"{}\",\
+                 \"detail\":\"{}\",\"repro\":\"{}\"}}\n",
+                json_escape(&git_sha),
+                case.target.name(),
+                case.seed,
+                case.case_index,
+                json_escape(case_path.to_str().expect("validated UTF-8 path")),
+                json_escape(&detail),
+                json_escape(&repro),
+            );
+            if line.len() > MAX_JSONL_BYTES {
+                drop(case_file);
+                drop(metadata_file);
+                return Err(failed_artifact_transaction(
+                    "artifact metadata exceeds 65536-byte limit",
+                    &[&case_path, &jsonl_path],
+                ));
+            }
+            if let Err(error) = metadata_file.write_all(line.as_bytes()) {
+                drop(case_file);
+                drop(metadata_file);
+                return Err(failed_artifact_transaction(
+                    &format!("write artifact metadata: {error}"),
+                    &[&case_path, &jsonl_path],
+                ));
+            }
+            return Ok(ArtifactRecord {
+                case_path,
+                jsonl_path,
+                repro,
+            });
+        }
+        Err("all 16 bounded artifact names already exist".to_owned())
+    }
+}
+
+pub fn load_replay_from_env() -> Result<Option<(PathBuf, Vec<u8>)>, String> {
+    let value = match env::var(REPLAY_ENV) {
+        Ok(value) => value,
+        Err(env::VarError::NotPresent) => return Ok(None),
+        Err(env::VarError::NotUnicode(_)) => {
+            return Err(format!("{REPLAY_ENV} must be valid UTF-8"));
+        }
+    };
+    let path = PathBuf::from(value);
+    load_replay(path).map(Some)
+}
+
+pub fn load_replay(path: PathBuf) -> Result<(PathBuf, Vec<u8>), String> {
+    validate_absolute_path(&path, "replay path")?;
+    validate_no_symlink_components(&path, "replay path", false)?;
+    let path_metadata =
+        fs::symlink_metadata(&path).map_err(|error| format!("inspect replay path: {error}"))?;
+    if path_metadata.file_type().is_symlink() || !path_metadata.is_file() {
+        return Err("replay path must be one regular file, not a symlink".to_owned());
+    }
+    let file = File::open(&path).map_err(|error| format!("open replay file: {error}"))?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| format!("inspect opened replay file: {error}"))?;
+    if !metadata.is_file() {
+        return Err("replay path must open as one regular file".to_owned());
+    }
+    let length =
+        usize::try_from(metadata.len()).map_err(|_| "replay file length overflow".to_owned())?;
+    if length > MAX_ENVELOPE_LEN {
+        return Err(format!(
+            "replay file exceeds {MAX_ENVELOPE_LEN}-byte envelope limit"
+        ));
+    }
+    let mut bytes = Vec::with_capacity(length.saturating_add(1));
+    file.take(u64::try_from(MAX_ENVELOPE_LEN).unwrap() + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|error| format!("read replay file: {error}"))?;
+    if bytes.len() > MAX_ENVELOPE_LEN {
+        return Err(format!(
+            "replay file exceeds {MAX_ENVELOPE_LEN}-byte envelope limit"
+        ));
+    }
+    Ok((path, bytes))
+}
+
+pub fn seed_repro(target: &str, seed: u64, case_index: u64) -> String {
+    format!(
+        "RUSTER_R16A_TARGET={target} RUSTER_R16A_SEED=0x{seed:016x} \
+         RUSTER_R16A_CASE_START={case_index} RUSTER_R16A_CASES=1 \
+         cargo test --locked -p ruster-io-sim --test security_property_smoke \
+         r16a_bounded_smoke -- --ignored --exact --nocapture --test-threads=1"
+    )
+}
+
+pub fn replay_repro(path: &Path) -> Result<String, String> {
+    validate_absolute_path(path, "replay path")?;
+    Ok(format!(
+        "{REPLAY_ENV}={} cargo test --locked -p ruster-io-sim \
+         --test security_property_smoke r16a_bounded_smoke -- \
+         --ignored --exact --nocapture --test-threads=1",
+        path.to_str().expect("validated UTF-8 path")
+    ))
+}
+
+fn create_new(path: &Path) -> std::io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options.open(path)
+}
+
+fn create_private_dir(path: &Path) -> std::io::Result<()> {
+    let mut builder = fs::DirBuilder::new();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        builder.mode(0o700);
+    }
+    builder.create(path)
+}
+
+fn validate_private_directory(metadata: &fs::Metadata) -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if metadata.permissions().mode() & 0o777 != 0o700 {
+            return Err("artifact directory must have private mode 0700".to_owned());
+        }
+    }
+    Ok(())
+}
+
+fn secure_created_file(file: &File, directory: &fs::Metadata) -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+        file.set_permissions(fs::Permissions::from_mode(0o600))
+            .map_err(|error| format!("set private artifact file mode: {error}"))?;
+        let metadata = file
+            .metadata()
+            .map_err(|error| format!("inspect created artifact file: {error}"))?;
+        if metadata.permissions().mode() & 0o777 != 0o600 {
+            return Err("artifact file must have private mode 0600".to_owned());
+        }
+        if metadata.uid() != directory.uid() {
+            return Err("artifact directory must be owned by the artifact writer user".to_owned());
+        }
+    }
+    Ok(())
+}
+
+fn validate_no_symlink_components(
+    path: &Path,
+    label: &str,
+    allow_missing_leaf: bool,
+) -> Result<(), String> {
+    let mut current = PathBuf::from("/");
+    let components: Vec<_> = path.components().collect();
+    for (index, component) in components.iter().enumerate() {
+        let Component::Normal(part) = component else {
+            continue;
+        };
+        current.push(part);
+        match fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(format!("{label} cannot traverse symlinks"));
+            }
+            Ok(_) => {}
+            Err(error)
+                if error.kind() == std::io::ErrorKind::NotFound
+                    && allow_missing_leaf
+                    && index + 1 == components.len() => {}
+            Err(error) => return Err(format!("inspect {label} component: {error}")),
+        }
+    }
+    Ok(())
+}
+
+fn failed_artifact_transaction(context: &str, created: &[&Path]) -> String {
+    let mut cleanup_failures = String::new();
+    for path in created {
+        match fs::remove_file(path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                use std::fmt::Write;
+                write!(
+                    &mut cleanup_failures,
+                    " cleanup {}: {error};",
+                    path.display()
+                )
+                .unwrap();
+            }
+        }
+    }
+    if cleanup_failures.is_empty() {
+        context.to_owned()
+    } else {
+        format!("{context};{cleanup_failures}")
+    }
+}
+
+fn bounded_detail(detail: &str) -> String {
+    const MARKER: &str = "...[truncated]";
+    if detail.len() <= MAX_DETAIL_BYTES {
+        return detail.to_owned();
+    }
+    let mut end = MAX_DETAIL_BYTES - MARKER.len();
+    while !detail.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut bounded = detail[..end].to_owned();
+    bounded.push_str(MARKER);
+    bounded
+}
+
+fn validate_absolute_path(path: &Path, label: &str) -> Result<(), String> {
+    let text = path
+        .to_str()
+        .ok_or_else(|| format!("{label} must be valid UTF-8"))?;
+    if !path.is_absolute() {
+        return Err(format!("{label} must be explicit and absolute"));
+    }
+    if text.len() > 4_096 {
+        return Err(format!("{label} exceeds 4096 bytes"));
+    }
+    if !text.bytes().all(
+        |byte| matches!(byte, b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'/' | b'_' | b'-' | b'.' | b':'),
+    ) {
+        return Err(format!("{label} contains unsupported characters"));
+    }
+    if path.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::CurDir | Component::Prefix(_)
+        )
+    }) {
+        return Err(format!("{label} must be canonical without dot components"));
+    }
+    Ok(())
+}
+
+fn validated_git_sha() -> String {
+    match env::var("GITHUB_SHA") {
+        Ok(value)
+            if value.len() == 40
+                && value
+                    .bytes()
+                    .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase()) =>
+        {
+            value
+        }
+        _ => "unknown".to_owned(),
+    }
+}
+
+fn json_escape(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        match character {
+            '"' => escaped.push_str("\\\""),
+            '\\' => escaped.push_str("\\\\"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            character if character.is_control() => {
+                use std::fmt::Write;
+                write!(&mut escaped, "\\u{:04x}", u32::from(character)).unwrap();
+            }
+            character => escaped.push(character),
+        }
+    }
+    escaped
+}

--- a/crates/io-sim/tests/r16a_support/corpus.rs
+++ b/crates/io-sim/tests/r16a_support/corpus.rs
@@ -1,0 +1,269 @@
+use super::envelope::{
+    CaseEnvelope, DropCode, Expected, ParserAccept, ResolutionSummary, Target, MAX_CORPUS_CASES,
+};
+
+pub struct NamedCase {
+    pub name: &'static str,
+    pub encoded: Vec<u8>,
+}
+
+pub fn past_regressions() -> Vec<NamedCase> {
+    let cases = vec![
+        parser_vlan(),
+        parser_reserved_flag(),
+        checksum_rfc1071(),
+        checksum_odd_length(),
+        admission_other_interface_mac(),
+        admission_local_source_claim(),
+        admission_arp_foreign_destination(),
+        resolution_cancel_and_reuse(),
+        resolution_zero_action_capacity(),
+    ];
+    assert!(
+        cases.len() <= MAX_CORPUS_CASES,
+        "static corpus exceeds {MAX_CORPUS_CASES}-case v1 bound"
+    );
+    cases
+}
+
+fn parser_vlan() -> NamedCase {
+    let mut frame = vec![0_u8; 14];
+    frame[12..14].copy_from_slice(&0x8100_u16.to_be_bytes());
+    encoded(
+        "vlan-inner-frame-not-parsed",
+        Target::Parser,
+        0,
+        0,
+        Expected::Drop(DropCode::new(2).unwrap()),
+        frame,
+    )
+}
+
+fn parser_reserved_flag() -> NamedCase {
+    let frame = ipv4_frame(
+        [0x02, 0, 0, 0, 0, 0x10],
+        [0x02, 0, 0, 0, 0, 0x40],
+        [192, 0, 2, 10],
+        [198, 51, 100, 20],
+        0x8000,
+        64,
+    );
+    encoded(
+        "reserved-ipv4-flag-parser-accept",
+        Target::Parser,
+        1,
+        1,
+        Expected::ParserAccept(ParserAccept {
+            header_len: 20,
+            total_len: 20,
+            ttl: 64,
+            protocol: 17,
+            source: [192, 0, 2, 10],
+            destination: [198, 51, 100, 20],
+            checksum: read_be_u16(&frame, 24),
+        }),
+        frame,
+    )
+}
+
+fn checksum_rfc1071() -> NamedCase {
+    encoded(
+        "rfc1071-known-vector",
+        Target::Checksum,
+        2,
+        2,
+        Expected::Checksum(0x220d),
+        vec![0x00, 0x01, 0xf2, 0x03, 0xf4, 0xf5, 0xf6, 0xf7],
+    )
+}
+
+fn checksum_odd_length() -> NamedCase {
+    encoded(
+        "odd-length-high-byte-padding",
+        Target::Checksum,
+        3,
+        3,
+        Expected::Checksum(0xfbfd),
+        vec![0x01, 0x02, 0x03],
+    )
+}
+
+fn admission_other_interface_mac() -> NamedCase {
+    let frame = ipv4_frame(
+        [0x02, 0, 0, 0, 0, 0x20],
+        [0x02, 0, 0, 0, 0, 0x40],
+        [192, 0, 2, 10],
+        [198, 51, 100, 20],
+        0x4000,
+        64,
+    );
+    encoded(
+        "cross-interface-router-mac",
+        Target::Admission,
+        4,
+        4,
+        Expected::Drop(DropCode::new(138).unwrap()),
+        frame,
+    )
+}
+
+fn admission_local_source_claim() -> NamedCase {
+    let frame = ipv4_frame(
+        [0x02, 0, 0, 0, 0, 0x10],
+        [0x02, 0, 0, 0, 0, 0x40],
+        [192, 0, 2, 1],
+        [198, 51, 100, 20],
+        0x4000,
+        64,
+    );
+    encoded(
+        "local-ipv4-source-claim",
+        Target::Admission,
+        5,
+        5,
+        Expected::Drop(DropCode::new(145).unwrap()),
+        frame,
+    )
+}
+
+fn admission_arp_foreign_destination() -> NamedCase {
+    let mut frame = vec![0_u8; 60];
+    frame[0..6].copy_from_slice(&[0x02, 0, 0, 0, 0, 0x20]);
+    frame[6..12].copy_from_slice(&[0x02, 0, 0, 0, 0, 0x40]);
+    frame[12..14].copy_from_slice(&0x0806_u16.to_be_bytes());
+    frame[14..16].copy_from_slice(&1_u16.to_be_bytes());
+    frame[16..18].copy_from_slice(&0x0800_u16.to_be_bytes());
+    frame[18] = 6;
+    frame[19] = 4;
+    frame[20..22].copy_from_slice(&1_u16.to_be_bytes());
+    frame[22..28].copy_from_slice(&[0x02, 0, 0, 0, 0, 0x41]);
+    frame[28..32].copy_from_slice(&[192, 0, 2, 10]);
+    frame[38..42].copy_from_slice(&[192, 0, 2, 1]);
+    encoded(
+        "arp-foreign-unicast-before-merge",
+        Target::Admission,
+        6,
+        6,
+        Expected::Drop(DropCode::new(138).unwrap()),
+        frame,
+    )
+}
+
+fn resolution_cancel_and_reuse() -> NamedCase {
+    let payload = vec![
+        2, 2, 2, 6, // capacities and operation count
+        0, 0, // miss target 0
+        0, 0, // duplicate miss target 0
+        0, 1, // miss target 1
+        1, 0, // learn target 0
+        2, 7, // invalid future frame cannot poison time
+        0, 2, // reuse the cancelled state/action capacity
+    ];
+    encoded(
+        "resolution-cancel-reuse-and-invalid-future",
+        Target::Resolution,
+        7,
+        7,
+        Expected::Resolution(ResolutionSummary {
+            pending_states: 2,
+            pending_actions: 2,
+            dynamic_neighbors: 1,
+            queued: 3,
+            suppressed: 1,
+            state_full: 0,
+            action_full: 0,
+            clock_regressions: 0,
+        }),
+        payload,
+    )
+}
+
+fn resolution_zero_action_capacity() -> NamedCase {
+    let payload = vec![
+        1, 0, 0, 2, // capacities and operation count
+        0, 0, // miss has a state slot but no action slot
+        1, 0, // cache full learning does not invent/cancel state
+    ];
+    encoded(
+        "resolution-zero-action-and-cache-capacity",
+        Target::Resolution,
+        8,
+        8,
+        Expected::Resolution(ResolutionSummary {
+            pending_states: 0,
+            pending_actions: 0,
+            dynamic_neighbors: 0,
+            queued: 0,
+            suppressed: 0,
+            state_full: 0,
+            action_full: 1,
+            clock_regressions: 0,
+        }),
+        payload,
+    )
+}
+
+fn encoded(
+    name: &'static str,
+    target: Target,
+    seed: u64,
+    case_index: u64,
+    expected: Expected,
+    payload: Vec<u8>,
+) -> NamedCase {
+    let encoded = CaseEnvelope {
+        target,
+        seed,
+        case_index,
+        now: 100,
+        ingress: 1,
+        expected,
+        payload: &payload,
+    }
+    .encode()
+    .unwrap();
+    NamedCase { name, encoded }
+}
+
+fn ipv4_frame(
+    destination_mac: [u8; 6],
+    source_mac: [u8; 6],
+    source: [u8; 4],
+    destination: [u8; 4],
+    flags_offset: u16,
+    ttl: u8,
+) -> Vec<u8> {
+    let mut frame = vec![0_u8; 34];
+    frame[0..6].copy_from_slice(&destination_mac);
+    frame[6..12].copy_from_slice(&source_mac);
+    frame[12..14].copy_from_slice(&0x0800_u16.to_be_bytes());
+    frame[14] = 0x45;
+    frame[16..18].copy_from_slice(&20_u16.to_be_bytes());
+    frame[20..22].copy_from_slice(&flags_offset.to_be_bytes());
+    frame[22] = ttl;
+    frame[23] = 17;
+    frame[26..30].copy_from_slice(&source);
+    frame[30..34].copy_from_slice(&destination);
+    let checksum = checksum(&frame[14..34]);
+    frame[24..26].copy_from_slice(&checksum.to_be_bytes());
+    frame
+}
+
+fn checksum(bytes: &[u8]) -> u16 {
+    let mut sum = 0_u64;
+    for chunk in bytes.chunks(2) {
+        sum += if chunk.len() == 2 {
+            u64::from(u16::from_be_bytes([chunk[0], chunk[1]]))
+        } else {
+            u64::from(chunk[0]) << 8
+        };
+    }
+    while sum >> 16 != 0 {
+        sum = (sum & 0xffff) + (sum >> 16);
+    }
+    !(sum as u16)
+}
+
+fn read_be_u16(bytes: &[u8], offset: usize) -> u16 {
+    u16::from_be_bytes(bytes[offset..offset + 2].try_into().unwrap())
+}

--- a/crates/io-sim/tests/r16a_support/envelope.rs
+++ b/crates/io-sim/tests/r16a_support/envelope.rs
@@ -1,0 +1,357 @@
+use std::fmt;
+
+pub const ENVELOPE_VERSION: u8 = 1;
+pub const HEADER_LEN: usize = 72;
+pub const MAX_ENVELOPE_LEN: usize = 131_072;
+pub const MAX_PAYLOAD_LEN: usize = MAX_ENVELOPE_LEN - HEADER_LEN;
+pub const MAX_CORPUS_CASES: usize = 512;
+pub const MAX_CASES_PER_RUN: u64 = 65_536;
+pub const MAX_RESOLUTION_NOW: u64 = u64::MAX - 1_000_064;
+
+const MAGIC: [u8; 4] = *b"R16A";
+const EXPECTED_LEN: usize = 32;
+const EXPECTED_OFFSET: usize = 40;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum Target {
+    Parser = 1,
+    Checksum = 2,
+    Admission = 3,
+    Resolution = 4,
+}
+
+impl Target {
+    pub const ALL: [Self; 4] = [
+        Self::Parser,
+        Self::Checksum,
+        Self::Admission,
+        Self::Resolution,
+    ];
+
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Parser => "parser",
+            Self::Checksum => "checksum",
+            Self::Admission => "admission",
+            Self::Resolution => "resolution",
+        }
+    }
+
+    pub fn from_name(name: &str) -> Result<Self, EnvelopeError> {
+        match name {
+            "parser" => Ok(Self::Parser),
+            "checksum" => Ok(Self::Checksum),
+            "admission" => Ok(Self::Admission),
+            "resolution" => Ok(Self::Resolution),
+            _ => Err(EnvelopeError::UnknownTargetName),
+        }
+    }
+
+    fn from_tag(tag: u8) -> Result<Self, EnvelopeError> {
+        match tag {
+            1 => Ok(Self::Parser),
+            2 => Ok(Self::Checksum),
+            3 => Ok(Self::Admission),
+            4 => Ok(Self::Resolution),
+            _ => Err(EnvelopeError::UnknownTargetTag),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DropCode(u16);
+
+impl DropCode {
+    pub fn new(value: u16) -> Result<Self, EnvelopeError> {
+        if (1..=145).contains(&value) {
+            Ok(Self(value))
+        } else {
+            Err(EnvelopeError::UnknownDropCode)
+        }
+    }
+
+    pub const fn value(self) -> u16 {
+        self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ParserAccept {
+    pub header_len: u8,
+    pub total_len: u16,
+    pub ttl: u8,
+    pub protocol: u8,
+    pub source: [u8; 4],
+    pub destination: [u8; 4],
+    pub checksum: u16,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ResolutionSummary {
+    pub pending_states: u16,
+    pub pending_actions: u16,
+    pub dynamic_neighbors: u16,
+    pub queued: u32,
+    pub suppressed: u32,
+    pub state_full: u32,
+    pub action_full: u32,
+    pub clock_regressions: u32,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Expected {
+    ParserAccept(ParserAccept),
+    Drop(DropCode),
+    Checksum(u16),
+    AdmissionTx,
+    Resolution(ResolutionSummary),
+}
+
+impl Expected {
+    const fn tag(self) -> u8 {
+        match self {
+            Self::ParserAccept(_) => 1,
+            Self::Drop(_) => 2,
+            Self::Checksum(_) => 3,
+            Self::AdmissionTx => 4,
+            Self::Resolution(_) => 5,
+        }
+    }
+
+    fn valid_for(self, target: Target) -> bool {
+        matches!(
+            (target, self),
+            (Target::Parser, Self::ParserAccept(_) | Self::Drop(_))
+                | (Target::Checksum, Self::Checksum(_))
+                | (Target::Admission, Self::Drop(_) | Self::AdmissionTx)
+                | (Target::Resolution, Self::Resolution(_))
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CaseEnvelope<'a> {
+    pub target: Target,
+    pub seed: u64,
+    pub case_index: u64,
+    pub now: u64,
+    pub ingress: u16,
+    pub expected: Expected,
+    pub payload: &'a [u8],
+}
+
+impl CaseEnvelope<'_> {
+    pub fn encode(&self) -> Result<Vec<u8>, EnvelopeError> {
+        if !self.expected.valid_for(self.target) {
+            return Err(EnvelopeError::ExpectedTargetMismatch);
+        }
+        if self.case_index >= MAX_CASES_PER_RUN {
+            return Err(EnvelopeError::CaseIndexOutOfRange);
+        }
+        if self.target == Target::Resolution && self.now > MAX_RESOLUTION_NOW {
+            return Err(EnvelopeError::ResolutionTimeOutOfRange);
+        }
+        if self.payload.len() > MAX_PAYLOAD_LEN {
+            return Err(EnvelopeError::PayloadTooLarge);
+        }
+        let payload_len =
+            u32::try_from(self.payload.len()).map_err(|_| EnvelopeError::PayloadTooLarge)?;
+        let mut encoded = vec![0_u8; HEADER_LEN + self.payload.len()];
+        encoded[0..4].copy_from_slice(&MAGIC);
+        encoded[4] = ENVELOPE_VERSION;
+        encoded[5] = self.target as u8;
+        encoded[6] = self.expected.tag();
+        encoded[8..16].copy_from_slice(&self.seed.to_le_bytes());
+        encoded[16..24].copy_from_slice(&self.case_index.to_le_bytes());
+        encoded[24..32].copy_from_slice(&self.now.to_le_bytes());
+        encoded[32..34].copy_from_slice(&self.ingress.to_le_bytes());
+        encoded[36..40].copy_from_slice(&payload_len.to_le_bytes());
+        encode_expected(
+            self.expected,
+            &mut encoded[EXPECTED_OFFSET..EXPECTED_OFFSET + EXPECTED_LEN],
+        );
+        encoded[HEADER_LEN..].copy_from_slice(self.payload);
+        Ok(encoded)
+    }
+}
+
+pub fn parse(encoded: &[u8]) -> Result<CaseEnvelope<'_>, EnvelopeError> {
+    if encoded.len() > MAX_ENVELOPE_LEN {
+        return Err(EnvelopeError::EnvelopeTooLarge);
+    }
+    if encoded.len() < HEADER_LEN {
+        return Err(EnvelopeError::HeaderTruncated);
+    }
+    if encoded[0..4] != MAGIC {
+        return Err(EnvelopeError::BadMagic);
+    }
+    if encoded[4] != ENVELOPE_VERSION {
+        return Err(EnvelopeError::UnsupportedVersion);
+    }
+    let target = Target::from_tag(encoded[5])?;
+    if encoded[7] != 0 || encoded[34..36] != [0; 2] {
+        return Err(EnvelopeError::ReservedNotZero);
+    }
+    let payload_len =
+        usize::try_from(read_u32(encoded, 36)?).map_err(|_| EnvelopeError::PayloadTooLarge)?;
+    if payload_len > MAX_PAYLOAD_LEN {
+        return Err(EnvelopeError::PayloadTooLarge);
+    }
+    let exact_len = HEADER_LEN
+        .checked_add(payload_len)
+        .ok_or(EnvelopeError::EnvelopeTooLarge)?;
+    if encoded.len() != exact_len {
+        return Err(EnvelopeError::LengthMismatch);
+    }
+    let expected_bytes = &encoded[EXPECTED_OFFSET..EXPECTED_OFFSET + EXPECTED_LEN];
+    let expected = decode_expected(encoded[6], expected_bytes)?;
+    if !expected.valid_for(target) {
+        return Err(EnvelopeError::ExpectedTargetMismatch);
+    }
+    let case_index = read_u64(encoded, 16)?;
+    if case_index >= MAX_CASES_PER_RUN {
+        return Err(EnvelopeError::CaseIndexOutOfRange);
+    }
+    let now = read_u64(encoded, 24)?;
+    if target == Target::Resolution && now > MAX_RESOLUTION_NOW {
+        return Err(EnvelopeError::ResolutionTimeOutOfRange);
+    }
+    Ok(CaseEnvelope {
+        target,
+        seed: read_u64(encoded, 8)?,
+        case_index,
+        now,
+        ingress: read_u16(encoded, 32)?,
+        expected,
+        payload: &encoded[HEADER_LEN..],
+    })
+}
+
+fn encode_expected(expected: Expected, bytes: &mut [u8]) {
+    debug_assert_eq!(bytes.len(), EXPECTED_LEN);
+    match expected {
+        Expected::ParserAccept(value) => {
+            bytes[0] = value.header_len;
+            bytes[1..3].copy_from_slice(&value.total_len.to_le_bytes());
+            bytes[3] = value.ttl;
+            bytes[4] = value.protocol;
+            bytes[5..9].copy_from_slice(&value.source);
+            bytes[9..13].copy_from_slice(&value.destination);
+            bytes[13..15].copy_from_slice(&value.checksum.to_le_bytes());
+        }
+        Expected::Drop(code) => bytes[0..2].copy_from_slice(&code.value().to_le_bytes()),
+        Expected::Checksum(checksum) => bytes[0..2].copy_from_slice(&checksum.to_le_bytes()),
+        Expected::AdmissionTx => {}
+        Expected::Resolution(summary) => {
+            bytes[0..2].copy_from_slice(&summary.pending_states.to_le_bytes());
+            bytes[2..4].copy_from_slice(&summary.pending_actions.to_le_bytes());
+            bytes[4..6].copy_from_slice(&summary.dynamic_neighbors.to_le_bytes());
+            bytes[6..10].copy_from_slice(&summary.queued.to_le_bytes());
+            bytes[10..14].copy_from_slice(&summary.suppressed.to_le_bytes());
+            bytes[14..18].copy_from_slice(&summary.state_full.to_le_bytes());
+            bytes[18..22].copy_from_slice(&summary.action_full.to_le_bytes());
+            bytes[22..26].copy_from_slice(&summary.clock_regressions.to_le_bytes());
+        }
+    }
+}
+
+fn decode_expected(tag: u8, bytes: &[u8]) -> Result<Expected, EnvelopeError> {
+    debug_assert_eq!(bytes.len(), EXPECTED_LEN);
+    let (expected, used) = match tag {
+        1 => (
+            Expected::ParserAccept(ParserAccept {
+                header_len: bytes[0],
+                total_len: read_u16(bytes, 1)?,
+                ttl: bytes[3],
+                protocol: bytes[4],
+                source: bytes[5..9].try_into().unwrap(),
+                destination: bytes[9..13].try_into().unwrap(),
+                checksum: read_u16(bytes, 13)?,
+            }),
+            15,
+        ),
+        2 => (Expected::Drop(DropCode::new(read_u16(bytes, 0)?)?), 2),
+        3 => (Expected::Checksum(read_u16(bytes, 0)?), 2),
+        4 => (Expected::AdmissionTx, 0),
+        5 => (
+            Expected::Resolution(ResolutionSummary {
+                pending_states: read_u16(bytes, 0)?,
+                pending_actions: read_u16(bytes, 2)?,
+                dynamic_neighbors: read_u16(bytes, 4)?,
+                queued: read_u32(bytes, 6)?,
+                suppressed: read_u32(bytes, 10)?,
+                state_full: read_u32(bytes, 14)?,
+                action_full: read_u32(bytes, 18)?,
+                clock_regressions: read_u32(bytes, 22)?,
+            }),
+            26,
+        ),
+        _ => return Err(EnvelopeError::UnknownExpectedTag),
+    };
+    if bytes[used..].iter().any(|byte| *byte != 0) {
+        return Err(EnvelopeError::NonCanonicalExpected);
+    }
+    Ok(expected)
+}
+
+fn read_u16(bytes: &[u8], offset: usize) -> Result<u16, EnvelopeError> {
+    let word = bytes
+        .get(
+            offset
+                ..offset
+                    .checked_add(2)
+                    .ok_or(EnvelopeError::HeaderTruncated)?,
+        )
+        .ok_or(EnvelopeError::HeaderTruncated)?;
+    Ok(u16::from_le_bytes(word.try_into().unwrap()))
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> Result<u32, EnvelopeError> {
+    let word = bytes
+        .get(
+            offset
+                ..offset
+                    .checked_add(4)
+                    .ok_or(EnvelopeError::HeaderTruncated)?,
+        )
+        .ok_or(EnvelopeError::HeaderTruncated)?;
+    Ok(u32::from_le_bytes(word.try_into().unwrap()))
+}
+
+fn read_u64(bytes: &[u8], offset: usize) -> Result<u64, EnvelopeError> {
+    let word = bytes
+        .get(
+            offset
+                ..offset
+                    .checked_add(8)
+                    .ok_or(EnvelopeError::HeaderTruncated)?,
+        )
+        .ok_or(EnvelopeError::HeaderTruncated)?;
+    Ok(u64::from_le_bytes(word.try_into().unwrap()))
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EnvelopeError {
+    HeaderTruncated,
+    EnvelopeTooLarge,
+    PayloadTooLarge,
+    BadMagic,
+    UnsupportedVersion,
+    UnknownTargetTag,
+    UnknownTargetName,
+    UnknownExpectedTag,
+    UnknownDropCode,
+    ReservedNotZero,
+    NonCanonicalExpected,
+    ExpectedTargetMismatch,
+    CaseIndexOutOfRange,
+    ResolutionTimeOutOfRange,
+    LengthMismatch,
+}
+
+impl fmt::Display for EnvelopeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{self:?}")
+    }
+}

--- a/crates/io-sim/tests/r16a_support/mod.rs
+++ b/crates/io-sim/tests/r16a_support/mod.rs
@@ -1,0 +1,222 @@
+pub mod artifact;
+pub mod corpus;
+pub mod envelope;
+pub mod targets;
+
+use std::{
+    env,
+    panic::{self, AssertUnwindSafe},
+};
+
+use artifact::{
+    load_replay_from_env, replay_repro, seed_repro, ArtifactWriter, ARTIFACT_DIR_ENV, REPLAY_ENV,
+};
+use envelope::{parse, Target, MAX_CASES_PER_RUN};
+use targets::{generate_encoded, run_encoded, smoke_budget, SHORT_CASES, V1_SEEDS};
+
+const TARGET_ENV: &str = "RUSTER_R16A_TARGET";
+const SEED_ENV: &str = "RUSTER_R16A_SEED";
+const CASE_START_ENV: &str = "RUSTER_R16A_CASE_START";
+const CASES_ENV: &str = "RUSTER_R16A_CASES";
+
+pub fn run_short_matrix() {
+    let writer = ArtifactWriter::from_env().unwrap_or_else(|error| panic!("{error}"));
+    for target in Target::ALL {
+        for case_index in 0..SHORT_CASES {
+            let encoded = generate_encoded(target, V1_SEEDS[0], case_index)
+                .unwrap_or_else(|failure| panic!("{}", failure.detail));
+            let repro = seed_repro(target.name(), V1_SEEDS[0], case_index);
+            run_one(&encoded, writer.as_ref(), &repro);
+        }
+    }
+}
+
+pub fn run_past_corpus() {
+    let writer = ArtifactWriter::from_env().unwrap_or_else(|error| panic!("{error}"));
+    for case in corpus::past_regressions() {
+        let result = panic::catch_unwind(AssertUnwindSafe(|| {
+            run_one(&case.encoded, writer.as_ref(), corpus_repro())
+        }));
+        if let Err(payload) = result {
+            panic!(
+                "past regression corpus={} failed: {}",
+                case.name,
+                panic_detail(payload)
+            );
+        }
+    }
+}
+
+pub fn run_bounded_smoke() {
+    let writer = ArtifactWriter::from_env().unwrap_or_else(|error| panic!("{error}"));
+    if let Some((path, encoded)) =
+        load_replay_from_env().unwrap_or_else(|error| panic!("replay configuration: {error}"))
+    {
+        reject_seed_selection_with_replay();
+        parse(&encoded).unwrap_or_else(|error| {
+            panic!("replay={} typed parse failed: {error}", path.display())
+        });
+        let repro =
+            replay_repro(&path).unwrap_or_else(|error| panic!("replay configuration: {error}"));
+        run_one(&encoded, writer.as_ref(), &repro);
+        return;
+    }
+
+    match explicit_selection() {
+        Some(selection) => {
+            for case_index in selection.start..selection.start + selection.cases {
+                let encoded = generate_encoded(selection.target, selection.seed, case_index)
+                    .unwrap_or_else(|failure| panic!("{}", failure.detail));
+                let repro = seed_repro(selection.target.name(), selection.seed, case_index);
+                run_one(&encoded, writer.as_ref(), &repro);
+            }
+        }
+        None => {
+            for target in Target::ALL {
+                for seed in V1_SEEDS {
+                    for case_index in 0..smoke_budget(target) {
+                        let encoded = generate_encoded(target, seed, case_index)
+                            .unwrap_or_else(|failure| panic!("{}", failure.detail));
+                        let repro = seed_repro(target.name(), seed, case_index);
+                        run_one(&encoded, writer.as_ref(), &repro);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn run_one(encoded: &[u8], writer: Option<&ArtifactWriter>, fallback_repro: &str) {
+    let parsed = parse(encoded).unwrap_or_else(|error| panic!("typed envelope parse: {error}"));
+    let outcome = panic::catch_unwind(AssertUnwindSafe(|| run_encoded(encoded)));
+    let detail = match outcome {
+        Ok(Ok(())) => return,
+        Ok(Err(failure)) => failure.detail,
+        Err(payload) => format!("target panicked: {}", panic_detail(payload)),
+    };
+    let (artifact, repro) = if let Some(writer) = writer {
+        match writer.write(encoded, &parsed, &detail) {
+            Ok(record) => (
+                format!(
+                    "case={} metadata={}",
+                    record.case_path.display(),
+                    record.jsonl_path.display()
+                ),
+                record.repro,
+            ),
+            Err(error) => (format!("artifact_error={error}"), fallback_repro.to_owned()),
+        }
+    } else {
+        ("artifact=disabled".to_owned(), fallback_repro.to_owned())
+    };
+    panic!(
+        "R16A_FAILURE schema=1 target={} seed=0x{:016x} case={} {} detail={} repro={}",
+        parsed.target.name(),
+        parsed.seed,
+        parsed.case_index,
+        artifact,
+        detail,
+        repro
+    );
+}
+
+fn corpus_repro() -> &'static str {
+    "cargo test --locked -p ruster-io-sim --test security_property_smoke \
+     r16a_past_regression_corpus_is_exact -- --exact --nocapture --test-threads=1"
+}
+
+struct ExplicitSelection {
+    target: Target,
+    seed: u64,
+    start: u64,
+    cases: u64,
+}
+
+fn explicit_selection() -> Option<ExplicitSelection> {
+    let values = [
+        env_value(TARGET_ENV),
+        env_value(SEED_ENV),
+        env_value(CASE_START_ENV),
+        env_value(CASES_ENV),
+    ];
+    if values.iter().all(Option::is_none) {
+        return None;
+    }
+    if values.iter().any(Option::is_none) {
+        panic!("{TARGET_ENV}, {SEED_ENV}, {CASE_START_ENV}, and {CASES_ENV} must be set together");
+    }
+    let target = Target::from_name(values[0].as_deref().unwrap())
+        .unwrap_or_else(|error| panic!("{TARGET_ENV}: {error}"));
+    let seed = parse_u64(values[1].as_deref().unwrap())
+        .unwrap_or_else(|error| panic!("{SEED_ENV}: {error}"));
+    let start = parse_u64(values[2].as_deref().unwrap())
+        .unwrap_or_else(|error| panic!("{CASE_START_ENV}: {error}"));
+    let cases = parse_u64(values[3].as_deref().unwrap())
+        .unwrap_or_else(|error| panic!("{CASES_ENV}: {error}"));
+    if cases == 0 || cases > MAX_CASES_PER_RUN {
+        panic!("{CASES_ENV} must be in 1..={MAX_CASES_PER_RUN}");
+    }
+    let end = start
+        .checked_add(cases)
+        .unwrap_or_else(|| panic!("case range overflow"));
+    if end > MAX_CASES_PER_RUN {
+        panic!("case range end {end} exceeds {MAX_CASES_PER_RUN}");
+    }
+    Some(ExplicitSelection {
+        target,
+        seed,
+        start,
+        cases,
+    })
+}
+
+fn reject_seed_selection_with_replay() {
+    for name in [TARGET_ENV, SEED_ENV, CASE_START_ENV, CASES_ENV] {
+        if env_value(name).is_some() {
+            panic!("{REPLAY_ENV} cannot be combined with {name}");
+        }
+    }
+}
+
+fn env_value(name: &str) -> Option<String> {
+    match env::var(name) {
+        Ok(value) => Some(value),
+        Err(env::VarError::NotPresent) => None,
+        Err(env::VarError::NotUnicode(_)) => panic!("{name} must be valid UTF-8"),
+    }
+}
+
+fn parse_u64(value: &str) -> Result<u64, String> {
+    if let Some(hex) = value.strip_prefix("0x") {
+        if hex.is_empty() || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return Err("invalid hexadecimal u64".to_owned());
+        }
+        u64::from_str_radix(hex, 16).map_err(|error| error.to_string())
+    } else {
+        if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+            return Err("invalid decimal u64".to_owned());
+        }
+        value.parse::<u64>().map_err(|error| error.to_string())
+    }
+}
+
+fn panic_detail(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_owned()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "non-string panic payload".to_owned()
+    }
+}
+
+pub fn env_names() -> [&'static str; 6] {
+    [
+        TARGET_ENV,
+        SEED_ENV,
+        CASE_START_ENV,
+        CASES_ENV,
+        REPLAY_ENV,
+        ARTIFACT_DIR_ENV,
+    ]
+}

--- a/crates/io-sim/tests/r16a_support/targets.rs
+++ b/crates/io-sim/tests/r16a_support/targets.rs
@@ -1,0 +1,930 @@
+use ruster_core::{
+    forward_batch_with_resolution, internet_checksum, validate_ipv4_frame, DropReason,
+    DynamicNeighborSlot, ForwardingSnapshot, IfId, Interface, Ipv4Address, LocalIpv4Binding,
+    MacAddress, MonotonicMillis, Neighbor, NoTrace, PacketIo, ResolutionActionSlot,
+    ResolutionPolicy, ResolutionRuntime, ResolutionStateSlot, Route, ETHERNET_HEADER_LEN,
+};
+use ruster_io_sim::{RecycleCause, SimIo};
+
+use super::envelope::{
+    parse, CaseEnvelope, DropCode, Expected, ParserAccept, ResolutionSummary, Target,
+    MAX_CASES_PER_RUN,
+};
+
+pub const V1_SEEDS: [u64; 4] = [
+    0x6a09_e667_f3bc_c909,
+    0x243f_6a88_85a3_08d3,
+    0x9e37_79b9_7f4a_7c15,
+    0xd1b5_4a32_d192_ed03,
+];
+
+pub const SHORT_CASES: u64 = 32;
+pub const PARSER_SMOKE_CASES: u64 = 4_096;
+pub const CHECKSUM_SMOKE_CASES: u64 = 4_096;
+pub const ADMISSION_SMOKE_CASES: u64 = 2_048;
+pub const RESOLUTION_SMOKE_CASES: u64 = 2_048;
+
+const LAN: IfId = IfId(1);
+const WAN: IfId = IfId(2);
+const UNKNOWN: IfId = IfId(99);
+const LAN_MAC: MacAddress = MacAddress([0x02, 0, 0, 0, 0, 0x10]);
+const WAN_MAC: MacAddress = MacAddress([0x02, 0, 0, 0, 0, 0x20]);
+const NEXT_HOP_MAC: MacAddress = MacAddress([0x02, 0, 0, 0, 0, 0x30]);
+const PEER_MAC: MacAddress = MacAddress([0x02, 0, 0, 0, 0, 0x40]);
+const ARP_SHA: MacAddress = MacAddress([0x02, 0, 0, 0, 0, 0x41]);
+const LAN_LOCAL: Ipv4Address = Ipv4Address::from_octets([192, 0, 2, 1]);
+const LAN_PEER: Ipv4Address = Ipv4Address::from_octets([192, 0, 2, 10]);
+const DESTINATION: Ipv4Address = Ipv4Address::from_octets([198, 51, 100, 20]);
+const GATEWAY: Ipv4Address = Ipv4Address::from_octets([203, 0, 113, 1]);
+const RESOLUTION_LOCAL: Ipv4Address = Ipv4Address::from_octets([198, 51, 100, 1]);
+
+#[derive(Debug)]
+pub struct CaseFailure {
+    pub detail: String,
+}
+
+impl CaseFailure {
+    fn new(detail: impl Into<String>) -> Self {
+        Self {
+            detail: detail.into(),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct V1Rng(u64);
+
+impl V1Rng {
+    fn for_case(target: Target, seed: u64, case_index: u64) -> Self {
+        let domain = match target {
+            Target::Parser => 0x7061_7273_6572_0001,
+            Target::Checksum => 0x6368_6563_6b73_0001,
+            Target::Admission => 0x6164_6d69_7373_0001,
+            Target::Resolution => 0x7265_736f_6c76_0001,
+        };
+        Self(seed ^ domain ^ case_index.wrapping_mul(0x9e37_79b9_7f4a_7c15) ^ 0x7631_5f72_6e67_0001)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut value = self.0;
+        value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        value ^ (value >> 31)
+    }
+
+    fn below(&mut self, exclusive_upper: usize) -> usize {
+        assert!(exclusive_upper != 0);
+        usize::try_from(self.next_u64() % u64::try_from(exclusive_upper).unwrap()).unwrap()
+    }
+
+    fn byte(&mut self) -> u8 {
+        self.next_u64().to_le_bytes()[0]
+    }
+
+    fn fill(&mut self, bytes: &mut [u8]) {
+        for byte in bytes {
+            *byte = self.byte();
+        }
+    }
+}
+
+pub fn smoke_budget(target: Target) -> u64 {
+    match target {
+        Target::Parser => PARSER_SMOKE_CASES,
+        Target::Checksum => CHECKSUM_SMOKE_CASES,
+        Target::Admission => ADMISSION_SMOKE_CASES,
+        Target::Resolution => RESOLUTION_SMOKE_CASES,
+    }
+}
+
+pub fn generate_encoded(
+    target: Target,
+    seed: u64,
+    case_index: u64,
+) -> Result<Vec<u8>, CaseFailure> {
+    if case_index >= MAX_CASES_PER_RUN {
+        return Err(CaseFailure::new(format!(
+            "case index {case_index} exceeds v1 limit {MAX_CASES_PER_RUN}"
+        )));
+    }
+    match target {
+        Target::Parser => generate_parser(seed, case_index),
+        Target::Checksum => generate_checksum(seed, case_index),
+        Target::Admission => generate_admission(seed, case_index),
+        Target::Resolution => generate_resolution(seed, case_index),
+    }
+}
+
+pub fn run_encoded(encoded: &[u8]) -> Result<(), CaseFailure> {
+    let case = parse(encoded)
+        .map_err(|error| CaseFailure::new(format!("typed envelope parse failed: {error}")))?;
+    match case.target {
+        Target::Parser => run_parser(&case),
+        Target::Checksum => run_checksum(&case),
+        Target::Admission => run_admission(&case),
+        Target::Resolution => run_resolution(&case),
+    }
+}
+
+fn generate_parser(seed: u64, case_index: u64) -> Result<Vec<u8>, CaseFailure> {
+    let mut rng = V1Rng::for_case(Target::Parser, seed, case_index);
+    let ihl_words = u8::try_from(5 + rng.below(11)).unwrap();
+    let payload_len = rng.below(257);
+    let padding_len = rng.below(33);
+    let flags_offset = rng.next_u64().to_le_bytes()[0..2]
+        .try_into()
+        .map(u16::from_le_bytes)
+        .unwrap();
+    let ttl = rng.byte();
+    let source = Ipv4Address::from_octets([192, 0, 2, 1 + (rng.byte() % 253)]);
+    let destination = Ipv4Address::from_octets([198, 51, 100, 1 + (rng.byte() % 253)]);
+    let mut frame = ipv4_frame(
+        ihl_words,
+        payload_len,
+        padding_len,
+        flags_offset,
+        ttl,
+        source,
+        destination,
+    );
+    randomize_ipv4(&mut frame, &mut rng);
+    mutate_parser_frame(&mut frame, &mut rng);
+    let expected = match model_ipv4(&frame) {
+        Ok(value) => Expected::ParserAccept(value),
+        Err(reason) => Expected::Drop(
+            DropCode::new(reason as u16)
+                .map_err(|error| CaseFailure::new(format!("drop code: {error}")))?,
+        ),
+    };
+    CaseEnvelope {
+        target: Target::Parser,
+        seed,
+        case_index,
+        now: 0,
+        ingress: LAN.0,
+        expected,
+        payload: &frame,
+    }
+    .encode()
+    .map_err(|error| CaseFailure::new(format!("encode parser case: {error}")))
+}
+
+fn generate_checksum(seed: u64, case_index: u64) -> Result<Vec<u8>, CaseFailure> {
+    const BOUNDARIES: [usize; 24] = [
+        0, 1, 2, 3, 4, 7, 8, 15, 16, 19, 20, 31, 32, 59, 60, 61, 255, 256, 257, 1_499, 1_500,
+        1_501, 65_534, 65_535,
+    ];
+    let mut rng = V1Rng::for_case(Target::Checksum, seed, case_index);
+    let length = if usize::try_from(case_index).unwrap() < BOUNDARIES.len() {
+        BOUNDARIES[usize::try_from(case_index).unwrap()]
+    } else {
+        rng.below(4_097)
+    };
+    let mut payload = vec![0_u8; length];
+    rng.fill(&mut payload);
+    let expected = Expected::Checksum(oracle_checksum(&payload));
+    CaseEnvelope {
+        target: Target::Checksum,
+        seed,
+        case_index,
+        now: 0,
+        ingress: 0,
+        expected,
+        payload: &payload,
+    }
+    .encode()
+    .map_err(|error| CaseFailure::new(format!("encode checksum case: {error}")))
+}
+
+fn generate_admission(seed: u64, case_index: u64) -> Result<Vec<u8>, CaseFailure> {
+    let mut rng = V1Rng::for_case(Target::Admission, seed, case_index);
+    let selector = rng.below(10);
+    let mut ingress = LAN;
+    let (frame, expected) = match selector {
+        0 => {
+            let mut frame = ipv4_frame(5, 8, 3, 0x4000, 64, LAN_PEER, DESTINATION);
+            let mut foreign = [0_u8; 6];
+            rng.fill(&mut foreign);
+            foreign[0] &= 0xfe;
+            if foreign == [0; 6] || foreign == LAN_MAC.0 {
+                foreign[5] ^= 0x5a;
+            }
+            frame[0..6].copy_from_slice(&foreign);
+            (
+                frame,
+                drop_expected(DropReason::EthernetDestinationNotLocal)?,
+            )
+        }
+        1 => (
+            ipv4_frame(5, 0, 0, 0x4000, 64, LAN_LOCAL, DESTINATION),
+            drop_expected(DropReason::Ipv4SourceLocalAddress)?,
+        ),
+        2 => {
+            let mut frame = ipv4_frame(5, 0, 0, 0x4000, 64, LAN_PEER, DESTINATION);
+            frame[12..14].copy_from_slice(&[0x81, 0x00]);
+            (frame, drop_expected(DropReason::UnsupportedEtherType)?)
+        }
+        3 => {
+            let mut frame = ipv4_frame(5, 0, 0, 0x4000, 64, LAN_PEER, DESTINATION);
+            frame[24] ^= 1;
+            (frame, drop_expected(DropReason::Ipv4HeaderChecksumInvalid)?)
+        }
+        4 => (
+            ipv4_frame(6, 0, 0, 0x4000, 64, LAN_PEER, DESTINATION),
+            drop_expected(DropReason::Ipv4OptionsUnsupported)?,
+        ),
+        5 => (
+            ipv4_frame(5, 0, 0, 0x4000, 1, LAN_PEER, DESTINATION),
+            drop_expected(DropReason::Ipv4TtlExpired)?,
+        ),
+        6 => (
+            arp_frame(MacAddress([0xff; 6]), LAN_PEER, LAN_LOCAL),
+            Expected::AdmissionTx,
+        ),
+        7 => (
+            ipv4_frame(
+                5,
+                11,
+                7,
+                0x8000 | u16::try_from(rng.below(0x2000)).unwrap(),
+                2,
+                LAN_PEER,
+                DESTINATION,
+            ),
+            Expected::AdmissionTx,
+        ),
+        8 => {
+            ingress = UNKNOWN;
+            (
+                ipv4_frame(5, 0, 0, 0x4000, 64, LAN_PEER, DESTINATION),
+                drop_expected(DropReason::Ipv4IngressInterfaceUnknown)?,
+            )
+        }
+        _ => (
+            arp_frame(WAN_MAC, LAN_PEER, LAN_LOCAL),
+            drop_expected(DropReason::EthernetDestinationNotLocal)?,
+        ),
+    };
+    CaseEnvelope {
+        target: Target::Admission,
+        seed,
+        case_index,
+        now: 10_000 + case_index,
+        ingress: ingress.0,
+        expected,
+        payload: &frame,
+    }
+    .encode()
+    .map_err(|error| CaseFailure::new(format!("encode admission case: {error}")))
+}
+
+fn generate_resolution(seed: u64, case_index: u64) -> Result<Vec<u8>, CaseFailure> {
+    let mut rng = V1Rng::for_case(Target::Resolution, seed, case_index);
+    let state_capacity = u8::try_from(rng.below(5)).unwrap();
+    let action_capacity = u8::try_from(rng.below(5)).unwrap();
+    let dynamic_capacity = u8::try_from(rng.below(5)).unwrap();
+    let operation_count = 1 + rng.below(32);
+    let mut payload = Vec::with_capacity(4 + operation_count * 2);
+    payload.extend_from_slice(&[
+        state_capacity,
+        action_capacity,
+        dynamic_capacity,
+        u8::try_from(operation_count).unwrap(),
+    ]);
+    for _ in 0..operation_count {
+        payload.push(u8::try_from(rng.below(3)).unwrap());
+        payload.push(u8::try_from(rng.below(8)).unwrap());
+    }
+    let summary = model_resolution(&payload)?;
+    CaseEnvelope {
+        target: Target::Resolution,
+        seed,
+        case_index,
+        now: 100 + (case_index % 1_000),
+        ingress: LAN.0,
+        expected: Expected::Resolution(summary),
+        payload: &payload,
+    }
+    .encode()
+    .map_err(|error| CaseFailure::new(format!("encode resolution case: {error}")))
+}
+
+fn run_parser(case: &CaseEnvelope<'_>) -> Result<(), CaseFailure> {
+    let before = case.payload.to_vec();
+    let actual = validate_ipv4_frame(case.payload);
+    match (case.expected, actual) {
+        (Expected::ParserAccept(expected), Ok(actual)) => {
+            let actual = ParserAccept {
+                header_len: u8::try_from(actual.header_len)
+                    .map_err(|_| CaseFailure::new("production header length overflow"))?,
+                total_len: u16::try_from(actual.total_len)
+                    .map_err(|_| CaseFailure::new("production total length overflow"))?,
+                ttl: actual.ttl,
+                protocol: actual.protocol,
+                source: actual.source.octets(),
+                destination: actual.destination.octets(),
+                checksum: actual.checksum,
+            };
+            if actual != expected {
+                return Err(CaseFailure::new(format!(
+                    "parser accept mismatch expected={expected:?} actual={actual:?}"
+                )));
+            }
+        }
+        (Expected::Drop(expected), Err(actual)) if actual as u16 == expected.value() => {}
+        (expected, actual) => {
+            return Err(CaseFailure::new(format!(
+                "parser disposition mismatch expected={expected:?} actual={actual:?}"
+            )));
+        }
+    }
+    if case.payload != before {
+        return Err(CaseFailure::new("parser mutated input bytes"));
+    }
+    Ok(())
+}
+
+fn run_checksum(case: &CaseEnvelope<'_>) -> Result<(), CaseFailure> {
+    let Expected::Checksum(expected) = case.expected else {
+        return Err(CaseFailure::new(
+            "checksum target has non-checksum expected value",
+        ));
+    };
+    let before = case.payload.to_vec();
+    let actual = internet_checksum(case.payload);
+    if actual != expected {
+        return Err(CaseFailure::new(format!(
+            "checksum mismatch expected={expected:#06x} actual={actual:#06x} length={}",
+            case.payload.len()
+        )));
+    }
+    if case.payload != before {
+        return Err(CaseFailure::new("checksum target mutated input bytes"));
+    }
+    Ok(())
+}
+
+fn run_admission(case: &CaseEnvelope<'_>) -> Result<(), CaseFailure> {
+    let (routes, interfaces, neighbors, bindings) = admission_topology();
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &neighbors, &bindings).unwrap();
+    let mut states = [ResolutionStateSlot::EMPTY; 2];
+    let mut actions = [ResolutionActionSlot::EMPTY; 2];
+    let mut dynamic = [DynamicNeighborSlot::EMPTY; 2];
+    let mut runtime = ResolutionRuntime::with_dynamic_neighbors(
+        ResolutionPolicy::new(1_000, 2_000).unwrap(),
+        &mut states,
+        &mut actions,
+        &mut dynamic,
+    );
+    let before = case.payload.to_vec();
+    let before_counters = runtime.counters();
+    let before_failure = runtime.failure_counters();
+    let mut io = SimIo::new();
+    io.inject(IfId(case.ingress), case.payload.to_vec());
+    let batch = io.receive(1).unwrap();
+    let report = forward_batch_with_resolution(
+        batch,
+        &snapshot,
+        &mut runtime,
+        MonotonicMillis(case.now),
+        &mut NoTrace,
+    );
+    if !report.invariants_hold() {
+        return Err(CaseFailure::new("admission report invariant failed"));
+    }
+    match case.expected {
+        Expected::Drop(expected) => {
+            if (report.tx_requested, report.dropped, report.consumed) != (0, 1, 0) {
+                return Err(CaseFailure::new(format!(
+                    "admission expected drop, report=({}, {}, {})",
+                    report.tx_requested, report.dropped, report.consumed
+                )));
+            }
+            let recycled = io
+                .pop_recycled()
+                .ok_or_else(|| CaseFailure::new("admission drop missing recycle"))?;
+            match recycled.cause {
+                RecycleCause::Forwarding(actual) if actual as u16 == expected.value() => {}
+                actual => {
+                    return Err(CaseFailure::new(format!(
+                        "admission drop mismatch expected={} actual={actual:?}",
+                        expected.value()
+                    )));
+                }
+            }
+            if recycled.bytes != before {
+                return Err(CaseFailure::new("admission drop mutated packet bytes"));
+            }
+            if runtime.counters() != before_counters
+                || runtime.failure_counters() != before_failure
+                || runtime.pending_states() != 0
+                || runtime.pending_actions() != 0
+                || runtime.dynamic_neighbor_count() != 0
+            {
+                return Err(CaseFailure::new(
+                    "admission drop mutated resolution state or counters",
+                ));
+            }
+        }
+        Expected::AdmissionTx => {
+            if (report.tx_requested, report.dropped, report.consumed) != (1, 0, 0) {
+                return Err(CaseFailure::new(format!(
+                    "admission expected TX, report=({}, {}, {})",
+                    report.tx_requested, report.dropped, report.consumed
+                )));
+            }
+            let tx = io
+                .pop_tx()
+                .ok_or_else(|| CaseFailure::new("admission success missing TX frame"))?;
+            if read_be_u16(&before, 12) == Some(0x0800) {
+                let parsed = model_ipv4(&tx.bytes).map_err(|reason| {
+                    CaseFailure::new(format!("transmitted IPv4 model failure: {reason:?}"))
+                })?;
+                if parsed.ttl != 1 {
+                    return Err(CaseFailure::new("transmitted IPv4 TTL is not one"));
+                }
+            } else if tx.bytes.get(6..12) != Some(&LAN_MAC.0) {
+                return Err(CaseFailure::new(
+                    "ARP reply does not use ingress interface source MAC",
+                ));
+            }
+        }
+        expected => {
+            return Err(CaseFailure::new(format!(
+                "admission target expected type mismatch: {expected:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn run_resolution(case: &CaseEnvelope<'_>) -> Result<(), CaseFailure> {
+    let Expected::Resolution(expected) = case.expected else {
+        return Err(CaseFailure::new(
+            "resolution target has non-resolution expected value",
+        ));
+    };
+    let operations = parse_resolution_payload(case.payload)?;
+    let (routes, interfaces, bindings) = resolution_topology();
+    let snapshot = ForwardingSnapshot::new(&routes, &interfaces, &[], &bindings).unwrap();
+    let mut states = vec![ResolutionStateSlot::EMPTY; usize::from(operations.state_capacity)];
+    let mut actions = vec![ResolutionActionSlot::EMPTY; usize::from(operations.action_capacity)];
+    let mut dynamic = vec![DynamicNeighborSlot::EMPTY; usize::from(operations.dynamic_capacity)];
+    let mut runtime = ResolutionRuntime::with_dynamic_neighbors(
+        ResolutionPolicy::with_dynamic_neighbor_ttl(1_000, 2_000, 60_000).unwrap(),
+        &mut states,
+        &mut actions,
+        &mut dynamic,
+    );
+
+    for (step, operation) in operations.operations.iter().copied().enumerate() {
+        let now = case
+            .now
+            .checked_add(u64::try_from(step).unwrap())
+            .ok_or_else(|| CaseFailure::new("resolution operation time overflow"))?;
+        match operation {
+            ResolutionOperation::Miss(target) => {
+                let packet = resolution_ipv4(target_address(target));
+                let mut io = SimIo::new();
+                io.inject(LAN, packet);
+                let batch = io.receive(1).unwrap();
+                let report = forward_batch_with_resolution(
+                    batch,
+                    &snapshot,
+                    &mut runtime,
+                    MonotonicMillis(now),
+                    &mut NoTrace,
+                );
+                if !report.invariants_hold() {
+                    return Err(CaseFailure::new(format!(
+                        "resolution miss report invariant failed at step={step}"
+                    )));
+                }
+            }
+            ResolutionOperation::Learn(target) => {
+                let packet = resolution_arp_reply(target_address(target));
+                let mut io = SimIo::new();
+                io.inject(WAN, packet);
+                let batch = io.receive(1).unwrap();
+                let report = forward_batch_with_resolution(
+                    batch,
+                    &snapshot,
+                    &mut runtime,
+                    MonotonicMillis(now),
+                    &mut NoTrace,
+                );
+                if !report.invariants_hold() || report.consumed != 1 {
+                    return Err(CaseFailure::new(format!(
+                        "resolution learn disposition failed at step={step}"
+                    )));
+                }
+            }
+            ResolutionOperation::InvalidFuture => {
+                let mut packet = resolution_ipv4(DESTINATION);
+                packet[0..6].copy_from_slice(&[0x02, 9, 9, 9, 9, 9]);
+                let original = packet.clone();
+                let before = runtime.counters();
+                let before_summary = visible_resolution_summary(&runtime)?;
+                let mut io = SimIo::new();
+                io.inject(LAN, packet);
+                let batch = io.receive(1).unwrap();
+                let report = forward_batch_with_resolution(
+                    batch,
+                    &snapshot,
+                    &mut runtime,
+                    MonotonicMillis(
+                        now.checked_add(1_000_000)
+                            .ok_or_else(|| CaseFailure::new("invalid future time overflow"))?,
+                    ),
+                    &mut NoTrace,
+                );
+                let recycled = io
+                    .pop_recycled()
+                    .ok_or_else(|| CaseFailure::new("invalid future packet missing recycle"))?;
+                if report.dropped != 1
+                    || recycled.bytes != original
+                    || runtime.counters() != before
+                    || visible_resolution_summary(&runtime)? != before_summary
+                {
+                    return Err(CaseFailure::new(format!(
+                        "invalid future packet mutated resolution state at step={step}"
+                    )));
+                }
+            }
+        }
+    }
+    let actual = visible_resolution_summary(&runtime)?;
+    if actual != expected {
+        return Err(CaseFailure::new(format!(
+            "resolution summary mismatch expected={expected:?} actual={actual:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn visible_resolution_summary(
+    runtime: &ResolutionRuntime<'_>,
+) -> Result<ResolutionSummary, CaseFailure> {
+    let counters = runtime.counters();
+    Ok(ResolutionSummary {
+        pending_states: u16::try_from(runtime.pending_states())
+            .map_err(|_| CaseFailure::new("pending state count overflow"))?,
+        pending_actions: u16::try_from(runtime.pending_actions())
+            .map_err(|_| CaseFailure::new("pending action count overflow"))?,
+        dynamic_neighbors: u16::try_from(runtime.dynamic_neighbor_count())
+            .map_err(|_| CaseFailure::new("dynamic neighbor count overflow"))?,
+        queued: u32::try_from(counters.queued)
+            .map_err(|_| CaseFailure::new("queued counter overflow"))?,
+        suppressed: u32::try_from(counters.suppressed)
+            .map_err(|_| CaseFailure::new("suppressed counter overflow"))?,
+        state_full: u32::try_from(counters.state_full)
+            .map_err(|_| CaseFailure::new("state_full counter overflow"))?,
+        action_full: u32::try_from(counters.action_full)
+            .map_err(|_| CaseFailure::new("action_full counter overflow"))?,
+        clock_regressions: u32::try_from(counters.clock_regressions)
+            .map_err(|_| CaseFailure::new("clock counter overflow"))?,
+    })
+}
+
+#[derive(Clone, Copy)]
+enum ResolutionOperation {
+    Miss(u8),
+    Learn(u8),
+    InvalidFuture,
+}
+
+struct ResolutionOperations {
+    state_capacity: u8,
+    action_capacity: u8,
+    dynamic_capacity: u8,
+    operations: Vec<ResolutionOperation>,
+}
+
+fn parse_resolution_payload(payload: &[u8]) -> Result<ResolutionOperations, CaseFailure> {
+    let header = payload
+        .get(0..4)
+        .ok_or_else(|| CaseFailure::new("resolution operation header truncated"))?;
+    let operation_count = usize::from(header[3]);
+    if header[0] > 4 || header[1] > 4 || header[2] > 4 || operation_count > 64 {
+        return Err(CaseFailure::new(
+            "resolution capacity or operation count exceeds v1 bound",
+        ));
+    }
+    if payload.len() != 4 + operation_count * 2 {
+        return Err(CaseFailure::new(
+            "resolution operation payload length mismatch",
+        ));
+    }
+    let mut operations = Vec::with_capacity(operation_count);
+    for operation in payload[4..].chunks_exact(2) {
+        if operation[1] >= 8 {
+            return Err(CaseFailure::new("resolution target index exceeds v1 bound"));
+        }
+        operations.push(match operation[0] {
+            0 => ResolutionOperation::Miss(operation[1]),
+            1 => ResolutionOperation::Learn(operation[1]),
+            2 => ResolutionOperation::InvalidFuture,
+            _ => return Err(CaseFailure::new("unknown resolution operation tag")),
+        });
+    }
+    Ok(ResolutionOperations {
+        state_capacity: header[0],
+        action_capacity: header[1],
+        dynamic_capacity: header[2],
+        operations,
+    })
+}
+
+fn model_resolution(payload: &[u8]) -> Result<ResolutionSummary, CaseFailure> {
+    let operations = parse_resolution_payload(payload)?;
+    let mut pending = Vec::<u8>::new();
+    let mut dynamic = Vec::<u8>::new();
+    let mut summary = ResolutionSummary::default();
+    for operation in operations.operations {
+        match operation {
+            ResolutionOperation::Miss(target) => {
+                if dynamic.contains(&target) {
+                    continue;
+                }
+                if pending.contains(&target) {
+                    summary.suppressed += 1;
+                } else if pending.len() == usize::from(operations.state_capacity) {
+                    summary.state_full += 1;
+                } else if pending.len() == usize::from(operations.action_capacity) {
+                    summary.action_full += 1;
+                } else {
+                    pending.push(target);
+                    summary.queued += 1;
+                }
+            }
+            ResolutionOperation::Learn(target) => {
+                let learned = if dynamic.contains(&target) {
+                    true
+                } else if dynamic.len() < usize::from(operations.dynamic_capacity) {
+                    dynamic.push(target);
+                    true
+                } else {
+                    false
+                };
+                if learned {
+                    pending.retain(|candidate| *candidate != target);
+                }
+            }
+            ResolutionOperation::InvalidFuture => {}
+        }
+    }
+    summary.pending_states = u16::try_from(pending.len()).unwrap();
+    summary.pending_actions = summary.pending_states;
+    summary.dynamic_neighbors = u16::try_from(dynamic.len()).unwrap();
+    Ok(summary)
+}
+
+fn drop_expected(reason: DropReason) -> Result<Expected, CaseFailure> {
+    DropCode::new(reason as u16)
+        .map(Expected::Drop)
+        .map_err(|error| CaseFailure::new(format!("drop expected: {error}")))
+}
+
+fn model_ipv4(frame: &[u8]) -> Result<ParserAccept, DropReason> {
+    if frame.len() < ETHERNET_HEADER_LEN {
+        return Err(DropReason::EthernetHeaderTruncated);
+    }
+    if read_be_u16(frame, 12) != Some(0x0800) {
+        return Err(DropReason::UnsupportedEtherType);
+    }
+    let available = frame.len() - ETHERNET_HEADER_LEN;
+    if available < 20 {
+        return Err(DropReason::Ipv4HeaderTruncated);
+    }
+    let first = frame[ETHERNET_HEADER_LEN];
+    if first >> 4 != 4 {
+        return Err(DropReason::Ipv4VersionUnsupported);
+    }
+    let ihl_words = usize::from(first & 0x0f);
+    if ihl_words < 5 {
+        return Err(DropReason::Ipv4IhlTooSmall);
+    }
+    let header_len = ihl_words * 4;
+    if header_len > available {
+        return Err(DropReason::Ipv4HeaderLengthExceedsPacket);
+    }
+    let total_len = usize::from(read_be_u16(frame, 16).unwrap());
+    if total_len < header_len {
+        return Err(DropReason::Ipv4TotalLengthTooSmall);
+    }
+    if total_len > available {
+        return Err(DropReason::Ipv4TotalLengthExceedsPacket);
+    }
+    if oracle_checksum(&frame[14..14 + header_len]) != 0 {
+        return Err(DropReason::Ipv4HeaderChecksumInvalid);
+    }
+    Ok(ParserAccept {
+        header_len: u8::try_from(header_len).unwrap(),
+        total_len: u16::try_from(total_len).unwrap(),
+        ttl: frame[22],
+        protocol: frame[23],
+        source: frame[26..30].try_into().unwrap(),
+        destination: frame[30..34].try_into().unwrap(),
+        checksum: read_be_u16(frame, 24).unwrap(),
+    })
+}
+
+fn oracle_checksum(bytes: &[u8]) -> u16 {
+    let mut high = 0_u64;
+    let mut low = 0_u64;
+    for (index, byte) in bytes.iter().enumerate() {
+        if index & 1 == 0 {
+            high += u64::from(*byte);
+        } else {
+            low += u64::from(*byte);
+        }
+    }
+    let mut sum = (high << 8) + low;
+    while sum >> 16 != 0 {
+        sum = (sum & 0xffff) + (sum >> 16);
+    }
+    !(sum as u16)
+}
+
+fn install_oracle_checksum(frame: &mut [u8]) {
+    let header_len = usize::from(frame[14] & 0x0f) * 4;
+    frame[24..26].fill(0);
+    let checksum = oracle_checksum(&frame[14..14 + header_len]);
+    frame[24..26].copy_from_slice(&checksum.to_be_bytes());
+}
+
+#[allow(clippy::too_many_arguments)]
+fn ipv4_frame(
+    ihl_words: u8,
+    payload_len: usize,
+    padding_len: usize,
+    flags_offset: u16,
+    ttl: u8,
+    source: Ipv4Address,
+    destination: Ipv4Address,
+) -> Vec<u8> {
+    let header_len = usize::from(ihl_words) * 4;
+    let total_len = header_len + payload_len;
+    let mut frame = vec![0_u8; ETHERNET_HEADER_LEN + total_len + padding_len];
+    frame[0..6].copy_from_slice(&LAN_MAC.0);
+    frame[6..12].copy_from_slice(&PEER_MAC.0);
+    frame[12..14].copy_from_slice(&0x0800_u16.to_be_bytes());
+    frame[14] = 0x40 | ihl_words;
+    frame[15] = 0x2e;
+    frame[16..18].copy_from_slice(&u16::try_from(total_len).unwrap().to_be_bytes());
+    frame[18..20].copy_from_slice(&0x6d5a_u16.to_be_bytes());
+    frame[20..22].copy_from_slice(&flags_offset.to_be_bytes());
+    frame[22] = ttl;
+    frame[23] = 17;
+    frame[26..30].copy_from_slice(&source.octets());
+    frame[30..34].copy_from_slice(&destination.octets());
+    for (index, byte) in frame[34..14 + header_len].iter_mut().enumerate() {
+        *byte = u8::try_from((index * 29 + 7) & 0xff).unwrap();
+    }
+    for (index, byte) in frame[14 + header_len..14 + total_len]
+        .iter_mut()
+        .enumerate()
+    {
+        *byte = u8::try_from((index * 17 + 3) & 0xff).unwrap();
+    }
+    frame[14 + total_len..].fill(0xa5);
+    install_oracle_checksum(&mut frame);
+    frame
+}
+
+fn randomize_ipv4(frame: &mut [u8], rng: &mut V1Rng) {
+    let header_len = usize::from(frame[14] & 0x0f) * 4;
+    frame[15] = rng.byte();
+    frame[18..20].copy_from_slice(&rng.next_u64().to_le_bytes()[0..2]);
+    frame[23] = rng.byte();
+    rng.fill(&mut frame[34..14 + header_len]);
+    rng.fill(&mut frame[14 + header_len..]);
+    install_oracle_checksum(frame);
+}
+
+fn mutate_parser_frame(frame: &mut Vec<u8>, rng: &mut V1Rng) {
+    let header_len = usize::from(frame[14] & 0x0f) * 4;
+    let total_len = usize::from(read_be_u16(frame, 16).unwrap());
+    match rng.below(12) {
+        0 => frame.truncate(rng.below(frame.len() + 1)),
+        1 => {
+            let ether_type = [0x0800_u16, 0x0806, 0x8100, 0x88a8, 0x86dd][rng.below(5)];
+            frame[12..14].copy_from_slice(&ether_type.to_be_bytes());
+        }
+        2 => frame[14] = rng.byte(),
+        3 => frame[16..18].copy_from_slice(&rng.next_u64().to_le_bytes()[0..2]),
+        4 => {
+            let index = 14 + rng.below(header_len);
+            frame[index] ^= 1 << rng.below(8);
+        }
+        5 if total_len > header_len => {
+            let index = 14 + header_len + rng.below(total_len - header_len);
+            frame[index] ^= rng.byte() | 1;
+        }
+        6 => frame[20..22].copy_from_slice(&rng.next_u64().to_le_bytes()[0..2]),
+        7 => frame[22] = rng.byte(),
+        8 => frame[24..26].copy_from_slice(&rng.next_u64().to_le_bytes()[0..2]),
+        9 => frame.extend((0..rng.below(17)).map(|_| rng.byte())),
+        10 if header_len > 20 => {
+            let index = 34 + rng.below(header_len - 20);
+            frame[index] ^= rng.byte() | 1;
+        }
+        _ => {}
+    }
+}
+
+fn arp_frame(
+    ethernet_destination: MacAddress,
+    sender: Ipv4Address,
+    target: Ipv4Address,
+) -> Vec<u8> {
+    let mut frame = vec![0_u8; 60];
+    frame[0..6].copy_from_slice(&ethernet_destination.0);
+    frame[6..12].copy_from_slice(&PEER_MAC.0);
+    frame[12..14].copy_from_slice(&0x0806_u16.to_be_bytes());
+    frame[14..16].copy_from_slice(&1_u16.to_be_bytes());
+    frame[16..18].copy_from_slice(&0x0800_u16.to_be_bytes());
+    frame[18] = 6;
+    frame[19] = 4;
+    frame[20..22].copy_from_slice(&1_u16.to_be_bytes());
+    frame[22..28].copy_from_slice(&ARP_SHA.0);
+    frame[28..32].copy_from_slice(&sender.octets());
+    frame[38..42].copy_from_slice(&target.octets());
+    frame
+}
+
+fn resolution_arp_reply(sender: Ipv4Address) -> Vec<u8> {
+    let mut frame = arp_frame(WAN_MAC, sender, RESOLUTION_LOCAL);
+    frame[20..22].copy_from_slice(&2_u16.to_be_bytes());
+    frame
+}
+
+fn resolution_ipv4(destination: Ipv4Address) -> Vec<u8> {
+    ipv4_frame(5, 0, 0, 0x4000, 64, LAN_PEER, destination)
+}
+
+fn target_address(index: u8) -> Ipv4Address {
+    Ipv4Address::from_octets([198, 51, 100, 10 + index])
+}
+
+fn admission_topology() -> (
+    [Route; 1],
+    [Interface; 2],
+    [Neighbor; 1],
+    [LocalIpv4Binding; 1],
+) {
+    (
+        [Route::new(Ipv4Address::from_octets([0; 4]), 0, WAN, Some(GATEWAY)).unwrap()],
+        [
+            Interface {
+                id: LAN,
+                mac: LAN_MAC,
+            },
+            Interface {
+                id: WAN,
+                mac: WAN_MAC,
+            },
+        ],
+        [Neighbor {
+            interface: WAN,
+            target: GATEWAY,
+            mac: NEXT_HOP_MAC,
+        }],
+        [LocalIpv4Binding {
+            interface: LAN,
+            address: LAN_LOCAL,
+        }],
+    )
+}
+
+fn resolution_topology() -> ([Route; 1], [Interface; 2], [LocalIpv4Binding; 2]) {
+    (
+        [Route::new(Ipv4Address::from_octets([198, 51, 100, 0]), 24, WAN, None).unwrap()],
+        [
+            Interface {
+                id: LAN,
+                mac: LAN_MAC,
+            },
+            Interface {
+                id: WAN,
+                mac: WAN_MAC,
+            },
+        ],
+        [
+            LocalIpv4Binding {
+                interface: LAN,
+                address: LAN_LOCAL,
+            },
+            LocalIpv4Binding {
+                interface: WAN,
+                address: RESOLUTION_LOCAL,
+            },
+        ],
+    )
+}
+
+fn read_be_u16(bytes: &[u8], offset: usize) -> Option<u16> {
+    let word = bytes.get(offset..offset.checked_add(2)?)?;
+    Some(u16::from_be_bytes(word.try_into().unwrap()))
+}

--- a/crates/io-sim/tests/security_property_smoke.rs
+++ b/crates/io-sim/tests/security_property_smoke.rs
@@ -1,0 +1,539 @@
+#[path = "r16a_support/mod.rs"]
+mod r16a;
+
+use std::{
+    fs::{self, OpenOptions},
+    io::Write,
+    os::unix::fs::{symlink, DirBuilderExt, OpenOptionsExt, PermissionsExt},
+    path::PathBuf,
+};
+
+use r16a::{
+    artifact::{load_replay, ArtifactWriter},
+    envelope::{
+        parse, CaseEnvelope, EnvelopeError, Expected, Target, MAX_CASES_PER_RUN, MAX_CORPUS_CASES,
+        MAX_ENVELOPE_LEN, MAX_PAYLOAD_LEN, MAX_RESOLUTION_NOW,
+    },
+    targets::{
+        generate_encoded, ADMISSION_SMOKE_CASES, CHECKSUM_SMOKE_CASES, PARSER_SMOKE_CASES,
+        RESOLUTION_SMOKE_CASES, V1_SEEDS,
+    },
+};
+
+#[test]
+fn r16a_envelope_parser_is_typed_canonical_and_bounded() {
+    let payload = [1_u8, 2, 3];
+    let encoded = CaseEnvelope {
+        target: Target::Checksum,
+        seed: V1_SEEDS[0],
+        case_index: 7,
+        now: 11,
+        ingress: 1,
+        expected: Expected::Checksum(0xfbfd),
+        payload: &payload,
+    }
+    .encode()
+    .unwrap();
+    let parsed = parse(&encoded).unwrap();
+    assert_eq!(parsed.target, Target::Checksum);
+    assert_eq!(parsed.seed, V1_SEEDS[0]);
+    assert_eq!(parsed.case_index, 7);
+    assert_eq!(parsed.payload, payload);
+    assert_eq!(parsed.encode().unwrap(), encoded);
+
+    let mut cases = Vec::new();
+    cases.push((
+        "header truncation",
+        encoded[..71].to_vec(),
+        EnvelopeError::HeaderTruncated,
+    ));
+    let mut bad_magic = encoded.clone();
+    bad_magic[0] ^= 1;
+    cases.push(("bad magic", bad_magic, EnvelopeError::BadMagic));
+    let mut bad_version = encoded.clone();
+    bad_version[4] = 2;
+    cases.push((
+        "unsupported version",
+        bad_version,
+        EnvelopeError::UnsupportedVersion,
+    ));
+    let mut bad_target = encoded.clone();
+    bad_target[5] = 99;
+    cases.push((
+        "unknown target",
+        bad_target,
+        EnvelopeError::UnknownTargetTag,
+    ));
+    let mut bad_expected = encoded.clone();
+    bad_expected[6] = 99;
+    cases.push((
+        "unknown expected",
+        bad_expected,
+        EnvelopeError::UnknownExpectedTag,
+    ));
+    let mut bad_reserved = encoded.clone();
+    bad_reserved[7] = 1;
+    cases.push((
+        "nonzero reserved",
+        bad_reserved,
+        EnvelopeError::ReservedNotZero,
+    ));
+    let mut bad_reserved_word = encoded.clone();
+    bad_reserved_word[35] = 1;
+    cases.push((
+        "nonzero reserved word",
+        bad_reserved_word,
+        EnvelopeError::ReservedNotZero,
+    ));
+    let mut noncanonical = encoded.clone();
+    noncanonical[42] = 1;
+    cases.push((
+        "noncanonical expected tail",
+        noncanonical,
+        EnvelopeError::NonCanonicalExpected,
+    ));
+    let mut target_mismatch = encoded.clone();
+    target_mismatch[5] = Target::Parser as u8;
+    cases.push((
+        "expected target mismatch",
+        target_mismatch,
+        EnvelopeError::ExpectedTargetMismatch,
+    ));
+    let mut unknown_drop = encoded.clone();
+    unknown_drop[6] = 2;
+    unknown_drop[40..72].fill(0);
+    cases.push((
+        "unknown drop code",
+        unknown_drop,
+        EnvelopeError::UnknownDropCode,
+    ));
+    let mut length_mismatch = encoded.clone();
+    length_mismatch[36..40].copy_from_slice(&4_u32.to_le_bytes());
+    cases.push((
+        "length mismatch",
+        length_mismatch,
+        EnvelopeError::LengthMismatch,
+    ));
+    cases.push((
+        "envelope too large",
+        vec![0; MAX_ENVELOPE_LEN + 1],
+        EnvelopeError::EnvelopeTooLarge,
+    ));
+    let mut case_out_of_range = encoded.clone();
+    case_out_of_range[16..24].copy_from_slice(&MAX_CASES_PER_RUN.to_le_bytes());
+    cases.push((
+        "case index out of range",
+        case_out_of_range,
+        EnvelopeError::CaseIndexOutOfRange,
+    ));
+    let mut resolution_time = generate_encoded(Target::Resolution, V1_SEEDS[0], 0).unwrap();
+    resolution_time[24..32].copy_from_slice(&(MAX_RESOLUTION_NOW + 1).to_le_bytes());
+    cases.push((
+        "resolution time out of range",
+        resolution_time,
+        EnvelopeError::ResolutionTimeOutOfRange,
+    ));
+
+    for (case, (label, bytes, expected)) in cases.into_iter().enumerate() {
+        assert_eq!(
+            parse(&bytes),
+            Err(expected),
+            "envelope_case={case} label={label}"
+        );
+    }
+
+    assert_eq!(MAX_PAYLOAD_LEN + 72, MAX_ENVELOPE_LEN);
+    assert_eq!(MAX_CORPUS_CASES, 512);
+    assert_eq!(MAX_CASES_PER_RUN, 65_536);
+    assert_eq!(
+        CaseEnvelope {
+            target: Target::Checksum,
+            seed: V1_SEEDS[0],
+            case_index: MAX_CASES_PER_RUN,
+            now: 0,
+            ingress: 0,
+            expected: Expected::Checksum(0),
+            payload: &[],
+        }
+        .encode(),
+        Err(EnvelopeError::CaseIndexOutOfRange)
+    );
+    assert_eq!(
+        CaseEnvelope {
+            target: Target::Resolution,
+            seed: V1_SEEDS[0],
+            case_index: 0,
+            now: MAX_RESOLUTION_NOW + 1,
+            ingress: 1,
+            expected: Expected::Resolution(Default::default()),
+            payload: &[0, 0, 0, 0],
+        }
+        .encode(),
+        Err(EnvelopeError::ResolutionTimeOutOfRange)
+    );
+}
+
+#[test]
+fn r16a_v1_generation_is_exact_case_replayable() {
+    assert_eq!(
+        V1_SEEDS,
+        [
+            0x6a09_e667_f3bc_c909,
+            0x243f_6a88_85a3_08d3,
+            0x9e37_79b9_7f4a_7c15,
+            0xd1b5_4a32_d192_ed03,
+        ]
+    );
+    assert_eq!(
+        (
+            PARSER_SMOKE_CASES,
+            CHECKSUM_SMOKE_CASES,
+            ADMISSION_SMOKE_CASES,
+            RESOLUTION_SMOKE_CASES,
+        ),
+        (4_096, 4_096, 2_048, 2_048)
+    );
+    for target in Target::ALL {
+        let first = generate_encoded(target, V1_SEEDS[2], 317).unwrap();
+        let replay = generate_encoded(target, V1_SEEDS[2], 317).unwrap();
+        let neighbor = generate_encoded(target, V1_SEEDS[2], 318).unwrap();
+        assert_eq!(first, replay, "target={} exact replay", target.name());
+        assert_ne!(first, neighbor, "target={} case domain", target.name());
+    }
+    let goldens = [
+        (Target::Parser, V1_SEEDS[0], 0, 147, 0xf086_57a1_48f7_7bc4),
+        (Target::Parser, V1_SEEDS[1], 31, 193, 0xadcd_b78a_dfc3_5aed),
+        (Target::Parser, V1_SEEDS[2], 317, 311, 0x9cda_284c_932e_fffb),
+        (
+            Target::Parser,
+            V1_SEEDS[3],
+            2_047,
+            266,
+            0xad1a_028b_c440_b06e,
+        ),
+        (Target::Checksum, V1_SEEDS[0], 0, 72, 0x0baf_8351_091e_9bca),
+        (
+            Target::Checksum,
+            V1_SEEDS[1],
+            31,
+            1_459,
+            0xa713_e4ed_2446_83ff,
+        ),
+        (
+            Target::Checksum,
+            V1_SEEDS[2],
+            317,
+            2_179,
+            0x1707_ca7f_ffab_9c64,
+        ),
+        (
+            Target::Checksum,
+            V1_SEEDS[3],
+            2_047,
+            1_737,
+            0x36db_e3c3_9e59_0213,
+        ),
+        (
+            Target::Admission,
+            V1_SEEDS[0],
+            0,
+            106,
+            0x951c_87e6_2dd0_9014,
+        ),
+        (
+            Target::Admission,
+            V1_SEEDS[1],
+            31,
+            132,
+            0x58c9_29b6_d9ac_c237,
+        ),
+        (
+            Target::Admission,
+            V1_SEEDS[2],
+            317,
+            132,
+            0x0a67_7a18_e227_eea2,
+        ),
+        (
+            Target::Admission,
+            V1_SEEDS[3],
+            2_047,
+            110,
+            0xb30b_be36_f61f_26b9,
+        ),
+        (
+            Target::Resolution,
+            V1_SEEDS[0],
+            0,
+            102,
+            0x0c5b_eb89_8c53_254d,
+        ),
+        (
+            Target::Resolution,
+            V1_SEEDS[1],
+            31,
+            124,
+            0x9570_677b_4bd6_d210,
+        ),
+        (
+            Target::Resolution,
+            V1_SEEDS[2],
+            317,
+            104,
+            0x3309_ecf4_7e34_7954,
+        ),
+        (
+            Target::Resolution,
+            V1_SEEDS[3],
+            2_047,
+            118,
+            0x8afa_4b2c_93dd_039d,
+        ),
+    ];
+    for (target, seed, case_index, length, digest) in goldens {
+        let encoded = generate_encoded(target, seed, case_index).unwrap();
+        assert_eq!(encoded.len(), length, "target={} length", target.name());
+        assert_eq!(
+            stable_digest(&encoded),
+            digest,
+            "target={} seed={seed:#018x} case={case_index}",
+            target.name()
+        );
+    }
+}
+
+#[test]
+fn r16a_past_regression_corpus_is_exact() {
+    let expected = [
+        ("vlan-inner-frame-not-parsed", 86, 0x2420_c338_87fc_b585),
+        (
+            "reserved-ipv4-flag-parser-accept",
+            106,
+            0xa4de_8a67_8db7_a30c,
+        ),
+        ("rfc1071-known-vector", 80, 0x7512_5b58_810b_98c3),
+        ("odd-length-high-byte-padding", 75, 0xb28f_cd8b_78e4_45c1),
+        ("cross-interface-router-mac", 106, 0xe937_4ca6_6a3b_a610),
+        ("local-ipv4-source-claim", 106, 0xb45a_4469_a391_e2ff),
+        (
+            "arp-foreign-unicast-before-merge",
+            132,
+            0x8573_b747_d761_1914,
+        ),
+        (
+            "resolution-cancel-reuse-and-invalid-future",
+            88,
+            0x9651_3a3b_31a7_d660,
+        ),
+        (
+            "resolution-zero-action-and-cache-capacity",
+            80,
+            0x8257_75e7_732e_ef57,
+        ),
+    ];
+    let corpus = r16a::corpus::past_regressions();
+    assert_eq!(corpus.len(), expected.len());
+    for (case, (name, length, digest)) in corpus.iter().zip(expected) {
+        assert_eq!(case.name, name);
+        assert_eq!(case.encoded.len(), length, "corpus={name}");
+        assert_eq!(stable_digest(&case.encoded), digest, "corpus={name}");
+    }
+    r16a::run_past_corpus();
+}
+
+#[test]
+fn r16a_short_seed_matrix_is_deterministic() {
+    r16a::run_short_matrix();
+}
+
+#[test]
+fn r16a_failure_artifact_is_binary_jsonl_and_exactly_replayable() {
+    let encoded = generate_encoded(Target::Parser, V1_SEEDS[1], 19).unwrap();
+    let parsed = parse(&encoded).unwrap();
+    let directory = missing_temp_path("artifact-meta");
+    let writer = ArtifactWriter::new(directory.clone()).unwrap();
+    let record = writer
+        .write(&encoded, &parsed, "synthetic \"failure\"\nline")
+        .unwrap();
+    let replay = fs::read(&record.case_path).unwrap();
+    assert_eq!(replay, encoded);
+    assert_eq!(parse(&replay).unwrap(), parsed);
+    r16a::targets::run_encoded(&replay).unwrap();
+    let metadata = fs::read_to_string(&record.jsonl_path).unwrap();
+    assert_eq!(metadata.lines().count(), 1);
+    assert!(metadata.contains("\"schema\":1"));
+    assert!(metadata.contains("\"target\":\"parser\""));
+    assert!(metadata.contains("synthetic \\\"failure\\\"\\nline"));
+    assert!(metadata.contains("RUSTER_R16A_REPLAY=/tmp/"));
+    assert!(record.repro.contains("--locked"));
+    assert!(record.repro.contains("--ignored --exact"));
+    assert_eq!(
+        fs::metadata(&directory).unwrap().permissions().mode() & 0o777,
+        0o700
+    );
+    assert_eq!(
+        fs::metadata(&record.case_path)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777,
+        0o600
+    );
+    assert_eq!(
+        fs::metadata(&record.jsonl_path)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777,
+        0o600
+    );
+    let bounded = writer
+        .write(&encoded, &parsed, &"x".repeat(10_000))
+        .unwrap();
+    let bounded_metadata = fs::read_to_string(&bounded.jsonl_path).unwrap();
+    assert!(bounded_metadata.len() <= 65_536);
+    assert!(bounded_metadata.contains("...[truncated]"));
+    fs::remove_file(record.case_path).unwrap();
+    fs::remove_file(record.jsonl_path).unwrap();
+    fs::remove_file(bounded.case_path).unwrap();
+    fs::remove_file(bounded.jsonl_path).unwrap();
+    fs::remove_dir(directory).unwrap();
+}
+
+#[test]
+fn r16a_artifact_paths_and_replay_reads_are_bounded() {
+    assert!(ArtifactWriter::new(PathBuf::from("relative")).is_err());
+    assert!(ArtifactWriter::new(PathBuf::from("/tmp/../tmp/r16a")).is_err());
+    assert!(ArtifactWriter::new(PathBuf::from("/")).is_err());
+    assert!(ArtifactWriter::new(PathBuf::from(format!("/tmp/{}", "a".repeat(4_096)))).is_err());
+
+    let directory = private_temp_dir("replay-bounds");
+    let oversized = directory.join("oversized.case");
+    let mut oversized_file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&oversized)
+        .unwrap();
+    oversized_file
+        .write_all(&vec![0_u8; MAX_ENVELOPE_LEN + 1])
+        .unwrap();
+    drop(oversized_file);
+    let error = load_replay(oversized.clone()).unwrap_err();
+    assert!(error.contains("exceeds"));
+    fs::remove_file(oversized).unwrap();
+
+    fs::set_permissions(&directory, fs::Permissions::from_mode(0o755)).unwrap();
+    let encoded = generate_encoded(Target::Parser, V1_SEEDS[0], 0).unwrap();
+    let parsed = parse(&encoded).unwrap();
+    let writer = ArtifactWriter::new(directory.clone()).unwrap();
+    assert!(writer
+        .write(&encoded, &parsed, "private mode required")
+        .is_err());
+    fs::set_permissions(&directory, fs::Permissions::from_mode(0o700)).unwrap();
+    fs::remove_dir(directory).unwrap();
+}
+
+#[test]
+fn r16a_artifact_and_replay_paths_reject_symlinks_directly() {
+    let directory = private_temp_dir("symlink-boundary");
+    let real_component = directory.join("real");
+    fs::DirBuilder::new()
+        .mode(0o700)
+        .create(&real_component)
+        .unwrap();
+    let linked_component = directory.join("linked");
+    symlink(&real_component, &linked_component).unwrap();
+
+    let encoded = generate_encoded(Target::Parser, V1_SEEDS[0], 0).unwrap();
+    let parsed = parse(&encoded).unwrap();
+    let writer = ArtifactWriter::new(linked_component.join("artifacts")).unwrap();
+    let error = match writer.write(&encoded, &parsed, "symlink component must fail") {
+        Err(error) => error,
+        Ok(_) => panic!("artifact symlink component was accepted"),
+    };
+    assert!(error.contains("cannot traverse symlinks"));
+    assert!(fs::read_dir(&real_component).unwrap().next().is_none());
+
+    let replay = directory.join("replay.case");
+    let mut replay_file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&replay)
+        .unwrap();
+    replay_file.write_all(&encoded).unwrap();
+    drop(replay_file);
+    let linked_replay = directory.join("linked-replay.case");
+    symlink(&replay, &linked_replay).unwrap();
+    let error = load_replay(linked_replay.clone()).unwrap_err();
+    assert!(error.contains("cannot traverse symlinks"));
+
+    fs::remove_file(linked_replay).unwrap();
+    fs::remove_file(replay).unwrap();
+    fs::remove_file(linked_component).unwrap();
+    fs::remove_dir(real_component).unwrap();
+    fs::remove_dir(directory).unwrap();
+}
+
+#[test]
+fn r16a_environment_surface_is_fixed_and_cold_only() {
+    assert_eq!(
+        r16a::env_names(),
+        [
+            "RUSTER_R16A_TARGET",
+            "RUSTER_R16A_SEED",
+            "RUSTER_R16A_CASE_START",
+            "RUSTER_R16A_CASES",
+            "RUSTER_R16A_REPLAY",
+            "RUSTER_R16A_ARTIFACT_DIR",
+        ]
+    );
+}
+
+#[test]
+#[ignore = "bounded R16A full smoke; invoke explicitly with the documented exact command"]
+fn r16a_bounded_smoke() {
+    r16a::run_bounded_smoke();
+}
+
+fn stable_digest(bytes: &[u8]) -> u64 {
+    let mut digest = 0xcbf2_9ce4_8422_2325_u64;
+    for byte in bytes {
+        digest ^= u64::from(*byte);
+        digest = digest.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    digest
+}
+
+fn missing_temp_path(label: &str) -> PathBuf {
+    for suffix in 0_u8..16 {
+        let path = PathBuf::from(format!(
+            "/tmp/ruster-r16a-{label}-{}-{suffix}",
+            std::process::id()
+        ));
+        match fs::symlink_metadata(&path) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return path,
+            Ok(_) => {}
+            Err(error) => panic!("inspect temporary artifact path: {error}"),
+        }
+    }
+    panic!("all bounded temporary artifact paths already exist");
+}
+
+fn private_temp_dir(label: &str) -> PathBuf {
+    for suffix in 0_u8..16 {
+        let path = PathBuf::from(format!(
+            "/tmp/ruster-r16a-{label}-{}-{suffix}",
+            std::process::id()
+        ));
+        let mut builder = fs::DirBuilder::new();
+        builder.mode(0o700);
+        match builder.create(&path) {
+            Ok(()) => return path,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(error) => panic!("create private temporary directory: {error}"),
+        }
+    }
+    panic!("all bounded private temporary directories already exist");
+}

--- a/docs/requirements-v0.2.md
+++ b/docs/requirements-v0.2.md
@@ -226,6 +226,35 @@ Statusは`implemented`、`deferred`、`deviation`のいずれかです。test名
 | FW-021 expiry cluster repair | architecture complexity contract | `cleanup_budget_is_linear_for_n_and_two_n_capacity` | implemented | capacity 4以上は最大75% usable。attemptごとにdelete/shift/restart各最大1回、probe+maintenanceは定数倍N、繰返しでempty terminationを回復、live evictionなし |
 | FW-022 SipHash conformance and flow layout | SipHash-2-4 reference vectors, local canonical-key contract | `siphash_vectors_and_canonical_flow_layout_match_independent_references` | implemented | official length 0/1/7/8/15/16/63 vectorsと固定64-byte canonical flow layoutの独立hard-coded reference値を検証 |
 | FW-023 explicit full-service generated ICMPv4 composition | RFC 1812 §4.3.2, architecture composition contract | `full_nat_firewall_composition_queues_and_dispatches_only_authorized_icmpv4_errors` | implemented | UDP/TCP NAT44+FWの明示error APIで認可後TTL errorをpre-NAT quoteでqueue。deny/authority/route失敗はsilent、RX後のgenerated phaseでdispatch |
+| R16A-001 versioned typed replay envelope | security test infrastructure contract | `r16a_envelope_parser_is_typed_canonical_and_bounded` | implemented | v1 magic/version、target別expected型、reserved/canonical encoding、128KiB envelope、payload、case countを固定上限で検証 |
+| R16A-002 deterministic parser/checksum/admission/resolution properties | security test infrastructure contract | `r16a_short_seed_matrix_is_deterministic` | implemented | dependency-free SplitMix64-v1、固定seed/budgetでproduction public APIをblack-box検証。parser/checksum oracleとadmission/resolution accounting modelはtest側で独立 |
+| R16A-003 fixed past-regression corpus | black-box regression contract | `r16a_past_regression_corpus_is_exact` | implemented | current-mainの固定input/expected 9件だけを保持し、prototype実装は再利用しない |
+| R16A-004 exact bounded failure replay | security test infrastructure contract | `r16a_failure_artifact_is_binary_jsonl_and_exactly_replayable` | implemented | private 0700の明示absolute directoryへ0600/create-newでbounded `.case`と1行JSONLを生成し、同一binary envelopeのexact replay commandを記録 |
+| R16A-005 explicit bounded smoke command | security test infrastructure contract | `r16a_bounded_smoke` | implemented | 手動または将来の専用jobから明示実行できるignored test。固定4 seed/target別case budget、または最大65536件の完全指定range/単一replay fileだけを許可。本PRはworkflowを追加せずrequired CI化を主張しない |
+
+### R16A dependency-free seed runner
+
+通常のworkspace testは、固定seedの短いparser/checksum/admission/resolution matrixと過去の
+black-box regression corpusを実行します。全固定seedとtarget別case budgetを実行する
+unprivileged smokeは次の明示commandです。
+
+```bash
+cargo test --locked -p ruster-io-sim --test security_property_smoke r16a_bounded_smoke -- --ignored --exact --nocapture --test-threads=1
+```
+
+seed failureはtarget、seed、caseを完全指定して1件だけ再現できます。
+
+```bash
+RUSTER_R16A_TARGET=parser RUSTER_R16A_SEED=0x6a09e667f3bcc909 RUSTER_R16A_CASE_START=317 RUSTER_R16A_CASES=1 cargo test --locked -p ruster-io-sim --test security_property_smoke r16a_bounded_smoke -- --ignored --exact --nocapture --test-threads=1
+```
+
+`RUSTER_R16A_ARTIFACT_DIR`には`/tmp/ruster-r16a-artifacts`のような明示absolute pathだけを
+指定できます。leaf directoryは新規0700で作成するか、既存ならexact 0700かつsymlinkを
+経由しない必要があります。failure時は0600のversioned binary `.case`と1行JSONLを
+create-newで保存します。detailは4096 bytes、JSONLは65536 bytesが上限です。
+JSONL内のcommand、または
+`RUSTER_R16A_REPLAY=/tmp/ruster-r16a-artifacts/<case>.case`を同じignored test commandへ
+付けると、そのbinary envelopeだけを再生します。replayとseed/range指定は併用できません。
 
 ## RFC deviation rule
 


### PR DESCRIPTION
## Summary
- add a dependency-free, versioned deterministic security property runner for parser/checksum/admission/resolution targets
- add bounded typed replay artifacts, fixed regression corpus, and exact reproduction commands
- keep the 49,152-case smoke opt-in; this PR does not claim required CI coverage

## Validation
- README full gate passed at `8f6cc6c79a6f538f82147bea9ff298fa66db3784`
- independent fresh exact-SHA review: C/H/M 0/0/0
- targeted tests: 8 passed, 1 ignored
- bounded smoke: 49,152 cases passed
- production/dependency/workflow files unchanged
- patch SHA-256: `e6aeeb9e27f6e1b270d373aa2039b23227ae6a85b50d0989870e864c2f990c71`
